### PR TITLE
F25: fix post-bwm app spawn hang

### DIFF
--- a/docs/planning/f25-spawn-hang/exit.md
+++ b/docs/planning/f25-spawn-hang/exit.md
@@ -1,0 +1,133 @@
+# F25 Exit - Post-bwm Spawn Hang
+
+Date: 2026-04-18
+
+Branch: `fix/f25-post-bwm-spawn-hang`
+
+Base: `97b441823473b81de7ba3ba89404c217903e0cd5`
+
+## Summary
+
+F25 narrowed the post-bwm spawn hang from a bounce-specific suspicion into an architectural exec-read problem under the active GUI workload, then fixed the storage/read amplification path enough for the boot sequence to bring up bwm, telnetd, bsshd, and the bounce window.
+
+The final ARM64 init sequence starts the long-lived network services before the continuously animating bounce workload. Bounce still spawns after bwm, which validates the original desktop-app goal, while avoiding further service exec reads after the animation begins.
+
+## Phase 1 Verdict
+
+The cheap narrowing test added `/bin/hello_raw` immediately after `/bin/bwm` and before `/sbin/telnetd`.
+
+Result:
+
+```text
+[spawn] path='/bin/bwm'
+[spawn] Created child PID 2 for parent PID 1
+[spawn] Success: child PID 2 scheduled
+[spawn] path='/bin/hello_raw'
+```
+
+There was no `Created child PID` for `hello_raw`, no `[hello_raw] start`, and no `[syscall] exit(42)`.
+
+Verdict: `hello_raw` also hangs after bwm, so the bug is not bounce-specific. Any post-bwm exec was vulnerable.
+
+Details are recorded in `docs/planning/f25-spawn-hang/phase1.md`.
+
+## Phase 2 Breadcrumbs
+
+Temporary raw serial breadcrumbs were added and then removed from the final patch.
+
+Spawn/exec breadcrumbs showed the stall after syscall entry and path preparation, before ELF read completion:
+
+```text
+S ... 3
+```
+
+The process manager breadcrumbs never reached page table allocation, mapping, or thread creation, so the stall was not child scheduling.
+
+AHCI breadcrumbs during the same run showed:
+
+```text
+W=58 I=57 C=57 D=57
+last marker: W
+```
+
+That means the next AHCI command was issued and the thread entered the scheduler sleep path, but no completion was delivered before the run ended. The stall localized to exec ELF file reads over ext2/AHCI under the active bwm workload.
+
+## Phase 3 Fix
+
+The fix reduces exec-time AHCI command pressure and removes the worst read amplification:
+
+- Added `BlockDevice::read_blocks()` as a default multi-block API.
+- Implemented native AHCI multi-sector reads in `AhciBlockDevice`, capped at the existing 128-sector / 64 KiB command-table limit.
+- Taught ext2 file reads to coalesce contiguous physical blocks into runs.
+- Cached the single-indirect pointer block during a file read instead of rereading it for every logical block.
+- Added a 1 ms sleep in bounce's window-buffer render loop so the animated demo yields when idle between presents.
+- Kept ARM64 init serialized: bwm first, then telnetd, then bsshd, then bounce.
+
+The AHCI multi-sector limit follows the driver structure already present in this tree: the command table reserves 8 PRDT entries for 128 sectors / 64 KiB, and the DMA buffers are 64 KiB per slot. The existing `setup_read_sectors` path already accepts counts up to 128 and emits `READ DMA EXT`; F25 uses that support instead of issuing one command per 512-byte sector.
+
+The project standard is to follow Linux/FreeBSD-grade practices (`CLAUDE.md`), and the pre-existing F18 analysis cites the relevant Linux v6.8 AHCI completion model: acknowledge port interrupt status, read `PORT_SCR_ACT` / `PORT_CMD_ISSUE`, and complete commands based on the hardware-active mask. F25 did not rewrite that completion model; it reduces the number of exposed completions needed for large exec reads.
+
+## Phase 4 Validation
+
+Final Parallels serial showed all target services and the app lifecycle:
+
+```text
+[spawn] path='/bin/bwm'
+[spawn] Created child PID 2 for parent PID 1
+[spawn] Success: child PID 2 scheduled
+[spawn] path='/sbin/telnetd'
+[spawn] Created child PID 3 for parent PID 1
+[spawn] Success: child PID 3 scheduled
+[spawn] path='/bin/bsshd'
+[spawn] Created child PID 4 for parent PID 1
+[spawn] Success: child PID 4 scheduled
+[spawn] path='/bin/bounce'
+[spawn] Created child PID 5 for parent PID 1
+[spawn] Success: child PID 5 scheduled
+TELNETD_STARTING
+TELNETD_LISTENING
+[init] Boot script completed
+bsshd: listening on 0.0.0.0:2222
+[init] bounce started (PID 5)
+Bounce spheres demo starting (for Gus!)
+[bwm] Discovered window 'Bounce' (id=1, 400x300) at (30,38)
+```
+
+No `SOFT LOCKUP` lines appeared in the final serial parse.
+
+Capture:
+
+```text
+/tmp/f25-captures/f25-final-rerun.png
+```
+
+Strict F23 verdict:
+
+```text
+distinct=2187 dominant=(10, 10, 25) dom_frac=0.0894
+big_color_buckets=12 blue_baseline=False red_baseline=False
+VERDICT=PASS
+```
+
+Build validation:
+
+```text
+./userspace/programs/build.sh --arch aarch64
+./scripts/create_ext2_disk.sh --arch aarch64
+cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64
+cargo build --release --features testing,external_test_bins --bin qemu-uefi
+```
+
+All completed without observed compiler warnings.
+
+## PR
+
+PR: https://github.com/ryanbreen/breenix/pull/318
+
+## Self-Audit
+
+- No polling or busy-wait fallback was added.
+- No Tier 1 prohibited files were modified.
+- No F1-F24 changes were reverted.
+- Temporary raw serial breadcrumbs were removed before commit.
+- The remaining architectural limitation is explicit: the init script avoids starting more exec-heavy services after the continuously animating bounce workload begins. This keeps boot reliable and leaves any future "arbitrary exec while GUI app is saturating graphics" work as a separate scheduler/storage stress item.

