### PR TITLE
chore: widen logs/ gitignore + add F24 docs/verdict script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,8 +97,7 @@ scripts/parallels/breenix-efi.hds/
 serial-capture*.txt
 xhci_ftrace*.txt
 .factory-runs/
-logs/linux-probe-cpu0/
-logs/breenix-parallels-cpu0/
+logs/
 .claude/worktrees/
 
 # Beads / Dolt files (added by bd init)

--- a/docs/planning/f24-apps-on-desktop/phase1-constraints.md
+++ b/docs/planning/f24-apps-on-desktop/phase1-constraints.md
@@ -1,0 +1,41 @@
+# F24 Phase 1 Constraints — GUI Apps On bwm Desktop
+
+## Current ARM64 Launch Path
+
+On `main`, `userspace/programs/src/init.rs` bypasses `bsh` on `aarch64` and directly spawns a minimal service list:
+
+1. `/bin/bwm`
+2. `/sbin/telnetd`
+3. `/bin/bsshd` after `[init] Boot script completed`
+
+This ordering is deliberate. F23 moved `bwm` before `telnetd` because the 75-second Parallels capture happened while init was still in the `telnetd` service path, leaving only the kernel cornflower-blue VirGL proof clear visible.
+
+## F22 Guardrails
+
+F22 found that early ARM64 userspace on Parallels is sensitive to AHCI-backed filesystem reads during the single-CPU boot window:
+
+- Loading the large `bsh` ELF early can stall before `/etc/init.js` runs.
+- bwm's first visible frame must avoid filesystem-backed font and hotkey config reads, so ARM64 bwm uses bitmap fonts and built-in hotkeys until after first presentation.
+- bwm's normal op16 per-window VirGL compositor path times out on ARM64 Parallels; the working path is the op10 direct VirGL blit used by `graphics::virgl_composite`.
+- `bsshd` is intentionally started after the boot script to avoid overlapping early exec reads against the AHCI-backed ext2 root.
+
+The practical constraint for F24 is that new apps should be launched one at a time after bwm has been spawned, with a small pacing delay between spawns, and every increment must be validated from a fresh build/capture rather than inferred from process creation.
+
+## bwm Multi-Window Behavior
+
+bwm discovers client windows from the kernel window registry via `graphics::list_windows`, assigns cascade positions, sets kernel window positions, draws bwm chrome into its compositor buffer, and routes input through the window input queue.
+
+On non-ARM64 targets, bwm uses `graphics::virgl_composite_windows_rect`, where the kernel uploads client window textures and composites content with the bwm chrome. On ARM64, F22 intentionally uses `graphics::virgl_composite(composite_buf, ...)` instead. That path only presents the CPU-composited buffer, so without an ARM64 fallback bwm can show the desktop and window frames but not client pixels.
+
+## App ELF Sizes
+
+Current aarch64 app binary sizes:
+
+| App | Size | Notes |
+| --- | ---: | --- |
+| `bounce.elf` | 387,456 bytes | Smallest final-target GUI app; creates one Breengel window and animates locally. |
+| `bcheck.elf` | 421,760 bytes | Optional diagnostic app. |
+| `blog.elf` | 467,392 bytes | Opens log files and creates one Breengel window. |
+| `bterm.elf` | 476,088 bytes | Largest target app; also spawns child PTY processes (`btop` and shell). |
+
+F24 will start with `bounce` because the task asks to pick the smallest binary first. `bterm` remains the most useful app and should be attempted after smaller GUI clients prove the launch/content path.

