### PR TITLE
Implement basic fork() system call with process duplication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,18 @@ breenix/
    - Process lifecycle management for QEMU/Breenix sessions
    - RESTful API and JSON-RPC endpoints for automation
 
-## MCP Server Usage
+## MCP Server Usage (REQUIRED - ALWAYS USE MCP)
 
-Breenix includes a comprehensive MCP (Model Context Protocol) server that enables programmatic interaction with the kernel for development and testing. This is especially useful for Claude Code integration.
+**CRITICAL: Always use MCP for ALL Breenix development and testing. NEVER run QEMU or kernel tests directly without MCP.**
+
+Breenix includes a comprehensive MCP (Model Context Protocol) server that enables programmatic interaction with the kernel for development and testing. This is REQUIRED for Claude Code integration and provides essential visibility for debugging.
+
+**Why MCP is mandatory:**
+- Provides real-time visibility into kernel behavior through tmux panes
+- Enables proper debugging with Ryan's assistance
+- Maintains consistent testing environment
+- Prevents stuck QEMU processes
+- Tracks all kernel interactions and logs
 
 ### Quick Start with tmuxinator
 

--- a/docs/planning/PROJECT_ROADMAP.md
+++ b/docs/planning/PROJECT_ROADMAP.md
@@ -5,44 +5,44 @@ This is the master project roadmap for Breenix OS. It consolidates all existing 
 ## Current Development Status
 
 ### Recently Completed (Last Sprint)
-- ✅ **MAJOR**: Fixed critical ELF loading bug preventing userspace execution
-- ✅ **MAJOR**: Resolved timer interrupt timing issue with proper OS practices
-- ✅ **MAJOR**: Userspace processes now execute and can make system calls!
-- ✅ Fixed entry point calculation in ELF loader (was double-adding base offset)
-- ✅ Fixed segment loading for absolute addresses in userspace binaries
-- ✅ Added proper interrupt masking during userspace context setup
-- ✅ Reduced timer frequency to 10Hz for better userspace execution
-- ✅ Fork test successfully runs: "Fork test starting..." output confirmed
-- ✅ System call infrastructure verified working (sys_fork called from userspace)
+- ✅ **MAJOR**: Fixed page fault in fork() - TLS access after SWAPGS fixed
+- ✅ **MAJOR**: Implemented basic fork() process duplication logic
+- ✅ Created ProcessManager::fork_process() with child process creation
+- ✅ Fixed sys_fork to use scheduler thread ID instead of TLS
+- ✅ Implemented child thread creation with parent context copying
+- ✅ Added child process to scheduler ready queue
+- ✅ Set up fork return values (0 for child, PID for parent)
+- ✅ Fork test now reaches process creation without crashes
 
 ### Currently Working On (Phase 8: Enhanced Process Control) 
-- 🚧 **Current Issue**: Page fault at 0x13008 in fork() implementation (TLS access)
-- 🚧 **Next**: Implement actual fork() logic with process duplication
-- 🚧 **Next**: Fix TLS handling in forked processes
+- 🚧 **Current Issue**: Thread creation/TLS initialization issue in forked child
+- 🚧 **Next**: Fix Thread::new to support fork (avoid double ID allocation)
+- 🚧 **Next**: Ensure proper TLS setup for forked processes
 - 🚧 **Next**: Implement copy-on-write memory for efficient forking
 - 🚧 **Next**: Add wait()/waitpid() for process synchronization
 
 ### **SESSION HANDOFF NOTES - CONTINUE HERE NEXT TIME** 🎯
-**MAJOR PROGRESS COMPLETED:**
-1. ✅ **Fixed timer interrupt doom loop** - No more endless terminated thread warnings 
-2. ✅ **Fixed idle thread context switching** - Proper kernel mode transitions with assembly
-3. ✅ **Implemented complete fork infrastructure** - sys_fork(), test programs, MCP integration
-4. ✅ **Built comprehensive testing framework** - Ctrl+F keyboard, forktest command, automated testing
+**FORK IMPLEMENTATION PROGRESS:**
+1. ✅ **Fixed TLS page fault** - sys_fork now uses scheduler thread ID not TLS
+2. ✅ **Implemented fork_process()** - Full process duplication in ProcessManager
+3. ✅ **Child process creation working** - Allocates stack, creates thread, copies context
+4. 🚧 **Current blocker** - Thread::new allocates its own ID/TLS, conflicts with fork
 
