### PR TITLE
Implement SWAPGS support for secure syscall entry/exit

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -118,6 +118,12 @@ fn kernel_main(boot_info: &'static mut bootloader_api::BootInfo) -> ! {
     tls::init();
     log::info!("TLS initialized");
     
+    // Setup SWAPGS support for syscall entry/exit
+    if let Err(e) = tls::setup_swapgs_support() {
+        log::error!("Failed to setup SWAPGS support: {}", e);
+    } else {
+        log::info!("SWAPGS support enabled");
+    }
     
     // Initialize timer
     time::init();

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -3,6 +3,7 @@
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
+use alloc::boxed::Box;
 use core::sync::atomic::{AtomicU64, Ordering};
 use x86_64::VirtAddr;
 

--- a/kernel/src/syscall/entry.asm
+++ b/kernel/src/syscall/entry.asm
@@ -37,9 +37,8 @@ syscall_entry:
     ; Clear direction flag for string operations
     cld
 
-    ; TODO: SWAPGS to switch to kernel GS (for TLS)
-    ; Commented out until we set up user GS properly
-    ; swapgs
+    ; Switch to kernel GS (for TLS)
+    swapgs
 
     ; Call the Rust syscall handler
     ; Pass pointer to saved registers as argument
@@ -48,9 +47,8 @@ syscall_entry:
 
     ; Return value is in RAX, which will be restored to userspace
 
-    ; TODO: SWAPGS back to user GS
-    ; Commented out until we set up user GS properly
-    ; swapgs
+    ; Switch back to user GS
+    swapgs
 
     ; Restore all general purpose registers
     pop r15
@@ -83,9 +81,8 @@ syscall_return_to_userspace:
     ; Disable interrupts during the switch
     cli
 
-    ; TODO: SWAPGS to prepare for userspace
-    ; Commented out until we set up user GS properly
-    ; swapgs
+    ; Switch to user GS for userspace
+    swapgs
 
     ; Build IRETQ frame on stack
     ; We need: SS, RSP, RFLAGS, CS, RIP

--- a/kernel/src/userspace_test.rs
+++ b/kernel/src/userspace_test.rs
@@ -1,6 +1,5 @@
 //! Userspace program testing module
 
-use alloc::boxed::Box;
 
 /// Include the compiled userspace test binaries
 #[cfg(feature = "testing")]


### PR DESCRIPTION
## Summary
- Implements SWAPGS instruction support for proper kernel/userspace GS segment separation
- Configures MSR_KERNEL_GS_BASE to point to kernel TLS block
- Enables SWAPGS in syscall entry/exit paths for security

## Implementation Details

### MSR Configuration
- Added `setup_swapgs_support()` function to configure KERNEL_GS_BASE MSR
- KERNEL_GS_BASE is set to the kernel's TLS block address
- User GS_BASE defaults to 0 (userspace can set it later)

### Syscall Entry/Exit
- Uncommented SWAPGS instructions in `syscall/entry.asm`
- SWAPGS at entry: switches from user GS to kernel GS
- SWAPGS at exit: switches back to user GS
- Also enabled in `syscall_return_to_userspace` for initial process entry

### Security Benefits
- Prevents userspace from accessing kernel TLS data
- Allows kernel to maintain its own thread-local storage safely
- Standard x86_64 security practice for system calls

## Test Results

Tested with userspace programs executing syscalls:
```
Hello from userspace\! Current time: 1489 ticks
Hello from second process\!
This process will exit with code 42
```

All syscalls (GetTime, Write, Exit) work correctly with SWAPGS enabled.

Standard kernel tests pass (except one unrelated keyboard test that was already failing).

🤖 Generated with [Claude Code](https://claude.ai/code)