--- a/docs/planning/f25-spawn-hang/phase1.md
+++ b/docs/planning/f25-spawn-hang/phase1.md
@@ -1,0 +1,53 @@
+# F25 Phase 1 — hello_raw Narrowing
+
+Date: 2026-04-18
+
+## Setup
+
+- Branch: `fix/f25-post-bwm-spawn-hang`
+- Base: `97b441823473b81de7ba3ba89404c217903e0cd5`
+- Test edit: ARM64 init service list changed to:
+  1. `/bin/bwm`
+  2. `/bin/hello_raw`
+  3. `/sbin/telnetd`
+- Spawn pacing: 75ms `nanosleep` after each service spawn.
+
+## Build
+
+`./userspace/programs/build.sh --arch aarch64` passed.
+
+`./scripts/create_ext2_disk.sh --arch aarch64` passed under Docker. The generated ext2 image contains `/bin/hello_raw` at 278000 bytes.
+
+## Parallels Run
+
+Command:
+
+```bash
+> /tmp/breenix-parallels-serial.log
+./run.sh --parallels --test 90
+```
+
+The run reached the screenshot step but failed to capture because no Parallels window matched the generated VM name. Serial was still usable for the Phase 1 verdict.
+
+Relevant serial:
+
+```text
+[init] Breenix init starting (PID 1)
+[spawn] path='/bin/bwm'
+[spawn] Created child PID 2 for parent PID 1
+[spawn] Success: child PID 2 scheduled
+[bwm] Breenix Window Manager starting... (v2-chromeless-skip)
+[bwm] GPU compositing mode (VirGL), display: 1280x960
+[bwm] Direct compositor mapping: 1280x960 at 0x7ffffdb4e000
+[bwm] using bitmap font fallback for early boot
+[bwm] hotkeys: using built-in defaults for early boot
+[spawn] path='/bin/hello_raw'
+```
+
+There was no `[spawn] Created child PID ...` for `hello_raw`, no `[hello_raw] start`, and no `[syscall] exit(42)`.
+
+## Verdict
+
+`hello_raw` also hangs when spawned after `bwm`. This is not bounce-specific. The bug is architectural: spawning any binary after `bwm` stalls before child process creation.
+
+Next step: add low-overhead breadcrumbs around the ARM64 spawn path and process creation path to identify the last completed phase.

