### PR TITLE
Update CLAUDE.md: Add critical rule about not pushing to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,19 +117,32 @@ When implementing new features, the build/test loop is KEY to our development pr
    - Ensure `cargo build` completes without warnings
 
 ### Pull Request Workflow
+
+**CRITICAL: NEVER push directly to main branch!**
+
 Once Ryan is happy with an implementation:
 
-1. **Create PR using GitHub CLI**:
+1. **Always work on a feature branch**:
+   ```bash
+   git checkout -b feature-name
+   ```
+
+2. **Push to the feature branch**:
+   ```bash
+   git push -u origin feature-name
+   ```
+
+3. **Create PR using GitHub CLI**:
    ```bash
    gh pr create --title "Brief description" --body "Detailed description with testing results"
    ```
 
-2. **After creating the PR**:
+4. **After creating the PR**:
    - The command will output a URL like `https://github.com/ryanbreen/breenix/pull/XX`
    - **ALWAYS open this URL** to verify the PR was created correctly
    - Share the URL with Ryan for review
 
-3. **PR Description Should Include**:
+5. **PR Description Should Include**:
    - Summary of changes
    - Implementation details
    - Testing performed and results


### PR DESCRIPTION
## Summary
This PR updates CLAUDE.md to add a critical rule about never pushing directly to the main branch.

## Changes
- Added **CRITICAL: NEVER push directly to main branch\!** warning
- Updated PR workflow to emphasize working on feature branches
- Clarified the proper git workflow:
  1. Create feature branch
  2. Push to feature branch
  3. Create PR for review
  4. Never push directly to main

## Context
This update was prompted by an accidental push to main. The repository now has branch protection rules that prevent this, and this documentation ensures the workflow is clear.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>