### PR TITLE
diagnostic(arm64): hello_raw minimal userspace test binary for F19

### DIFF
--- a/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
+++ b/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
@@ -3321,3 +3321,61 @@ failure signature. Recommended next step: open a cleanup PR to remove the
 F8-F17 diagnostic scaffolding and keep only the minimal AHCI CI-level
 completion behavior plus any low-cost regression signal needed for future
 AHCI timeout triage.
+
+## 2026-04-17 - F19 Phase 0 hello_raw post-exec probe
+
+F19 begins from the post-F18 state where `/sbin/init` can fork and exec
+`/bin/bsh` without the prior AHCI `EIO`, but bsh produces no serial output and
+init remains blocked in `waitpid`.
+
+### Hypothesis
+
+H0: if a minimal `/bin/hello_raw` binary writes to fd 1 after init execs it and
+then exits with code 42, then the broad ARM64 exec path, fd inheritance, raw
+write syscall path, and process exit/waitpid path are healthy for a simple
+post-exec binary. The next phase should trace bsh userspace runtime startup.
+
+H1: if `/bin/hello_raw` produces no output and init remains blocked in
+`waitpid`, then the kernel exec/fd path is suspect and the next phase should
+trace the kernel exec path.
+
+H2: if `/bin/hello_raw` produces no output but init observes an exit code other
+than 42, then the kernel likely enters userspace but lands at the wrong entry
+point or terminates the process early; the next phase should also trace the
+kernel exec path.
+
+### Probe
+
+Added `userspace/programs/src/hello_raw.rs`, registered it in
+`userspace/programs/Cargo.toml`, installed it from
+`userspace/programs/build.sh`, and temporarily changed
+`userspace/programs/src/init.rs` to exec `/bin/hello_raw` instead of
+`/bin/bsh`.
+
+Validation command:
+
+```text
+./run.sh --parallels --test 45
+```
+
+The command exited nonzero because the screenshot helper could not find the
+generated Parallels VM window. As in prior F-series sweeps, serial output is the
+validation source. `/tmp/breenix-parallels-serial.log` contained:
+
+```text
+[init] Breenix init starting (PID 1)
+F123456789SC[init] bsshd started (PID 2)
+F123456789SCT9T0[hello_raw] start
+[syscall] exit(42) pid=3 name=/bin/hello_raw
+[init] Boot script exited with code 42
+```
+
+### Verdict
+
+Verdict: **H0 confirmed**. A minimal post-exec userspace binary runs, can write
+to fd 1, exits with code 42, and is observed by init through `waitpid`.
+
+F19 Phase 0 therefore rules out a broad kernel exec/fd-inheritance failure for
+the minimal path. The next branch should be **Phase 2**:
+`diagnostic/f19-runtime-trace`, focused on bsh's userspace startup path
+(`_start` / Rust runtime / `main`) and subsequent shell initialization.

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -336,6 +336,10 @@ name = "hello_time"
 path = "src/hello_time.rs"
 
 [[bin]]
+name = "hello_raw"
+path = "src/hello_raw.rs"
+
+[[bin]]
 name = "http_test"
 path = "src/http_test.rs"
 

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -192,6 +192,7 @@ STD_BINARIES=(
     "simple_exit"
     "counter"
     "spinner"
+    "hello_raw"
     "hello_time"
     "fbinfo_test"
     "demo"

--- a/userspace/programs/src/hello_raw.rs
+++ b/userspace/programs/src/hello_raw.rs
@@ -1,0 +1,9 @@
+//! Minimal raw-write post-exec diagnostic for ARM64.
+
+use libbreenix::{io, process, Fd};
+
+fn main() {
+    let _ = io::write(Fd::STDOUT, b"[hello_raw] start\n");
+    process::exit(42);
+}
+

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -33,18 +33,19 @@ fn main() {
         }
     }
 
-    // Fork bsh — it will detect it's the init shell and load /etc/init.js
+    // F19 Phase 0 diagnostic: temporarily exec hello_raw instead of bsh.
+    // Expected successful signature: "[hello_raw] start" then exit code 42.
     match fork() {
         Ok(ForkResult::Child) => {
-            let arg0 = b"bsh\0";
+            let arg0 = b"hello_raw\0";
             let argv: [*const u8; 2] = [
                 arg0.as_ptr(),
                 core::ptr::null(),
             ];
-            match execv(b"/bin/bsh\0", argv.as_ptr()) {
+            match execv(b"/bin/hello_raw\0", argv.as_ptr()) {
                 Ok(_) => unreachable!(),
                 Err(e) => {
-                    print!("[init] Failed to exec bsh: {}\n", e);
+                    print!("[init] Failed to exec hello_raw: {}\n", e);
                     std::process::exit(127);
                 }
             }


### PR DESCRIPTION
## Summary
- add /bin/hello_raw as a minimal post-exec raw-write diagnostic
- temporarily exec hello_raw from init for F19 Phase 0
- document serial evidence and verdict in ARM64 investigation notes

## Evidence
- ./userspace/programs/build.sh --arch aarch64 completed cleanly
- kernel release build completed cleanly; warning/error grep produced no output
- ./run.sh --parallels --test 45 reached serial evidence below, but exited 1 because screenshot helper could not find the generated VM window

Serial verdict:
```text
[init] Breenix init starting (PID 1)
F123456789SC[init] bsshd started (PID 2)
F123456789SCT9T0[hello_raw] start
[syscall] exit(42) pid=3 name=/bin/hello_raw
[init] Boot script exited with code 42
```

## Verdict
Phase 0 H0 confirmed: minimal post-exec userspace runs, fd 1 reaches serial, exit(42) reaches init waitpid. Next branch should be diagnostic/f19-runtime-trace for bsh runtime startup.