-**TIMING ISSUE COMPLETELY RESOLVED:**
-1. ✅ **Root cause identified** - ELF loader bug, not timer frequency issue
-2. ✅ **Fixed entry point calculation** - No longer double-adding base offset
-3. ✅ **Fixed segment loading** - Properly handles absolute userspace addresses
-4. ✅ **Added interrupt masking** - Critical sections properly protected
-5. ✅ **Userspace execution verified** - Processes run and make system calls
+**WHAT'S IMPLEMENTED:**
+- ProcessManager::fork_process() creates child with:
+  - New PID allocation
+  - Stack allocation for child
+  - Thread creation with parent context copy
+  - RAX=0 for child, parent PID for parent
+  - Child added to scheduler ready queue
+  
+**NEXT SESSION TODO:**
+1. Create Thread::new_forked() that accepts pre-allocated thread ID
+2. Fix TLS allocation for forked threads
+3. Test that both parent and child execute after fork
+4. Eventually add copy-on-write pages
 
-**CURRENT WORK - FORK IMPLEMENTATION:**
-- sys_fork() skeleton implemented and callable from userspace
-- Page fault at 0x13008 indicates TLS access issue in fork
-- Need to implement actual process duplication logic
-- Need to handle TLS properly for forked processes
-
-**TEST COMMAND:** `forktest` in serial console triggers fork test (via MCP or direct QEMU)
+**TEST COMMAND:** `forktest` in serial console (always use MCP!)
 
 ### Immediate Next Steps
 1. **🔥 PRIORITY**: Fix page fault in fork() - handle TLS access properly

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -260,3 +260,8 @@ pub fn get_pending_switch() -> Option<(u64, u64)> {
     // In a real implementation, we might cache this decision
     schedule()
 }
+
+/// Allocate a new thread ID
+pub fn allocate_thread_id() -> Option<u64> {
+    Some(super::thread::allocate_thread_id())
+}

--- a/kernel/src/task/thread.rs
+++ b/kernel/src/task/thread.rs
@@ -9,6 +9,11 @@ use x86_64::VirtAddr;
 /// Global thread ID counter
 static NEXT_THREAD_ID: AtomicU64 = AtomicU64::new(1); // 0 is reserved for kernel thread
 
+/// Allocate a new thread ID
+pub fn allocate_thread_id() -> u64 {
+    NEXT_THREAD_ID.fetch_add(1, Ordering::SeqCst)
+}
+
 /// Thread states
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ThreadState {


### PR DESCRIPTION
## Summary
- Fixed TLS page fault in fork() by using scheduler thread ID instead of TLS
- Implemented ProcessManager::fork_process() with child process creation
- Set up proper fork return values and scheduler integration

## Implementation Details

### Fixed TLS Page Fault
The original fork() implementation was accessing TLS using `current_thread_id()` after SWAPGS had switched from user GS to kernel GS. This caused a page fault at address 0x13008. Fixed by using `scheduler::current_thread_id()` instead.

### Process Duplication
Created `ProcessManager::fork_process()` that:
- Allocates new PID for child process
- Creates new stack for child thread
- Copies parent's CPU context to child
- Sets RAX=0 for child (fork return value)
- Adds child to parent's children list
- Adds child to scheduler ready queue

### Current Status
Fork successfully creates child process but hangs during thread initialization. The issue is that `Thread::new()` allocates its own thread ID and TLS, which conflicts with fork's needs.

### Next Steps
- Create `Thread::new_forked()` that accepts pre-allocated thread ID
- Fix TLS allocation for forked threads
- Test both parent and child execution after fork
- Implement copy-on-write memory pages

## Testing
Test with `forktest` command in serial console via MCP:
```
> forktest
Testing Fork System Call (Debug Mode)
Fork test starting...
sys_fork called - implementing basic fork
Fork successful - parent 1 gets child PID 2
```

## Other Changes
- Updated CLAUDE.md to emphasize ALWAYS using MCP for development
- Updated PROJECT_ROADMAP.md with current fork implementation status
- Added allocate_thread_id() helper function to thread module

🤖 Generated with [Claude Code](https://claude.ai/code)