--- a/kernel/src/block/mod.rs
+++ b/kernel/src/block/mod.rs
@@ -26,6 +26,32 @@ pub trait BlockDevice: Send + Sync {
     /// Returns `BlockError::IoError` if the read operation fails
     fn read_block(&self, block_num: u64, buf: &mut [u8]) -> Result<(), BlockError>;
 
+    /// Read consecutive blocks into the provided buffer.
+    ///
+    /// The default implementation preserves compatibility for simple block
+    /// devices. Drivers with native multi-block commands should override this
+    /// to avoid issuing one hardware command per sector.
+    fn read_blocks(
+        &self,
+        start_block: u64,
+        block_count: usize,
+        buf: &mut [u8],
+    ) -> Result<(), BlockError> {
+        let block_size = self.block_size();
+        if buf.len() < block_count.saturating_mul(block_size) {
+            return Err(BlockError::IoError);
+        }
+
+        for i in 0..block_count {
+            self.read_block(
+                start_block + i as u64,
+                &mut buf[i * block_size..(i + 1) * block_size],
+            )?;
+        }
+
+        Ok(())
+    }
+
     /// Write a block from the provided buffer
     ///
     /// # Arguments

--- a/kernel/src/drivers/ahci/mod.rs
+++ b/kernel/src/drivers/ahci/mod.rs
@@ -2986,63 +2986,110 @@ pub struct AhciBlockDevice {
 
 impl BlockDevice for AhciBlockDevice {
     fn read_block(&self, block_num: u64, buf: &mut [u8]) -> Result<(), BlockError> {
-        if block_num >= self.sector_count {
+        self.read_blocks(block_num, 1, buf)
+    }
+
+    fn read_blocks(
+        &self,
+        start_block: u64,
+        block_count: usize,
+        buf: &mut [u8],
+    ) -> Result<(), BlockError> {
+        if block_count == 0 {
+            return Ok(());
+        }
+        if start_block >= self.sector_count
+            || start_block.saturating_add(block_count as u64) > self.sector_count
+        {
             return Err(BlockError::OutOfBounds);
         }
-        if buf.len() < SECTOR_SIZE {
+        let total_bytes = block_count
+            .checked_mul(SECTOR_SIZE)
+            .ok_or(BlockError::IoError)?;
+        if buf.len() < total_bytes {
             return Err(BlockError::IoError);
         }
 
-        // ── PHASE 1: lock + setup (PORT_IO_IN_PROGRESS=true) ─────────────────
-        let port_guard = begin_port_io(self.port_num);
-        let setup_result: Result<(CmdToken, usize), BlockError> = {
-            let ctrl = AHCI_CONTROLLER.lock();
-            match ctrl.as_ref() {
-                Some(ctrl) => ctrl
-                    .setup_read_sectors(self.port_num, self.dma_index, block_num, 1)
-                    .map_err(|e| {
-                        #[cfg(target_arch = "aarch64")]
-                        crate::serial_println!(
-                            "[ahci] read_block({}) setup failed: {}",
-                            block_num,
-                            e
-                        );
-                        BlockError::IoError
-                    }),
-                None => Err(BlockError::DeviceNotReady),
-            }
-        }; // AHCI_CONTROLLER lock released
-        let (token, byte_count) = match setup_result {
-            Ok(value) => value,
-            Err(err) => {
-                end_port_io(self.port_num);
-                drop(port_guard);
-                return Err(err);
-            }
-        };
-        drop(port_guard);
+        let mut current_block = start_block;
+        let mut remaining = block_count;
+        let mut offset = 0usize;
 
-        // ── PHASE 2: wait (NO locks held) ────────────────────────────────────
-        let wait_result = wait_cmd_slot0(token).map_err(|e| {
-            #[cfg(target_arch = "aarch64")]
-            {
-                crate::serial_println!("[ahci] read_block({}) wait failed: {}", block_num, e);
-                if e == "AHCI: command timeout" {
-                    crate::arch_impl::aarch64::gic::dump_stuck_state_for_spi(34);
-                    dump_recent_ahci_events(Some(self.port_num as u8), 16);
+        while remaining > 0 {
+            let chunk = remaining.min(128);
+
+            // PHASE 1: lock + setup (PORT_IO_IN_PROGRESS=true)
+            let port_guard = begin_port_io(self.port_num);
+            let setup_result: Result<(CmdToken, usize), BlockError> = {
+                let ctrl = AHCI_CONTROLLER.lock();
+                match ctrl.as_ref() {
+                    Some(ctrl) => ctrl
+                        .setup_read_sectors(
+                            self.port_num,
+                            self.dma_index,
+                            current_block,
+                            chunk as u16,
+                        )
+                        .map_err(|e| {
+                            #[cfg(target_arch = "aarch64")]
+                            crate::serial_println!(
+                                "[ahci] read_blocks({}, {}) setup failed: {}",
+                                current_block,
+                                chunk,
+                                e
+                            );
+                            BlockError::IoError
+                        }),
+                    None => Err(BlockError::DeviceNotReady),
                 }
-            }
-            BlockError::IoError
-        });
+            }; // AHCI_CONTROLLER lock released
+            let (token, byte_count) = match setup_result {
+                Ok(value) => value,
+                Err(err) => {
+                    end_port_io(self.port_num);
+                    drop(port_guard);
+                    return Err(err);
+                }
+            };
+            drop(port_guard);
 
-        // ── PHASE 3: re-lock + finish (copy DMA result before next issue) ────
-        let port_guard = PORT_IO_LOCK[self.port_num].lock();
-        let result = wait_result.and_then(|_| {
-            finish_read_sectors(self.dma_index, byte_count, buf).map_err(|_| BlockError::IoError)
-        });
-        end_port_io(self.port_num);
-        drop(port_guard);
-        result
+            // PHASE 2: wait (NO locks held)
+            let wait_result = wait_cmd_slot0(token).map_err(|e| {
+                #[cfg(target_arch = "aarch64")]
+                {
+                    crate::serial_println!(
+                        "[ahci] read_blocks({}, {}) wait failed: {}",
+                        current_block,
+                        chunk,
+                        e
+                    );
+                    if e == "AHCI: command timeout" {
+                        crate::arch_impl::aarch64::gic::dump_stuck_state_for_spi(34);
+                        dump_recent_ahci_events(Some(self.port_num as u8), 16);
+                    }
+                }
+                BlockError::IoError
+            });
+
+            // PHASE 3: re-lock + finish (copy DMA result before next issue)
+            let port_guard = PORT_IO_LOCK[self.port_num].lock();
+            let result = wait_result.and_then(|_| {
+                finish_read_sectors(
+                    self.dma_index,
+                    byte_count,
+                    &mut buf[offset..offset + byte_count],
+                )
+                .map_err(|_| BlockError::IoError)
+            });
+            end_port_io(self.port_num);
+            drop(port_guard);
+
+            result?;
+            current_block += chunk as u64;
+            remaining -= chunk;
+            offset += byte_count;
+        }
+
+        Ok(())
     }
 
     fn write_block(&self, block_num: u64, buf: &[u8]) -> Result<(), BlockError> {

--- a/kernel/src/fs/ext2/file.rs
+++ b/kernel/src/fs/ext2/file.rs
@@ -24,18 +24,32 @@ pub fn read_ext2_block<B: BlockDevice + ?Sized>(
     ext2_block_size: usize,
     buf: &mut [u8],
 ) -> Result<(), BlockError> {
+    read_ext2_blocks(device, ext2_block_num, 1, ext2_block_size, buf)
+}
+
+/// Read consecutive ext2 blocks using the block device's multi-block path.
+pub fn read_ext2_blocks<B: BlockDevice + ?Sized>(
+    device: &B,
+    ext2_block_num: u32,
+    ext2_block_count: usize,
+    ext2_block_size: usize,
+    buf: &mut [u8],
+) -> Result<(), BlockError> {
     let device_block_size = device.block_size();
     let device_blocks_per_ext2_block = ext2_block_size / device_block_size;
     let start_device_block = (ext2_block_num as usize) * device_blocks_per_ext2_block;
+    let total_device_blocks = ext2_block_count * device_blocks_per_ext2_block;
+    let byte_count = ext2_block_count * ext2_block_size;
 
-    for i in 0..device_blocks_per_ext2_block {
-        device.read_block(
-            (start_device_block + i) as u64,
-            &mut buf[i * device_block_size..(i + 1) * device_block_size],
-        )?;
+    if buf.len() < byte_count {
+        return Err(BlockError::IoError);
     }
 
-    Ok(())
+    device.read_blocks(
+        start_device_block as u64,
+        total_device_blocks,
+        &mut buf[..byte_count],
+    )
 }
 
 /// Write an ext2 block using device block numbers
@@ -261,37 +275,112 @@ pub fn read_file_range<B: BlockDevice + ?Sized>(
     let offset_in_first_block = (offset % block_size as u64) as usize;
     let end_offset = offset + actual_length as u64;
     let end_block = ((end_offset + block_size as u64 - 1) / block_size as u64) as u32;
+    let ptrs_per_block = (block_size / 4) as u32;
+    let i_block = unsafe { core::ptr::read_unaligned(core::ptr::addr_of!(inode.i_block)) };
+    let single_indirect_cache = if end_block > DIRECT_BLOCKS && i_block[SINGLE_INDIRECT] != 0 {
+        Some(read_indirect_block(
+            device,
+            i_block[SINGLE_INDIRECT],
+            block_size,
+        )?)
+    } else {
+        None
+    };
+
+    let physical_for = |logical: u32| -> Result<Option<u32>, BlockError> {
+        if logical < DIRECT_BLOCKS {
+            let block_num = i_block[logical as usize];
+            return Ok(if block_num == 0 {
+                None
+            } else {
+                Some(block_num)
+            });
+        }
+
+        let single_index = logical - DIRECT_BLOCKS;
+        if single_index < ptrs_per_block {
+            if let Some(ptrs) = single_indirect_cache.as_ref() {
+                let block_num = ptrs[single_index as usize];
+                return Ok(if block_num == 0 {
+                    None
+                } else {
+                    Some(block_num)
+                });
+            }
+            return Ok(None);
+        }
+
+        get_block_num(device, inode, superblock, logical)
+    };
 
     let mut result = Vec::with_capacity(actual_length);
     // Use stack-based buffer to avoid heap allocation (bump allocator doesn't reclaim)
     let mut block_buf = [0u8; 4096]; // Max block size
+    let max_run_blocks = core::cmp::max(1, 65536 / block_size);
+    let mut run_buf = Vec::with_capacity(max_run_blocks * block_size);
 
-    for logical_block in start_block..end_block {
+    let mut logical_block = start_block;
+    while logical_block < end_block {
         // Get physical block number (or None for sparse holes)
-        let physical_block = get_block_num(device, inode, superblock, logical_block)?;
+        let physical_block = physical_for(logical_block)?;
 
         // Read block or fill with zeros for sparse holes
         if let Some(block_num) = physical_block {
-            read_ext2_block(device, block_num, block_size, &mut block_buf[..block_size])?;
+            let mut run_len = 1usize;
+            while run_len < max_run_blocks && logical_block + (run_len as u32) < end_block {
+                let next_logical = logical_block + run_len as u32;
+                let next_physical = physical_for(next_logical)?;
+                if next_physical != Some(block_num + run_len as u32) {
+                    break;
+                }
+                run_len += 1;
+            }
+
+            let run_bytes = run_len * block_size;
+            run_buf.clear();
+            run_buf.resize(run_bytes, 0);
+            read_ext2_blocks(device, block_num, run_len, block_size, &mut run_buf)?;
+
+            for run_index in 0..run_len {
+                let current_logical = logical_block + run_index as u32;
+                let block_offset = current_logical as u64 * block_size as u64;
+                let start_in_block = if block_offset < offset {
+                    offset_in_first_block
+                } else {
+                    0
+                };
+                let end_in_block = if block_offset + block_size as u64 > end_offset {
+                    (end_offset - block_offset) as usize
+                } else {
+                    block_size
+                };
+                let run_start = run_index * block_size;
+                result.extend_from_slice(
+                    &run_buf[run_start + start_in_block..run_start + end_in_block],
+                );
+            }
+
+            logical_block += run_len as u32;
         } else {
             // Sparse hole - fill with zeros
             block_buf[..block_size].fill(0);
+
+            // Calculate which bytes from this block to copy
+            let block_offset = logical_block as u64 * block_size as u64;
+            let start_in_block = if block_offset < offset {
+                offset_in_first_block
+            } else {
+                0
+            };
+            let end_in_block = if block_offset + block_size as u64 > end_offset {
+                (end_offset - block_offset) as usize
+            } else {
+                block_size
+            };
+
+            result.extend_from_slice(&block_buf[start_in_block..end_in_block]);
+            logical_block += 1;
         }
-
-        // Calculate which bytes from this block to copy
-        let block_offset = logical_block as u64 * block_size as u64;
-        let start_in_block = if block_offset < offset {
-            offset_in_first_block
-        } else {
-            0
-        };
-        let end_in_block = if block_offset + block_size as u64 > end_offset {
-            (end_offset - block_offset) as usize
-        } else {
-            block_size
-        };
-
-        result.extend_from_slice(&block_buf[start_in_block..end_in_block]);
     }
 
     Ok(result)

--- a/userspace/programs/src/bounce.rs
+++ b/userspace/programs/src/bounce.rs
@@ -533,6 +533,7 @@ fn run_window_loop(win: &mut Window, spheres: &mut [Sphere; NUM_SPHERES]) {
         fps.draw(fb);
 
         let _ = win.present();
+        let _ = time::sleep_ms(1);
     }
 }
 

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -3,7 +3,7 @@
 //! PID 1 - runs bsh (no arguments), then starts background services and reaps zombies.
 //! bsh detects it's the init shell (PID 2) and loads /etc/init.js.
 
-use libbreenix::process::{spawn, waitpid, getpid, yield_now};
+use libbreenix::process::{getpid, spawn, waitpid, yield_now};
 
 fn main() {
     let pid = getpid().map(|p| p.raw()).unwrap_or(0);
@@ -11,6 +11,8 @@ fn main() {
 
     run_boot_script();
     start_bsshd();
+    #[cfg(target_arch = "aarch64")]
+    start_bounce();
 
     // Reap zombies forever
     let mut status: i32 = 0;
@@ -26,7 +28,10 @@ fn main() {
                 }
             }
             Err(_) => {
-                let ts = libbreenix::types::Timespec { tv_sec: 1, tv_nsec: 0 };
+                let ts = libbreenix::types::Timespec {
+                    tv_sec: 1,
+                    tv_nsec: 0,
+                };
                 let _ = libbreenix::time::nanosleep(&ts);
             }
         }
@@ -41,15 +46,17 @@ fn run_boot_script() {
         // the boot script's service sequence directly from init. Start bwm
         // before network services so the compositor replaces the kernel VirGL
         // proof clear within the Parallels validation window.
-        const SERVICES: &[&[u8]] = &[
-            b"/bin/bwm\0",
-            b"/sbin/telnetd\0",
-        ];
+        const SERVICES: &[&[u8]] = &[b"/bin/bwm\0", b"/sbin/telnetd\0"];
         for path in SERVICES {
             if let Err(e) = spawn(path) {
                 print!("[init] Warning: failed to spawn service: {}\n", e);
             }
             let _ = yield_now();
+            let ts = libbreenix::types::Timespec {
+                tv_sec: 0,
+                tv_nsec: 75_000_000,
+            };
+            let _ = libbreenix::time::nanosleep(&ts);
         }
         print!("[init] Boot script completed\n");
         return;
@@ -70,6 +77,27 @@ fn run_boot_script() {
         }
         Err(e) => {
             print!("[init] Failed to spawn boot script: {}\n", e);
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn start_bounce() {
+    // Start the animated GUI demo last. It continuously presents frames, so
+    // keeping it after the early service execs avoids overlapping AHCI-backed
+    // ELF reads with active compositor traffic.
+    let _ = yield_now();
+    let ts = libbreenix::types::Timespec {
+        tv_sec: 0,
+        tv_nsec: 75_000_000,
+    };
+    let _ = libbreenix::time::nanosleep(&ts);
+    match spawn(b"/bin/bounce\0") {
+        Ok(child_pid) => {
+            print!("[init] bounce started (PID {})\n", child_pid.raw());
+        }
+        Err(_) => {
+            print!("[init] Warning: failed to start bounce\n");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a multi-block BlockDevice path and native AHCI READ DMA EXT batching for contiguous reads
- coalesce ext2 file reads and cache single-indirect block pointers during ELF loads
- start ARM64 services in a serialized order: bwm, telnetd, bsshd, then bounce, with bounce yielding between presents

## Validation
- ./userspace/programs/build.sh --arch aarch64
- ./scripts/create_ext2_disk.sh --arch aarch64
- cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64
- cargo build --release --features testing,external_test_bins --bin qemu-uefi 2>&1 | tee /tmp/f25-qemu-uefi-build-rerun.log; grep -E '^(warning|error)' /tmp/f25-qemu-uefi-build-rerun.log || true
- ./run.sh --parallels --test 90 (VM booted; legacy window screenshot helper failed)
- scripts/parallels/capture-display.sh breenix-1776504664 /tmp/f25-captures/f25-final-rerun.png
- bash scripts/f23-render-verdict.sh /tmp/f25-captures/f25-final-rerun.png => VERDICT=PASS

Serial showed bwm, telnetd, bsshd, and bounce all spawned; telnetd and bsshd listening; bwm discovered the Bounce window; no SOFT LOCKUP in lifecycle grep.