### PR TITLE
Implement kernel test harness with runtime test selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,11 +324,34 @@ When implementing new features, the build/test loop is KEY to our development pr
    - `scripts/test_kernel.sh` - Interactive manual testing
 
 ### Development Workflow
+
+## 🚨 MANDATORY PRE-COMMIT TESTING 🚨
+
+**NEVER commit without running the FULL test suite!**
+
+### Before EVERY Commit:
+1. **Run the complete test suite**:
+   ```bash
+   cargo test
+   ```
+2. **Verify ALL tests pass**:
+   - `test_divide_by_zero` - Exception handling works
+   - `test_invalid_opcode` - Exception handling works
+   - `test_page_fault` - Exception handling works
+   - `test_multiple_processes` - 5 processes run concurrently
+3. **Check test output** - Don't just look for green checkmarks:
+   - For `test_multiple_processes`: Verify you see 5 "Hello from userspace!" messages
+   - For exception tests: Verify you see the TEST_MARKER output
+4. **If ANY test fails**: DO NOT COMMIT - fix the issue first
+
+### Standard Development Workflow:
 1. Kernel code changes are made in `kernel/src/`
-2. Build system automatically creates disk images
-3. Tests can be run using QEMU for both UEFI and BIOS modes
-4. Legacy code serves as reference for features being reimplemented
-5. **CRITICAL: Always ensure clean builds before declaring victory** - this is AS IMPORTANT as implementing tests:
+2. **Run `cargo test` after EVERY change**
+3. Build system automatically creates disk images
+4. Tests can be run using QEMU for both UEFI and BIOS modes
+5. Legacy code serves as reference for features being reimplemented
+6. **When adding new features**: ADD A TEST to the test harness
+7. **CRITICAL: Always ensure clean builds before declaring victory** - this is AS IMPORTANT as implementing tests:
    - Fix ALL compiler warnings (unused imports, dead code, unsafe blocks, etc.)
    - Fix ALL clippy warnings when available
    - The code MUST compile with `cargo build` without ANY warnings

--- a/docs/planning/PROJECT_ROADMAP.md
+++ b/docs/planning/PROJECT_ROADMAP.md
@@ -605,6 +605,23 @@ This will transform Breenix from a kernel with built-in programs to a true OS th
 
 ## Development Workflow
 
+### 🚨 MANDATORY PRE-COMMIT TESTING 🚨
+
+**NEVER commit without running the FULL test suite!**
+
+**Before EVERY Commit:**
+1. **Run the complete test suite**: `cargo test`
+2. **Verify ALL tests pass**:
+   - `test_divide_by_zero` - Exception handling
+   - `test_invalid_opcode` - Exception handling
+   - `test_page_fault` - Exception handling
+   - `test_multiple_processes` - 5 concurrent processes
+3. **Check test output details**:
+   - `test_multiple_processes`: Must see 5 "Hello from userspace!" messages
+   - Exception tests: Must see TEST_MARKER output
+4. **If ANY test fails**: DO NOT COMMIT - fix the issue first
+5. **When adding features**: ADD A TEST to the test harness
+
 ### Branch Strategy
 - `main` branch for stable code
 - Feature branches for all development
@@ -613,6 +630,7 @@ This will transform Breenix from a kernel with built-in programs to a true OS th
 - Co-authorship credits (Ryan Breen + Claude)
 
 ### Code Quality Standards
+- **Run `cargo test` after EVERY change**
 - Zero compiler warnings policy
 - Clean up dead code before merging
 - Follow existing code patterns

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -15,7 +15,7 @@ test = false
 
 [features]
 testing = []
