### PR TITLE
diagnostic(arm64): trace F19 exec read contention

### DIFF
--- a/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
+++ b/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
@@ -3426,3 +3426,55 @@ Verdict: **R1 confirmed**. bsh does not reach its Rust `main()` on ARM64
 Parallels in this boot path. The next Phase 2 diagnostic should compare against
 a minimal std `println!` binary to separate "std println/stdout startup" from a
 bsh-specific pre-main/ELF/runtime issue.
+
+## 2026-04-17 - F19 Phase 2 hello_println control
+
+The next control added a minimal std binary, `/bin/hello_println`, whose `main`
+does only:
+
+```text
+println!("[hello_println] start");
+std::process::exit(42);
+```
+
+Init was temporarily changed to exec `/bin/hello_println`.
+
+### Hypothesis
+
+P0: if `[hello_println] start` appears and init observes exit code 42, minimal
+std startup and std stdout/`println!` work after init exec. bsh's failure is
+therefore bsh-specific before `main()`.
+
+P1: if `[hello_println] start` does not appear and init remains blocked, std
+stdout/`println!` is suspect despite Phase 0 proving that a minimal std binary
+can reach `main()` and raw-write fd 1.
+
+### Probe
+
+Attempt 1 was invalid: the serial log showed an AHCI timeout and
+`[init] Failed to exec hello_println: EIO`, so the binary did not run.
+
+Attempt 2 used the same validation command:
+
+```text
+./run.sh --parallels --test 45
+```
+
+Attempt 2 serial reached:
+
+```text
+[init] Breenix init starting (PID 1)
+F123456789SC[init] bsshd started (PID 2)
+F123456789SCT9T0
+```
+
+No `[hello_println] start` marker appeared, and init did not observe child
+exit.
+
+### Verdict
+
+Verdict: **P1 confirmed for the println-only control**. A minimal std
+`println!` binary hangs silently where `hello_raw` succeeded. The next
+diagnostic should put a raw fd-1 write before `println!` in the same binary to
+separate "main not reached when println is linked" from "main reached, then
+blocks inside std stdout/println".

--- a/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
+++ b/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
@@ -3532,3 +3532,66 @@ distinguish a std/runtime linkage issue from an ELF text-size/page-layout
 threshold. Local ELF inspection shows the successful `hello_raw` text segment
 ends below `0x4000f000`, while both `hello_raw_then_println` and bsh have larger
 text layouts that extend beyond that page.
+
+## 2026-04-17 - F19 Phase 2 padded raw-only control
+
+The next control added `/bin/hello_raw_padded`, a raw-only diagnostic that
+executes a referenced NOP block in executable text between two raw fd-1 writes:
+
+```text
+raw write: [hello_raw_padded] raw-before
+execute padded .text block
+raw write: [hello_raw_padded] raw-after
+exit(42)
+```
+
+Init was temporarily changed to exec `/bin/hello_raw_padded`.
+
+### Hypothesis
+
+PAD0: if the first raw marker does not appear, larger executable layout is
+enough to reproduce the pre-user-main hang without std `println!`.
+
+PAD1: if both raw markers appear and init observes exit code 42, padded text
+alone works and the failing differentiator is a runtime/linkage path pulled in
+by `println!`/bsh rather than text size.
+
+PAD2: if the first raw marker appears but the second does not, control reaches
+user `main()` but executing the padded text block hangs or faults.
+
+### Probe
+
+Local ELF inspection confirmed that the padded control exercises a much larger
+executable layout:
+
+```text
+Entry:           0x400160e8
+Executable LOAD: vaddr=0x40000000 filesz=92688
+main shim:       0x4000bfe4
+_start:          0x400160e8
+```
+
+Validation command:
+
+```text
+./run.sh --parallels --test 45
+```
+
+The serial log reached:
+
+```text
+[init] Breenix init starting (PID 1)
+F123456789SC[init] bsshd started (PID 2)
+F123456789SCT9T0
+```
+
+No `[hello_raw_padded] raw-before` marker appeared, no later marker appeared,
+and init did not observe child exit.
+
+### Verdict
+
+Verdict: **PAD0 confirmed**. A raw-only binary with larger executable layout
+also hangs before user Rust `main()`. This narrows the failure beyond
+`println!`, but the padded binary still uses Rust std's `_start`/`lang_start`
+path. The next control should bypass std entirely with a `#![no_std]`
+`#![no_main]` `_start` binary using a similar large executable layout.

--- a/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
+++ b/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
@@ -3478,3 +3478,57 @@ Verdict: **P1 confirmed for the println-only control**. A minimal std
 diagnostic should put a raw fd-1 write before `println!` in the same binary to
 separate "main not reached when println is linked" from "main reached, then
 blocks inside std stdout/println".
