### PR TITLE
fix(ahci): gate completion detection on PORT_IS hardware bit

### DIFF
--- a/kernel/src/drivers/ahci/mod.rs
+++ b/kernel/src/drivers/ahci/mod.rs
@@ -2638,15 +2638,26 @@ const AHCI_TRACKED_SLOT_MASK: u32 = (1u32 << AHCI_MAX_CONCURRENT) - 1;
 #[inline]
 fn detect_completed_slots(active: u32, ci_after: u32, port_is: u32) -> u32 {
     let active = active & AHCI_TRACKED_SLOT_MASK;
+
+    // Require a hardware completion IRQ signal before declaring any slot done.
+    // Without this gate, `active & !ci_after` is ambiguous during the
+    // submission window between `PORT_ACTIVE_MASK |= 1` and `port_write(PORT_CI, 1)`:
+    // a concurrent or stale ISR can read active=1, CI=0 and falsely conclude
+    // the command already completed — stealing the cmd_num and clearing the
+    // active bit before hardware is even kicked. The real completion IRQ then
+    // finds active=0 and gets dropped, leaving the waiter blocked forever
+    // (manifests as `cmd#=N+1, last_port1_cmd_num=N, CI=0, IS=1` at timeout).
+    if (port_is & (PORT_IRQ_COMPLETE | PORT_IRQ_ERROR)) == 0 {
+        return 0;
+    }
+
     let mut completed = active & !ci_after;
 
-    if completed == 0
-        && active.count_ones() == 1
-        && (port_is & (PORT_IRQ_COMPLETE | PORT_IRQ_ERROR)) != 0
-    {
+    if completed == 0 && active.count_ones() == 1 {
         // Some HBAs raise the completion/error interrupt before PORT_CI is
-        // observed cleared. With exactly one active slot, the interrupt itself
-        // still identifies the finished command unambiguously.
+        // observed cleared. With exactly one active slot and the completion
+        // IRQ signal already gated above, the interrupt still identifies the
+        // finished command unambiguously.
         completed = active;
     }
 


### PR DESCRIPTION
## Summary

F18's CI-diff completion loop fixed the outer handler race but left a deeper race inside `detect_completed_slots()` itself: the primary path `active & !ci_after` is TRUE during the submission window between `PORT_ACTIVE_MASK |= 1` (line 1540) and `port_write(PORT_CI, 1)` (line 1544).

A concurrent or stale ISR running in that window reads `active=1, CI=0` and falsely concludes the command completed — steals the cmd_num and clears the active bit **before hardware is even kicked**. The real completion IRQ arrives later with `active_mask=0` and gets dropped, leaving the waiter blocked until its 5s timeout fires.

## Signature

```
[ahci] Port 1 TIMEOUT (5s): CI=0x0 IS=0x1 cmd#=N+1 last_port1_cmd_num=N
```

Handler processed command N but silently dropped N+1's completion because N+1's active bit was cleared before PORT_CI was written.

## How it was discovered

Investigating why `execv /bin/bsh` fails with EIO on interactive boot (`./run.sh --parallels` without `--test`). The F18 5/5 PASS was legitimate for the 60s automated sweep workload, but the interactive workload reading the 740KB bsh binary triggers enough AHCI traffic to hit this race roughly every boot.

## Fix

Require `port_is & (PORT_IRQ_COMPLETE | PORT_IRQ_ERROR)` on the primary path, not just the single-slot fallback. The hardware-side IRQ bit distinguishes "CI=0 because hardware completed" from "CI=0 because hardware hasn't been kicked yet."

## Test plan

- [ ] `./run.sh --parallels --test 45` — no `Port N TIMEOUT` lines in serial
- [ ] `./run.sh --parallels` interactive — no `[init] Failed to exec bsh: EIO` (a separate pre-existing bug keeps bsh silent, but the exec itself now succeeds — tracked separately)
- [ ] `./docker/qemu/run-boot-parallel.sh 3` — x86 regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)