--- a/scripts/f24-render-verdict.sh
+++ b/scripts/f24-render-verdict.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Strict bwm render verdict for F24 Parallels captures.
+#
+# Usage:
+#   scripts/f24-render-verdict.sh <png_path>
+#
+# Returns 0 if rendered desktop content includes a spatially coherent UI region.
+
+set -euo pipefail
+
+PNG="${1:?png path required}"
+
+python3 - "$PNG" <<'PY'
+import sys
+import warnings
+from collections import Counter
+from math import sqrt
+from PIL import Image
+
+img = Image.open(sys.argv[1]).convert("RGB")
+w, h = img.size
+
+# Crop top 40px to remove the Parallels toolbar from the verdict.
+content = img.crop((0, 40, w, h))
+cw, ch = content.size
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    pixels = list(content.getdata())
+total = len(pixels)
+
+distinct = len(set(pixels))
+colors = Counter(pixels)
+dominant, dom_count = colors.most_common(1)[0]
+dom_frac = dom_count / total
+
+def dist(a, b):
+    return sqrt(sum((a[i] - b[i]) ** 2 for i in range(3)))
+
+def bucket(p):
+    # Quantize to 32 levels per channel, same bucket width as F23.
+    return (p[0] >> 3, p[1] >> 3, p[2] >> 3)
+
+bucket_counts = Counter(bucket(p) for p in pixels)
+big_buckets = sum(1 for v in bucket_counts.values() if v / total > 0.01)
+
+blue_baseline = dist(dominant, (100, 149, 237)) < 15
+red_baseline = dist(dominant, (255, 0, 0)) < 15
+
+def coherent_region(candidate_bucket):
+    xs = []
+    ys = []
+    count = 0
+    for y in range(ch):
+        row_start = y * cw
+        for x in range(cw):
+            if bucket(pixels[row_start + x]) == candidate_bucket:
+                xs.append(x)
+                ys.append(y)
+                count += 1
+    if count == 0:
+        return None
+
+    x0, x1 = min(xs), max(xs)
+    y0, y1 = min(ys), max(ys)
+    bbox_w = x1 - x0 + 1
+    bbox_h = y1 - y0 + 1
+    bbox_area = bbox_w * bbox_h
+    frac = count / total
+    bbox_frac = bbox_area / total
+    fill_frac = count / bbox_area if bbox_area else 0
+    coherent = frac >= 0.02 and bbox_frac < 0.80 and fill_frac >= 0.20
+    return {
+        "bucket": candidate_bucket,
+        "count": count,
+        "frac": frac,
+        "bbox": (x0, y0, x1, y1),
+        "bbox_frac": bbox_frac,
+        "fill_frac": fill_frac,
+        "coherent": coherent,
+    }
+
+regions = []
+for candidate, _ in bucket_counts.most_common(4)[1:4]:
+    region = coherent_region(candidate)
+    if region:
+        regions.append(region)
+
+region = next((r for r in regions if r["coherent"]), None)
+
+passes_base = (
+    distinct > 20
+    and dom_frac < 0.90
+    and not blue_baseline
+    and not red_baseline
+    and big_buckets >= 3
+)
+passes = passes_base and region is not None
+
+print(f"distinct={distinct} dominant={dominant} dom_frac={dom_frac:.4f}")
+print(f"big_color_buckets={big_buckets} blue_baseline={blue_baseline} red_baseline={red_baseline}")
+if region:
+    print(
+        "coherent_region="
+        f"bucket={region['bucket']} frac={region['frac']:.4f} "
+        f"bbox={region['bbox']} bbox_frac={region['bbox_frac']:.4f} "
+        f"fill_frac={region['fill_frac']:.4f}"
+    )
+else:
+    print("coherent_region=None")
+print(f"VERDICT={'PASS' if passes else 'FAIL'}")
+sys.exit(0 if passes else 1)
+PY


### PR DESCRIPTION
## Summary

- `.gitignore`: widen `logs/` to ignore all subdirs (was only `logs/linux-probe-cpu0/` + `logs/breenix-parallels-cpu0/`)
- Add `scripts/f24-render-verdict.sh` (extends F23's strict verdict with per-window detection, useful for future app-render validation)
- Add `docs/planning/f24-apps-on-desktop/phase1-constraints.md` investigation notes

No kernel or userspace code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)