+
+## 2026-04-17 - F19 Phase 2 raw-before-println control
+
+The next control added `/bin/hello_raw_then_println`, whose `main` performs a
+raw fd-1 write before invoking std `println!`:
+
+```text
+raw write: [hello_raw_then_println] raw-before
+println!:  [hello_raw_then_println] println
+raw write: [hello_raw_then_println] raw-after
+exit(42)
+```
+
+Init was temporarily changed to exec `/bin/hello_raw_then_println`.
+
+### Hypothesis
+
+RP0: if the first raw marker does not appear and init remains blocked, the
+binary does not reach user `main()` when `println!` is linked/used.
+
+RP1: if the first raw marker appears but the `println!` marker and second raw
+marker do not appear, the binary reaches `main()` and hangs inside std
+stdout/`println!`.
+
+RP2: if all markers appear and init observes exit code 42, the previous
+println-only result was not stable and should be repeated.
+
+### Probe
+
+Validation command:
+
+```text
+./run.sh --parallels --test 45
+```
+
+The serial log reached:
+
+```text
+[init] Breenix init starting (PID 1)
+F123456789SC[init] bsshd started (PID 2)
+F123456789SCT9T0
+```
+
+No `[hello_raw_then_println] raw-before` marker appeared, no later marker
+appeared, and init did not observe child exit.
+
+### Verdict
+
+Verdict: **RP0 confirmed**. The failing control does not reach user `main()`;
+the first stdout operation is not the hang site. The next diagnostic should
+distinguish a std/runtime linkage issue from an ELF text-size/page-layout
+threshold. Local ELF inspection shows the successful `hello_raw` text segment
+ends below `0x4000f000`, while both `hello_raw_then_println` and bsh have larger
+text layouts that extend beyond that page.

--- a/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
+++ b/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
@@ -3595,3 +3595,66 @@ also hangs before user Rust `main()`. This narrows the failure beyond
 `println!`, but the padded binary still uses Rust std's `_start`/`lang_start`
 path. The next control should bypass std entirely with a `#![no_std]`
 `#![no_main]` `_start` binary using a similar large executable layout.
+
+## 2026-04-17 - F19 Phase 2 no-std padded control
+
+The next control added `/bin/hello_nostd_padded`, a `#![no_std]`
+`#![no_main]` binary with direct `_start`, direct raw syscall assembly, and a
+large referenced NOP block in executable text:
+
+```text
+_start:
+  raw write: [hello_nostd_padded] raw-before
+  execute padded .text block
+  raw write: [hello_nostd_padded] raw-after
+  exit(42)
+```
+
+Init was temporarily changed to exec `/bin/hello_nostd_padded`.
+
+### Hypothesis
+
+NS0: if both raw markers appear and init observes exit code 42, the kernel can
+exec a large/high-entry image and the remaining hang is in Rust std startup
+before the user main function.
+
+NS1: if the first raw marker does not appear and init remains blocked, std
+startup is not required; kernel exec/ELF/page-table handling remains suspect
+for larger/high-entry layouts.
+
+NS2: if the first raw marker appears but the second does not, direct `_start`
+runs but executing the padded text block hangs or faults.
+
+### Probe
+
+The adjusted no-std ELF exercised the high-entry layout:
+
+```text
+Entry:           0x40018004
+Executable LOAD: vaddr=0x40000000 filesz=98384
+pad symbol:      0x40000000
+_start:          0x40018004
+```
+
+Validation command:
+
+```text
+./run.sh --parallels --test 45
+```
+
+The serial log reached:
+
+```text
+[init] Breenix init starting (PID 1)
+F123456789SC[init] bsshd started (PID 2)
+F123456789SCT9T0
+```
+
+No `[hello_nostd_padded] raw-before` marker appeared, no later marker appeared,
+init did not observe child exit, and no instruction/data abort log appeared.
+
+### Verdict
+
+Verdict: **NS1 confirmed**. Rust std startup is not required to reproduce the
+silent pre-first-instruction hang. The root cause is now narrowed to kernel
+exec/return-to-userspace behavior for larger/high-entry ELF layouts.

--- a/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
+++ b/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
@@ -3379,3 +3379,50 @@ F19 Phase 0 therefore rules out a broad kernel exec/fd-inheritance failure for
 the minimal path. The next branch should be **Phase 2**:
 `diagnostic/f19-runtime-trace`, focused on bsh's userspace startup path
 (`_start` / Rust runtime / `main`) and subsequent shell initialization.
+
+## 2026-04-17 - F19 Phase 2 bsh main-entry probe
+
+Phase 2 restored init to exec `/bin/bsh` and added a single raw fd-1 marker as
+the first statement in `bsh::main()`:
+
+```text
+[bsh] RAW main() entry
+```
+
+### Hypothesis
+
+R0: if the marker appears, bsh reaches Rust `main()` and the hang is later in
+argument collection, REPL/init script selection, JavaScript context setup, or
+script execution.
+
+R1: if the marker does not appear and init remains blocked in `waitpid`, bsh is
+hanging before or during entry to Rust `main()` even though Phase 0 proved a
+minimal std binary reaches `main()` and can raw-write fd 1.
+
+### Probe
+
+Validation command:
+
+```text
+./run.sh --parallels --test 45
+```
+
+As before, the command exited nonzero because the screenshot helper could not
+find the generated Parallels VM window. The serial log is the validation source.
+`/tmp/breenix-parallels-serial.log` reached:
+
+```text
+[init] Breenix init starting (PID 1)
+F123456789SC[init] bsshd started (PID 2)
+F123456789SCT0
+```
+
+No `[bsh] RAW main() entry` marker appeared, and init did not report a child
+exit.
+
+### Verdict
+
+Verdict: **R1 confirmed**. bsh does not reach its Rust `main()` on ARM64
+Parallels in this boot path. The next Phase 2 diagnostic should compare against
+a minimal std `println!` binary to separate "std println/stdout startup" from a
+bsh-specific pre-main/ELF/runtime issue.