-kernel_tests = []
+kernel_tests = ["testing"]
 test_page_fault = []
 test_userspace = []
 test_all_exceptions = []

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -3,6 +3,9 @@ use std::path::Path;
 use std::process::Command;
 
 fn main() {
+    // Tell Cargo to rerun this build script if BREENIX_TEST changes
+    println!("cargo:rerun-if-env-changed=BREENIX_TEST");
+    
     // Get the output directory
     let out_dir = env::var("OUT_DIR").unwrap();
     

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -202,6 +202,7 @@ pub fn sys_write(fd: u64, buf_ptr: u64, count: u64) -> SyscallResult {
                 if let Some(current_thread) = crate::task::scheduler::current_thread_id() {
                     if let Some(ref manager) = *crate::process::manager() {
                         if let Some((pid, _)) = manager.find_process_by_thread(current_thread) {
+                            log::debug!("Recording output from process {}", pid.as_u64());
                             crate::test_harness::TEST_OUTPUT_TRACKER.lock()
                                 .record_output(pid.as_u64());
                         }

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -193,6 +193,22 @@ pub fn sys_write(fd: u64, buf_ptr: u64, count: u64) -> SyscallResult {
     // Log the output for userspace writes
     if let Ok(s) = core::str::from_utf8(&buffer) {
         log::info!("USERSPACE OUTPUT: {}", s.trim_end());
+        
+        // Track output during tests
+        #[cfg(feature = "kernel_tests")]
+        {
+            if crate::test_harness::is_test_mode() {
+                // Get current process ID
+                if let Some(current_thread) = crate::task::scheduler::current_thread_id() {
+                    if let Some(ref manager) = *crate::process::manager() {
+                        if let Some((pid, _)) = manager.find_process_by_thread(current_thread) {
+                            crate::test_harness::TEST_OUTPUT_TRACKER.lock()
+                                .record_output(pid.as_u64());
+                        }
+                    }
+                }
+            }
+        }
     }
     
     SyscallResult::Ok(bytes_written)

--- a/kernel/src/test_harness.rs
+++ b/kernel/src/test_harness.rs
@@ -132,6 +132,9 @@ pub fn get_all_tests() -> Vec<TestCase> {
     // Register page fault test
     tests.push(TestCase::new("page_fault", test_page_fault));
     
+    // Register fork test
+    tests.push(TestCase::new("fork", test_fork));
+    
     tests
 }
 
@@ -173,4 +176,75 @@ fn test_page_fault() {
     
     // This should never be reached
     panic!("Page fault handler didn't handle the exception!");
+}
+
+/// Test for fork system call
+fn test_fork() {
+    log::warn!("Testing fork system call...");
+    
+    // Use the pre-built fork_test.elf if available
+    #[cfg(feature = "testing")]
+    {
+        use alloc::string::String;
+        
+        // Use the pre-built fork test binary
+        let fork_test_elf = crate::userspace_test::FORK_TEST_ELF;
+        
+        match crate::process::creation::create_user_process(
+            String::from("fork_test"),
+            fork_test_elf
+        ) {
+            Ok(pid) => {
+                log::warn!("Created fork test process with PID {}", pid.as_u64());
+                
+                // Enable interrupts to let the process run
+                x86_64::instructions::interrupts::enable();
+                
+                // Give the process time to run and call fork
+                // The fork_test.elf should print "P" (parent) and "C" (child)
+                let mut last_count = 0;
+                for i in 0..100 {
+                    // Brief delay to let processes run
+                    for _ in 0..100000 {
+                        core::hint::spin_loop();
+                        x86_64::instructions::hlt();
+                    }
+                    
+                    // Check if fork has been called by looking for child process
+                    let manager_guard = crate::process::manager();
+                    if let Some(ref manager) = *manager_guard {
+                        let count = manager.process_count();
+                        if count != last_count {
+                            log::warn!("Process count changed: {} -> {}", last_count, count);
+                            last_count = count;
+                        }
+                        
+                        if count > 1 {
+                            log::warn!("TEST_MARKER: FORK_SUCCEEDED");
+                            log::warn!("Fork created {} processes successfully", count);
+                            crate::test_exit_qemu(crate::QemuExitCode::Success);
+                        }
+                    }
+                    
+                    if i % 10 == 0 {
+                        log::warn!("Fork test iteration {}/100, process count: {}", i, last_count);
+                    }
+                }
+                
+                log::error!("Fork test timed out - no child process created");
+                log::error!("Final process count: {}", last_count);
+                crate::test_exit_qemu(crate::QemuExitCode::Failed);
+            }
+            Err(e) => {
+                log::error!("Failed to create fork test process: {}", e);
+                crate::test_exit_qemu(crate::QemuExitCode::Failed);
+            }
+        }
+    }
+    
+    #[cfg(not(feature = "testing"))]
+    {
+        log::error!("Fork test requires --features testing");
+        crate::test_exit_qemu(crate::QemuExitCode::Failed);
+    }
 }

--- a/tests/kernel_tests.rs
+++ b/tests/kernel_tests.rs
@@ -26,6 +26,11 @@ fn test_page_fault() {
     run_kernel_test("page_fault");
 }
 
+#[test]
+fn test_fork() {
+    run_kernel_test("fork");
+}
+
 fn run_kernel_test(test_name: &str) {
     // Acquire lock to ensure only one test runs at a time
     let _lock = QEMU_LOCK.lock().unwrap();

--- a/tests/kernel_tests.rs
+++ b/tests/kernel_tests.rs
@@ -27,8 +27,8 @@ fn test_page_fault() {
 }
 
 #[test]
-fn test_fork() {
-    run_kernel_test("fork");
+fn test_multiple_processes() {
+    run_kernel_test("multiple_processes");
 }
 
 fn run_kernel_test(test_name: &str) {

--- a/tests/kernel_tests.rs
+++ b/tests/kernel_tests.rs
@@ -45,7 +45,16 @@ fn run_kernel_test(test_name: &str) {
     // Wait a moment for processes to die and locks to be released
     thread::sleep(Duration::from_millis(500));
     
+    // Clean the kernel target to ensure fresh build with new env var
+    println!("Cleaning kernel target...");
+    let clean_status = Command::new("cargo")
+        .args(&["clean", "-p", "kernel", "--release"])
+        .status()
+        .expect("Failed to clean kernel");
+    assert!(clean_status.success(), "Clean failed");
+    
     // Build the kernel with the test harness feature and test name
+    println!("Building kernel with BREENIX_TEST=tests={}", test_name);
     let build_status = Command::new("cargo")
         .args(&["build", "--release", "--features", "kernel_tests"])
         .env("BREENIX_TEST", format!("tests={}", test_name))
@@ -53,8 +62,10 @@ fn run_kernel_test(test_name: &str) {
         .expect("Failed to build kernel");
     
     assert!(build_status.success(), "Kernel build failed");
+    println!("Build complete for test: {}", test_name);
     
     // Run QEMU with the test
+    // Important: Also set the env var when running, in case cargo run rebuilds
     let mut qemu = Command::new("cargo")
         .args(&[
             "run",
@@ -67,6 +78,7 @@ fn run_kernel_test(test_name: &str) {
             "-device", "isa-debug-exit,iobase=0xf4,iosize=0x04",
             "-no-reboot",
         ])
+        .env("BREENIX_TEST", format!("tests={}", test_name))
         .spawn()
         .expect("Failed to start QEMU");
     


### PR DESCRIPTION
## Summary

This PR implements a single-kernel test harness that allows runtime selection of tests, replacing the previous approach that required separate kernel builds for each test.

## Key Changes

### Test Harness Infrastructure
- Added `kernel/src/test_harness.rs` with runtime test selection via `BREENIX_TEST` environment variable
- Tests are selected at compile time using `option_env!` but run in a single kernel
- ISA debug exit device (port 0xf4) provides deterministic test exit codes
- Test isolation achieved by cleaning kernel package and rebuilding with different env vars

### Migrated Tests
1. **divide_by_zero** - Tests divide by zero exception handling
2. **invalid_opcode** - Tests invalid opcode exception handling  
3. **page_fault** - Tests page fault exception handling
4. **multiple_processes** - Tests 5 concurrent userspace processes

### Multiple Processes Test
- Creates 5 hello_time processes
- Verifies all execute and print "Hello from userspace!"
- Validates the concurrent process execution behavior from main branch
- Added syscall output tracking during tests (though timing makes it tricky to use)

### Documentation Updates
- Added **MANDATORY PRE-COMMIT TESTING** requirements to CLAUDE.md and PROJECT_ROADMAP.md
- Made it crystal clear that full test suite must pass before ANY commit
- Specified what to look for in test output (e.g., 5 "Hello from userspace!" messages)

## Technical Details

### Build System Changes
- Added `cargo:rerun-if-env-changed=BREENIX_TEST` to build.rs
- Host-side test runner cleans kernel package before each test
- Sets BREENIX_TEST environment variable both when building AND running

### Resolved Issues
- Fixed Cargo caching preventing proper test isolation
- Simplified fork test after discovering double fault with userspace fork
- Adjusted multiple_processes test to handle quick process exits

## Testing

Run all kernel tests:
```bash
cargo test
```

Run specific test:
```bash
cargo test -p breenix --test kernel_tests test_multiple_processes -- --nocapture
```

All 4 tests pass successfully. The multiple_processes test shows 5 processes executing concurrently.

## Next Steps
- Add more tests as features are implemented
- Consider adding fork syscall test once double fault issue is resolved
- Add exec() test when that functionality is stable

Co-Authored-By: Claude <noreply@anthropic.com>