--- a/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
+++ b/docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md
@@ -3658,3 +3658,107 @@ init did not observe child exit, and no instruction/data abort log appeared.
 Verdict: **NS1 confirmed**. Rust std startup is not required to reproduce the
 silent pre-first-instruction hang. The root cause is now narrowed to kernel
 exec/return-to-userspace behavior for larger/high-entry ELF layouts.
+
+## 2026-04-17 - F19 Phase 2 exec-read isolation
+
+The next probe added ARM64 exec-path breadcrumbs and an ELF entry-byte verifier.
+The verifier compares the first instruction word at the loaded ELF entry VA
+against the expected bytes from the ELF file after segment loading.
+
+### Hypotheses
+
+EP0: if exec reaches the ext2 file-content read but never reaches the loader,
+the observed silent hang is an exec-read problem rather than Rust startup or
+ELF entry dispatch.
+
+EP1: if file read completes and the entry verifier reports `match=1`, but the
+program still produces no raw marker, the remaining failure is in frame/TTBR
+return-to-userspace handling.
+
+CON0: if skipping the background bsshd fork makes the same
+`hello_nostd_padded` exec succeed, overlapping early boot exec reads are the
+trigger.
+
+### Probe A: bsshd + hello_nostd_padded
+
+With bsshd still started in the background, init's child printed immediately
+before calling `execv("/bin/hello_nostd_padded")`, proving the forked child had
+returned to userspace and fd 1 still worked:
+
+```text
+[init] Breenix init starting (PID 1)
+F123456789SC
+[F19_EXEC] E
+[F19_EXEC] N
+[F19_EXEC] A
+[F19_EXEC] O
+[F19_EXEC] r
+[F19_EXEC] g
+[init] bsshd started (PID 2)
+F123456789SC[init-child] before hello_nostd_padded exec
+[F19_EXEC] E
+[F19_EXEC] N
+[F19_EXEC] A
+[F19_EXEC] O
+[F19_EXEC] r
+[F19_EXEC] g
+T9T0
+[F19_EXEC] i
+[F19_EXEC] n
+[F19_EXEC] p
+[F19_EXEC] q
+[F19_EXEC] i
+!!! SOFT LOCKUP DETECTED !!!
+...
+[ahci] read_block(360472) wait failed: AHCI: command timeout
+[init] Failed to exec hello_nostd_padded: EIO
+```
+
+The last unambiguous tag for the hello exec was `q`: about to read ELF file
+content. No `d` (file content read complete) and no exec-target `[F19_ELF]`
+entry verification appeared before the AHCI timeout.
+
+### Probe B: skip bsshd
+
+When init temporarily skipped bsshd and performed only the boot-script exec,
+the same target completed:
+
+```text
+[init] Breenix init starting (PID 1)
+[init] bsshd skipped for F19
+F123456789SC[init-child] before hello_nostd_padded exec
+[F19_EXEC] E
+[F19_EXEC] N
+[F19_EXEC] A
+[F19_EXEC] O
+[F19_EXEC] r
+[F19_EXEC] g
+[F19_EXEC] i
+[F19_EXEC] n
+[F19_EXEC] p
+[F19_EXEC] q
+[F19_EXEC] d
+[F19_EXEC] L
+[F19_EXEC] P
+[F19_EXEC] M
+[F19_ELF] entry=0x40018004 phys=0x4405b004 loaded=0xf81f0ffe expected=0xf81f0ffe match=1
+[F19_EXEC] S
+[F19_EXEC] F
+[F19_EXEC] T
+[F19_EXEC] R
+[hello_nostd_padded] raw-before
+[hello_nostd_padded] raw-after
+[syscall] exit(42) pid=2 name=/bin/hello_nostd_padded
+[init] Boot script exited with code 42
+```
+
+### Verdict
+
+Verdict: **CON0 confirmed**. The no-std high-entry diagnostic executes
+correctly when it is the only early boot exec read. The bsh symptom is not Rust
+std startup and not ELF entry mapping. It is triggered by overlapping early
+boot exec reads: the background bsshd exec and the boot shell exec contend in
+the ext2/AHCI read path, leading to a stalled file-content read and eventual
+AHCI timeout/EIO under instrumentation. The minimal F19 fix should serialize
+early boot exec reads by running the boot shell first and starting bsshd only
+after the boot script has completed.

--- a/kernel/src/arch_impl/aarch64/elf.rs
+++ b/kernel/src/arch_impl/aarch64/elf.rs
@@ -363,6 +363,8 @@ pub fn load_elf_into_page_table(
         }
     }
 
+    f19_verify_entry_mapping(data, header, page_table);
+
     // Page-align the heap start (4KB alignment)
     let heap_start = (max_segment_end + 0xfff) & !0xfff;
 
@@ -404,6 +406,84 @@ pub fn load_elf_into_page_table(
         phnum: header.phnum,
         phentsize: header.phentsize,
     })
+}
+
+/// F19 diagnostic tags:
+/// - `[F19_ELF] match=1`: entry VA translated and first word matches ELF bytes
+/// - `[F19_ELF] match=0`: entry VA translated but copied bytes differ
+/// - `[F19_ELF] missing`: entry VA did not translate in the new page table
+fn f19_verify_entry_mapping(
+    data: &[u8],
+    header: &Elf64Header,
+    page_table: &crate::memory::process_memory::ProcessPageTable,
+) {
+    use crate::arch_impl::aarch64::context_switch::{raw_uart_hex, raw_uart_str};
+
+    let Some(expected_word) = f19_expected_entry_word(data, header) else {
+        raw_uart_str("\n[F19_ELF] no_entry_file_word entry=");
+        raw_uart_hex(header.entry);
+        raw_uart_str("\n");
+        return;
+    };
+
+    let Some(entry_phys) = page_table.translate_page(VirtAddr::new(header.entry)) else {
+        raw_uart_str("\n[F19_ELF] missing entry=");
+        raw_uart_hex(header.entry);
+        raw_uart_str(" expected=");
+        raw_uart_hex(expected_word as u64);
+        raw_uart_str("\n");
+        return;
+    };
+
+    let physical_memory_offset = crate::memory::physical_memory_offset();
+    let entry_ptr = (physical_memory_offset.as_u64() + entry_phys.as_u64()) as *const u32;
+    let loaded_word = unsafe { core::ptr::read_volatile(entry_ptr) };
+    raw_uart_str("\n[F19_ELF] entry=");
+    raw_uart_hex(header.entry);
+    raw_uart_str(" phys=");
+    raw_uart_hex(entry_phys.as_u64());
+    raw_uart_str(" loaded=");
+    raw_uart_hex(loaded_word as u64);
+    raw_uart_str(" expected=");
+    raw_uart_hex(expected_word as u64);
+    raw_uart_str(" match=");
+    raw_uart_str(if loaded_word == expected_word { "1" } else { "0" });
+    raw_uart_str("\n");
+}
+
+fn f19_expected_entry_word(data: &[u8], header: &Elf64Header) -> Option<u32> {
+    let ph_offset = header.phoff as usize;
+    let ph_size = header.phentsize as usize;
+    let ph_count = header.phnum as usize;
+
+    for i in 0..ph_count {
+        let ph_start = ph_offset.checked_add(i.checked_mul(ph_size)?)?;
+        let ph_end = ph_start.checked_add(mem::size_of::<Elf64ProgramHeader>())?;
+        if ph_end > data.len() {
+            return None;
+        }
+
+        let mut ph_bytes = [0u8; mem::size_of::<Elf64ProgramHeader>()];
+        ph_bytes.copy_from_slice(&data[ph_start..ph_end]);
+        let ph: &Elf64ProgramHeader = unsafe { &*(ph_bytes.as_ptr() as *const Elf64ProgramHeader) };
+
+        if ph.p_type != SegmentType::Load as u32 {
+            continue;
+        }
+
+        let seg_start = ph.p_vaddr;
+        let seg_file_end = ph.p_vaddr.checked_add(ph.p_filesz)?;
+        if header.entry < seg_start || header.entry.checked_add(4)? > seg_file_end {
+            continue;
+        }
+
+        let entry_offset = header.entry.checked_sub(ph.p_vaddr)?;
+        let file_offset = (ph.p_offset.checked_add(entry_offset)?) as usize;
+        let bytes = data.get(file_offset..file_offset.checked_add(4)?)?;
+        return Some(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
+    }
+
+    None
 }
 
 /// Load a single ELF segment into a process page table.

--- a/kernel/src/arch_impl/aarch64/syscall_entry.rs
+++ b/kernel/src/arch_impl/aarch64/syscall_entry.rs
@@ -1010,6 +1010,34 @@ fn sys_fork_aarch64(frame: &Aarch64ExceptionFrame) -> u64 {
 // Exec syscall implementation for ARM64
 // =============================================================================
 
+/// F19 exec-path serial breadcrumbs (single-letter tags):
+/// - `E`: exec syscall entered
+/// - `N`: program name copied from userspace
+/// - `A`: argv copied from userspace
+/// - `O`: about to open/read target ELF from ext2
+/// - `L`: target ELF bytes read into kernel memory
+/// - `P`: current process identified
+/// - `M`: entering process-manager exec replacement
+/// - `S`: process-manager exec replacement succeeded
+/// - `F`: exception frame updated for the new image
+/// - `T`: TTBR0 switched to the new process page table
+/// - `R`: exec syscall about to return to the assembly exit path
+/// - `r`: load_elf_from_ext2 entered
+/// - `g`: ext2 filesystem guard acquired
+/// - `i`: path resolved to inode
+/// - `n`: inode read
+/// - `p`: execute permissions accepted
+/// - `q`: about to read file content
+/// - `d`: file content read complete
+#[inline(never)]
+fn f19_exec_tag(tag: u8) {
+    use crate::arch_impl::aarch64::context_switch::{raw_uart_char, raw_uart_str};
+
+    raw_uart_str("\n[F19_EXEC] ");
+    raw_uart_char(tag);
+    raw_uart_str("\n");
+}
+
 /// sys_exec for ARM64 - Replace current process with a new program
 ///
 /// This function replaces the current process's address space with a new program.
@@ -1030,6 +1058,7 @@ fn sys_exec_aarch64(
 ) -> u64 {
     // Trace: exec syscall entered
     super::trace::trace_exec(b'E');
+    f19_exec_tag(b'E');
 
     log::info!(
         "sys_exec_aarch64: program_name_ptr={:#x}, argv_ptr={:#x}",
@@ -1068,6 +1097,7 @@ fn sys_exec_aarch64(
 
     // Trace: program name parsed successfully
     super::trace::trace_exec(b'N');
+    f19_exec_tag(b'N');
 
     log::info!("sys_exec_aarch64: Loading program '{}'", program_name);
 
@@ -1120,9 +1150,11 @@ fn sys_exec_aarch64(
         arg0.push(0);
         argv_vec.push(arg0);
     }
+    f19_exec_tag(b'A');
 
     // Trace: attempting to open ELF file
     super::trace::trace_exec(b'O');
+    f19_exec_tag(b'O');
 
     let elf_vec = if program_name.contains('/') {
         match load_elf_from_ext2(&program_name) {
@@ -1151,6 +1183,7 @@ fn sys_exec_aarch64(
 
     // Trace: ELF file loaded from filesystem
     super::trace::trace_exec(b'L');
+    f19_exec_tag(b'L');
 
     let elf_data = elf_vec.as_slice();
 
@@ -1171,6 +1204,7 @@ fn sys_exec_aarch64(
             return (-12_i64) as u64; // -ENOMEM
         }
     };
+    f19_exec_tag(b'P');
 
     log::info!(
         "sys_exec_aarch64: Replacing process {} (thread {}) with new program",
@@ -1185,6 +1219,7 @@ fn sys_exec_aarch64(
         if let Some(ref mut manager) = *manager_guard {
             // Trace: calling exec_process_with_argv (process manager)
             super::trace::trace_exec(b'M');
+            f19_exec_tag(b'M');
 
             match manager.exec_process_with_argv(
                 current_pid,
@@ -1195,6 +1230,7 @@ fn sys_exec_aarch64(
                 Ok((new_entry_point, new_rsp)) => {
                     // Trace: exec_process_with_argv succeeded
                     super::trace::trace_exec(b'S');
+                    f19_exec_tag(b'S');
 
                     log::info!(
                             "sys_exec_aarch64: Successfully replaced process address space, entry point: {:#x}",
@@ -1247,6 +1283,7 @@ fn sys_exec_aarch64(
 
                     // Trace: frame registers zeroed, SPSR set
                     super::trace::trace_exec(b'F');
+                    f19_exec_tag(b'F');
 
                     if let Some(process) = manager.get_process(current_pid) {
                         if let Some(ref page_table) = process.page_table {
@@ -1266,6 +1303,7 @@ fn sys_exec_aarch64(
                             }
                             // Trace: TTBR0 page table switched
                             super::trace::trace_exec(b'P');
+                            f19_exec_tag(b'T');
 
                             // CRITICAL: Update saved_process_cr3 so the assembly ERET
                             // path doesn't restore the OLD (now-freed) page table.
@@ -1285,6 +1323,7 @@ fn sys_exec_aarch64(
                     );
                     // Trace: about to return 0 from exec syscall
                     super::trace::trace_exec(b'R');
+                    f19_exec_tag(b'R');
 
                     0
                 }
@@ -1311,6 +1350,7 @@ fn load_elf_from_ext2(path: &str) -> Result<alloc::vec::Vec<u8>, i32> {
 
     // Trace: entering load_elf_from_ext2
     super::trace::trace_exec(b'1');
+    f19_exec_tag(b'r');
 
     // Determine which filesystem to use based on path
     let is_home = ext2::is_home_path(path);
@@ -1323,12 +1363,14 @@ fn load_elf_from_ext2(path: &str) -> Result<alloc::vec::Vec<u8>, i32> {
     if is_home {
         let fs_guard = ext2::home_fs_read();
         super::trace::trace_exec(b'2');
+        f19_exec_tag(b'g');
         let fs = fs_guard.as_ref().ok_or(EIO)?;
         super::trace::trace_exec(b'3');
         load_elf_from_ext2_inner(fs, fs_path)
     } else {
         let fs_guard = ext2::root_fs_read();
         super::trace::trace_exec(b'2');
+        f19_exec_tag(b'g');
         let fs = fs_guard.as_ref().ok_or(EIO)?;
         super::trace::trace_exec(b'3');
         load_elf_from_ext2_inner(fs, fs_path)
@@ -1351,12 +1393,14 @@ fn load_elf_from_ext2_inner(
         }
     })?;
     super::trace::trace_exec(b'4');
+    f19_exec_tag(b'i');
 
     let inode = fs.read_inode(inode_num).map_err(|_| {
         super::trace::trace_exec(b'@');
         EIO
     })?;
     super::trace::trace_exec(b'5');
+    f19_exec_tag(b'n');
 
     if inode.is_dir() {
         super::trace::trace_exec(b'#');
@@ -1369,12 +1413,15 @@ fn load_elf_from_ext2_inner(
         return Err(EACCES);
     }
     super::trace::trace_exec(b'6');
+    f19_exec_tag(b'p');
 
+    f19_exec_tag(b'q');
     let data = fs.read_file_content(&inode).map_err(|_| {
         super::trace::trace_exec(b'%');
         EIO
     })?;
     super::trace::trace_exec(b'7');
+    f19_exec_tag(b'd');
 
     Ok(data)
 }

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -348,6 +348,10 @@ name = "hello_raw_then_println"
 path = "src/hello_raw_then_println.rs"
 
 [[bin]]
+name = "hello_raw_padded"
+path = "src/hello_raw_padded.rs"
+
+[[bin]]
 name = "http_test"
 path = "src/http_test.rs"
 

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -352,6 +352,10 @@ name = "hello_raw_padded"
 path = "src/hello_raw_padded.rs"
 
 [[bin]]
+name = "hello_nostd_padded"
+path = "src/hello_nostd_padded.rs"
+
+[[bin]]
 name = "http_test"
 path = "src/http_test.rs"
 

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -340,6 +340,10 @@ name = "hello_raw"
 path = "src/hello_raw.rs"
 
 [[bin]]
+name = "hello_println"
+path = "src/hello_println.rs"
+
+[[bin]]
 name = "http_test"
 path = "src/http_test.rs"
 

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -344,6 +344,10 @@ name = "hello_println"
 path = "src/hello_println.rs"
 
 [[bin]]
+name = "hello_raw_then_println"
+path = "src/hello_raw_then_println.rs"
+
+[[bin]]
 name = "http_test"
 path = "src/http_test.rs"
 

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -194,6 +194,7 @@ STD_BINARIES=(
     "spinner"
     "hello_raw"
     "hello_println"
+    "hello_raw_then_println"
     "hello_time"
     "fbinfo_test"
     "demo"

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -193,6 +193,7 @@ STD_BINARIES=(
     "counter"
     "spinner"
     "hello_raw"
+    "hello_println"
     "hello_time"
     "fbinfo_test"
     "demo"

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -196,6 +196,7 @@ STD_BINARIES=(
     "hello_println"
     "hello_raw_then_println"
     "hello_raw_padded"
+    "hello_nostd_padded"
     "hello_time"
     "fbinfo_test"
     "demo"

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -195,6 +195,7 @@ STD_BINARIES=(
     "hello_raw"
     "hello_println"
     "hello_raw_then_println"
+    "hello_raw_padded"
     "hello_time"
     "fbinfo_test"
     "demo"

--- a/userspace/programs/src/bsh.rs
+++ b/userspace/programs/src/bsh.rs
@@ -2576,6 +2576,8 @@ fn run_file(path: &str) {
 }
 
 fn main() {
+    let _ = libbreenix::io::write(libbreenix::Fd::STDOUT, b"[bsh] RAW main() entry\n");
+
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() == 1 {

--- a/userspace/programs/src/hello_nostd_padded.rs
+++ b/userspace/programs/src/hello_nostd_padded.rs
@@ -1,0 +1,132 @@
+#![no_std]
+#![no_main]
+
+//! No-std raw `_start` diagnostic with deliberately padded executable text.
+
+use core::arch::asm;
+use core::panic::PanicInfo;
+
+#[cfg(target_arch = "aarch64")]
+core::arch::global_asm!(
+    ".section .text.hello_nostd_padded_pad,\"ax\"",
+    ".global hello_nostd_padded_pad",
+    "hello_nostd_padded_pad:",
+    ".rept 24576",
+    "nop",
+    ".endr",
+    "ret",
+);
+
+#[cfg(target_arch = "x86_64")]
+core::arch::global_asm!(
+    ".section .text.hello_nostd_padded_pad,\"ax\"",
+    ".global hello_nostd_padded_pad",
+    "hello_nostd_padded_pad:",
+    ".rept 24576",
+    "nop",
+    ".endr",
+    "ret",
+);
+
+extern "C" {
+    fn hello_nostd_padded_pad();
+}
+
+const RAW_BEFORE: &[u8] = b"[hello_nostd_padded] raw-before\n";
+const RAW_AFTER: &[u8] = b"[hello_nostd_padded] raw-after\n";
+
+#[cfg(target_arch = "aarch64")]
+unsafe fn syscall1(num: u64, arg0: u64) -> u64 {
+    let ret: u64;
+    asm!(
+        "svc #0",
+        in("x8") num,
+        inlateout("x0") arg0 => ret,
+        options(nostack)
+    );
+    ret
+}
+
+#[cfg(target_arch = "aarch64")]
+unsafe fn syscall3(num: u64, arg0: u64, arg1: u64, arg2: u64) -> u64 {
+    let ret: u64;
+    asm!(
+        "svc #0",
+        in("x8") num,
+        inlateout("x0") arg0 => ret,
+        in("x1") arg1,
+        in("x2") arg2,
+        options(nostack)
+    );
+    ret
+}
+
+#[cfg(target_arch = "x86_64")]
+unsafe fn syscall1(num: u64, arg0: u64) -> u64 {
+    let ret: u64;
+    asm!(
+        "int 0x80",
+        in("rax") num,
+        in("rdi") arg0,
+        lateout("rax") ret,
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+#[cfg(target_arch = "x86_64")]
+unsafe fn syscall3(num: u64, arg0: u64, arg1: u64, arg2: u64) -> u64 {
+    let ret: u64;
+    asm!(
+        "int 0x80",
+        in("rax") num,
+        in("rdi") arg0,
+        in("rsi") arg1,
+        in("rdx") arg2,
+        lateout("rax") ret,
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+#[cfg(target_arch = "aarch64")]
+const SYS_WRITE: u64 = 64;
+#[cfg(target_arch = "aarch64")]
+const SYS_EXIT: u64 = 93;
+
+#[cfg(target_arch = "x86_64")]
+const SYS_WRITE: u64 = 1;
+#[cfg(target_arch = "x86_64")]
+const SYS_EXIT: u64 = 60;
+
+#[inline(always)]
+fn raw_write(buf: &[u8]) {
+    unsafe {
+        let _ = syscall3(SYS_WRITE, 1, buf.as_ptr() as u64, buf.len() as u64);
+    }
+}
+
+#[inline(always)]
+fn raw_exit(code: i32) -> ! {
+    unsafe {
+        let _ = syscall1(SYS_EXIT, code as u64);
+    }
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    raw_write(RAW_BEFORE);
+    unsafe {
+        hello_nostd_padded_pad();
+    }
+    raw_write(RAW_AFTER);
+    raw_exit(42);
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo<'_>) -> ! {
+    raw_exit(101);
+}

--- a/userspace/programs/src/hello_println.rs
+++ b/userspace/programs/src/hello_println.rs
@@ -1,0 +1,7 @@
+//! Minimal std println post-exec diagnostic for ARM64.
+
+fn main() {
+    println!("[hello_println] start");
+    std::process::exit(42);
+}
+

--- a/userspace/programs/src/hello_raw_padded.rs
+++ b/userspace/programs/src/hello_raw_padded.rs
@@ -1,0 +1,44 @@
+//! Raw-write diagnostic with deliberately padded executable text.
+
+use libbreenix::{io, process, Fd};
+
+#[cfg(target_arch = "aarch64")]
+core::arch::global_asm!(
+    ".section .text.hello_raw_padded_pad,\"ax\"",
+    ".global hello_raw_padded_pad",
+    "hello_raw_padded_pad:",
+    ".rept 8192",
+    "nop",
+    ".endr",
+    "ret",
+);
+
+#[cfg(target_arch = "x86_64")]
+core::arch::global_asm!(
+    ".section .text.hello_raw_padded_pad,\"ax\"",
+    ".global hello_raw_padded_pad",
+    "hello_raw_padded_pad:",
+    ".rept 8192",
+    "nop",
+    ".endr",
+    "ret",
+);
+
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+extern "C" {
+    fn hello_raw_padded_pad();
+}
+
+fn run_padding() {
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    unsafe {
+        hello_raw_padded_pad();
+    }
+}
+
+fn main() {
+    let _ = io::write(Fd::STDOUT, b"[hello_raw_padded] raw-before\n");
+    run_padding();
+    let _ = io::write(Fd::STDOUT, b"[hello_raw_padded] raw-after\n");
+    process::exit(42);
+}

--- a/userspace/programs/src/hello_raw_then_println.rs
+++ b/userspace/programs/src/hello_raw_then_println.rs
@@ -1,0 +1,11 @@
+//! Raw-before-println diagnostic for ARM64 std stdout narrowing.
+
+use libbreenix::{io, Fd};
+
+fn main() {
+    let _ = io::write(Fd::STDOUT, b"[hello_raw_then_println] raw-before\n");
+    println!("[hello_raw_then_println] println");
+    let _ = io::write(Fd::STDOUT, b"[hello_raw_then_println] raw-after\n");
+    std::process::exit(42);
+}
+

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -33,19 +33,18 @@ fn main() {
         }
     }
 
-    // F19 Phase 0 diagnostic: temporarily exec hello_raw instead of bsh.
-    // Expected successful signature: "[hello_raw] start" then exit code 42.
+    // Fork bsh — it will detect it's the init shell and load /etc/init.js
     match fork() {
         Ok(ForkResult::Child) => {
-            let arg0 = b"hello_raw\0";
+            let arg0 = b"bsh\0";
             let argv: [*const u8; 2] = [
                 arg0.as_ptr(),
                 core::ptr::null(),
             ];
-            match execv(b"/bin/hello_raw\0", argv.as_ptr()) {
+            match execv(b"/bin/bsh\0", argv.as_ptr()) {
                 Ok(_) => unreachable!(),
                 Err(e) => {
-                    print!("[init] Failed to exec hello_raw: {}\n", e);
+                    print!("[init] Failed to exec bsh: {}\n", e);
                     std::process::exit(127);
                 }
             }

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -33,19 +33,19 @@ fn main() {
         }
     }
 
-    // F19 Phase 2 diagnostic: raw write before std println.
-    // Expected signature distinguishes pre-main/linkage from println blocking.
+    // F19 Phase 2 diagnostic: raw-only binary with padded executable text.
+    // Expected signature distinguishes ELF layout from std/println linkage.
     match fork() {
         Ok(ForkResult::Child) => {
-            let arg0 = b"hello_raw_then_println\0";
+            let arg0 = b"hello_raw_padded\0";
             let argv: [*const u8; 2] = [
                 arg0.as_ptr(),
                 core::ptr::null(),
             ];
-            match execv(b"/bin/hello_raw_then_println\0", argv.as_ptr()) {
+            match execv(b"/bin/hello_raw_padded\0", argv.as_ptr()) {
                 Ok(_) => unreachable!(),
                 Err(e) => {
-                    print!("[init] Failed to exec hello_raw_then_println: {}\n", e);
+                    print!("[init] Failed to exec hello_raw_padded: {}\n", e);
                     std::process::exit(127);
                 }
             }

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -33,19 +33,19 @@ fn main() {
         }
     }
 
-    // F19 Phase 2 diagnostic: temporarily exec hello_println instead of bsh.
-    // Expected successful signature: "[hello_println] start" then exit code 42.
+    // F19 Phase 2 diagnostic: raw write before std println.
+    // Expected signature distinguishes pre-main/linkage from println blocking.
     match fork() {
         Ok(ForkResult::Child) => {
-            let arg0 = b"hello_println\0";
+            let arg0 = b"hello_raw_then_println\0";
             let argv: [*const u8; 2] = [
                 arg0.as_ptr(),
                 core::ptr::null(),
             ];
-            match execv(b"/bin/hello_println\0", argv.as_ptr()) {
+            match execv(b"/bin/hello_raw_then_println\0", argv.as_ptr()) {
                 Ok(_) => unreachable!(),
                 Err(e) => {
-                    print!("[init] Failed to exec hello_println: {}\n", e);
+                    print!("[init] Failed to exec hello_raw_then_println: {}\n", e);
                     std::process::exit(127);
                 }
             }

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -4,39 +4,51 @@
 //! bsh detects it's the init shell (PID 2) and loads /etc/init.js.
 
 use libbreenix::process::{fork, execv, waitpid, getpid, ForkResult};
+use libbreenix::types::Fd;
 
 fn main() {
     let pid = getpid().map(|p| p.raw()).unwrap_or(0);
     print!("[init] Breenix init starting (PID {})\n", pid);
 
-    // Fork bsshd — SSH server daemon (background)
-    match fork() {
-        Ok(ForkResult::Child) => {
-            let arg0 = b"bsshd\0";
-            let argv: [*const u8; 2] = [
-                arg0.as_ptr(),
-                core::ptr::null(),
-            ];
-            match execv(b"/bin/bsshd\0", argv.as_ptr()) {
-                Ok(_) => unreachable!(),
-                Err(_) => {
-                    // bsshd not installed — silently exit
-                    std::process::exit(0);
+    // F19 diagnostic: skip bsshd to isolate whether concurrent boot-time exec
+    // reads are what starve the boot shell replacement exec.
+    let start_bsshd = false;
+    if start_bsshd {
+        // Fork bsshd — SSH server daemon (background)
+        match fork() {
+            Ok(ForkResult::Child) => {
+                let arg0 = b"bsshd\0";
+                let argv: [*const u8; 2] = [
+                    arg0.as_ptr(),
+                    core::ptr::null(),
+                ];
+                match execv(b"/bin/bsshd\0", argv.as_ptr()) {
+                    Ok(_) => unreachable!(),
+                    Err(_) => {
+                        // bsshd not installed — silently exit
+                        std::process::exit(0);
+                    }
                 }
             }
+            Ok(ForkResult::Parent(child_pid)) => {
+                print!("[init] bsshd started (PID {})\n", child_pid.raw());
+            }
+            Err(_) => {
+                print!("[init] Warning: failed to start bsshd\n");
+            }
         }
-        Ok(ForkResult::Parent(child_pid)) => {
-            print!("[init] bsshd started (PID {})\n", child_pid.raw());
-        }
-        Err(_) => {
-            print!("[init] Warning: failed to start bsshd\n");
-        }
+    } else {
+        print!("[init] bsshd skipped for F19\n");
     }
 
     // F19 Phase 2 diagnostic: no-std raw _start with padded executable text.
     // Expected signature distinguishes kernel ELF exec from Rust std startup.
     match fork() {
         Ok(ForkResult::Child) => {
+            let _ = libbreenix::io::write(
+                Fd::STDOUT,
+                b"[init-child] before hello_nostd_padded exec\n",
+            );
             let arg0 = b"hello_nostd_padded\0";
             let argv: [*const u8; 2] = [
                 arg0.as_ptr(),

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -33,19 +33,19 @@ fn main() {
         }
     }
 
-    // F19 Phase 2 diagnostic: raw-only binary with padded executable text.
-    // Expected signature distinguishes ELF layout from std/println linkage.
+    // F19 Phase 2 diagnostic: no-std raw _start with padded executable text.
+    // Expected signature distinguishes kernel ELF exec from Rust std startup.
     match fork() {
         Ok(ForkResult::Child) => {
-            let arg0 = b"hello_raw_padded\0";
+            let arg0 = b"hello_nostd_padded\0";
             let argv: [*const u8; 2] = [
                 arg0.as_ptr(),
                 core::ptr::null(),
             ];
-            match execv(b"/bin/hello_raw_padded\0", argv.as_ptr()) {
+            match execv(b"/bin/hello_nostd_padded\0", argv.as_ptr()) {
                 Ok(_) => unreachable!(),
                 Err(e) => {
-                    print!("[init] Failed to exec hello_raw_padded: {}\n", e);
+                    print!("[init] Failed to exec hello_nostd_padded: {}\n", e);
                     std::process::exit(127);
                 }
             }

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -33,18 +33,19 @@ fn main() {
         }
     }
 
-    // Fork bsh — it will detect it's the init shell and load /etc/init.js
+    // F19 Phase 2 diagnostic: temporarily exec hello_println instead of bsh.
+    // Expected successful signature: "[hello_println] start" then exit code 42.
     match fork() {
         Ok(ForkResult::Child) => {
-            let arg0 = b"bsh\0";
+            let arg0 = b"hello_println\0";
             let argv: [*const u8; 2] = [
                 arg0.as_ptr(),
                 core::ptr::null(),
             ];
-            match execv(b"/bin/bsh\0", argv.as_ptr()) {
+            match execv(b"/bin/hello_println\0", argv.as_ptr()) {
                 Ok(_) => unreachable!(),
                 Err(e) => {
-                    print!("[init] Failed to exec bsh: {}\n", e);
+                    print!("[init] Failed to exec hello_println: {}\n", e);
                     std::process::exit(127);
                 }
             }


### PR DESCRIPTION
## Summary
- documents F19 runtime controls from bsh main through no-std padded exec
- adds targeted ARM64 exec/read breadcrumbs and ELF entry-byte verification
- captures the verdict that overlapping bsshd + boot-shell exec reads stall in ext2/AHCI file-content read; skipping bsshd lets the same no-std padded binary run and exit 42

## Validation
- cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64 (0 warnings/errors)
- ./run.sh --parallels --test 45 (breadcrumb evidence captured; wrapper exits on screenshot lookup)
