### PR TITLE
F27 restore cursor rendering on aarch64 bwm

### DIFF
--- a/docs/planning/f27-cursor-rendering-regression/exit.md
+++ b/docs/planning/f27-cursor-rendering-regression/exit.md
@@ -1,0 +1,92 @@
+# F27 Exit - Mouse Cursor Rendering Regression
+
+Date: 2026-04-18
+
+Branch: `f27-cursor-rendering-regression`
+
+Base: `ab351efe`
+
+PR: https://github.com/ryanbreen/breenix/pull/322
+
+## What I Built
+
+- `docs/planning/f27-cursor-rendering-regression/phase1.md`: recorded the layer-localization evidence and regression range.
+- `userspace/programs/src/init.rs`: fixed the x86_64 build warning by making the `yield_now` import aarch64-only.
+- `userspace/programs/src/bwm.rs`: added an aarch64-only software cursor overlay for the direct VirGL blit path, with arrow and resize shapes tracked from bwm's existing cursor-shape logic.
+- `docs/planning/f27-cursor-rendering-regression/phase3.md`: recorded build, capture, cursor pixel-mask, and movement-probe validation.
+- `docs/planning/f27-cursor-rendering-regression/exit.md`: this exit report.
+
+## Original Ask
+
+Determine where the F27 cursor regression occurred, bisect likely F22/F25/F26
+GUI changes, restore cursor rendering without reverting F1-F26 or regressing F26
+animation performance, validate with Parallels capture evidence, then open and
+merge a PR.
+
+## How This Meets The Ask
+
+Phase 1 layer localization: implemented. `phase1.md` records that F22 moved the
+aarch64 bwm path to direct `virgl_composite()`, while the kernel cursor quad is
+only drawn by the op16 `virgl_composite_windows*()` path.
+
+Phase 2 bisect/regression range: implemented by history inspection. The likely
+regression point is F22 (`657d18c0`), with F24/F26 preserving that direct path.
+No F1-F26 revert was used.
+
+Phase 3 fix: implemented. `bwm.rs` now draws the cursor into the aarch64
+direct-blit desktop buffer immediately before `graphics::virgl_composite()`.
+Mouse input remains event-driven through `compositor_wait`; no polling was
+added.
+
+Phase 4 validation: partial/implemented. A one-off `f27cursor-*` Parallels VM
+booted this branch, rendered bwm+bounce, passed strict F23 render verdict, and
+the capture pixel-mask detector found an arrow-shaped cursor region. A
+best-effort host-pointer movement probe rendered the cursor at a non-default
+kernel-reported location, but `prlctl` has no mouse injection API and the
+synthetic Quartz move did not produce a second in-boot delta.
+
+## What I Did Not Build
+
+- I did not restore the aarch64 op16 VirGL multi-window compositor path; that was
+  intentionally avoided to preserve the F26 direct-blit FPS path.
+- I did not add polling.
+- I did not modify Tier 1 prohibited files.
+- I did not commit screenshots, serial logs, or generated disk artifacts.
+
+## Known Risks And Gaps
+
+- Cursor rendering on aarch64 is now duplicated in bwm rather than sharing the
+  kernel VirGL cursor atlas. That is deliberate because the aarch64 path does
+  not use the kernel cursor-quad compositor.
+- The in-boot HID movement proof is partial because Parallels CLI supports
+  keyboard event injection only. The code path updates cursor coordinates from
+  existing bwm mouse-event handling, and the movement probe did show a
+  non-default cursor position.
+- `cargo run -p xtask -- boot-stages` was attempted during Phase 1 and failed at
+  a pre-existing x86_64 `sigaltstack()` marker after reaching 162/252 stages.
+  The final gate therefore uses clean builds plus Parallels capture validation.
+
+## How To Verify
+
+```bash
+./userspace/programs/build.sh --arch aarch64
+cargo build --release --target aarch64-breenix.json \
+  -Z build-std=core,alloc \
+  -Z build-std-features=compiler-builtins-mem \
+  -p kernel --bin kernel-aarch64
+cargo build --release --features testing,external_test_bins --bin qemu-uefi
+bash scripts/f23-render-verdict.sh /tmp/f27cursor-1776510485-screen.png
+grep -E "SOFT_LOCKUP|SOFT LOCKUP|TIMEOUT|UNHANDLED|DATA_ABORT|FATAL|panic|PANIC" \
+  /tmp/f27cursor-1776510485-serial.log
+```
+
+For the final run, `grep -E '^(warning|error)'` over all three build logs
+produced no output. The fault-marker grep also produced no output.
+
+## Self-Audit
+
+- No polling added.
+- No Tier 1 prohibited files modified.
+- F1-F26 intact; no revert used.
+- F26 direct `virgl_composite()` frame path preserved.
+- One-off `f27cursor-*` validation VMs were stopped and deleted.

--- a/docs/planning/f27-cursor-rendering-regression/phase1.md
+++ b/docs/planning/f27-cursor-rendering-regression/phase1.md
@@ -1,0 +1,53 @@
+# F27 Phase 1 - Cursor Regression Layer Localization
+
+Date: 2026-04-18
+
+## Summary
+
+The cursor regression is in the aarch64 bwm presentation layer, not in cursor
+texture initialization or cursor-shape plumbing.
+
+F22 moved the aarch64 bwm render path to `graphics::virgl_composite()` because
+the op16 multi-window VirGL compositor path timed out on Parallels after bwm
+took over scanout. That direct-blit path uploads and displays the CPU-composited
+desktop, but it does not invoke the kernel's GPU cursor-quad renderer.
+
+The cursor renderer still exists in `kernel/src/drivers/virtio/gpu_pci.rs` and
+is only reached from `graphics::virgl_composite_windows*()` / op16. The current
+aarch64 bwm loop never calls that path, so mouse movement can update bwm state
+without producing a visible cursor glyph.
+
+## Evidence
+
+- `userspace/programs/src/bwm.rs` uses `graphics::virgl_composite()` for the
+  aarch64 initial composite and every aarch64 frame.
+- The non-aarch64 path still calls `graphics::virgl_composite_windows_rect()`,
+  whose kernel implementation explicitly handles cursor-only redraws.
+- `kernel/src/syscall/graphics.rs` documents that VirGL cursor-only frames fall
+  through to `virgl_composite_windows()`.
+- `kernel/src/drivers/virtio/gpu_pci.rs` initializes the cursor atlas as
+  resource id 6 and draws it in `virgl_composite_single_quad()`, which is only
+  called by `virgl_composite_windows()`.
+- bwm still processes `COMPOSITOR_READY_MOUSE`, calls `mouse_state_with_scroll()`,
+  routes mouse events, and calls `set_cursor_shape()`. Those calls update state
+  but do not draw anything on the aarch64 direct-blit path.
+
+## Regression Range
+
+The likely regression point is F22 (`657d18c0 fix(gui): F22 render bwm desktop
+on Parallels`), which introduced the aarch64 direct `virgl_composite()` fallback.
+F24 then added mapped-window blitting on top of that direct path. F26 preserved
+the same bwm presentation path while improving frame pacing, so the fix should
+not revert F26.
+
+## Validation Notes
+
+Initial `cargo run -p xtask -- boot-stages` on x86_64 reached QEMU but surfaced
+an unrelated compile warning first: `userspace/programs/src/init.rs` imported
+`yield_now` in an x86_64 build even though its uses are aarch64-only. The Phase
+1 commit fixes that conditional import so later quality gates can be clean.
+
+The same run ended at `162/252` stages with the first missing marker reported as
+`sigaltstack() syscall verified`. The user output showed the sigaltstack test
+had started and passed its first checks, so this is recorded as a pre-existing
+x86 boot-stage validation failure for this branch rather than cursor evidence.

--- a/docs/planning/f27-cursor-rendering-regression/phase3.md
+++ b/docs/planning/f27-cursor-rendering-regression/phase3.md
@@ -1,0 +1,97 @@
+# F27 Phase 3 - Cursor Fix Validation
+
+Date: 2026-04-18
+
+## Build Validation
+
+The Phase 3 fix passed the aarch64 userspace and kernel build gates:
+
+```bash
+./userspace/programs/build.sh --arch aarch64
+cargo build --release --target aarch64-breenix.json \
+  -Z build-std=core,alloc \
+  -Z build-std-features=compiler-builtins-mem \
+  -p kernel --bin kernel-aarch64
+```
+
+`grep -E '^(warning|error)'` over both build logs produced no output.
+
+## Parallels Capture
+
+The normal `./run.sh --parallels --test 120` path could not be used as the
+final capture command because other concurrent `breenix-*` Parallels factories
+were running and their cleanup loops deleted the freshly-created test VM while
+this run was still configuring disks.
+
+To avoid interfering with those runs, validation used a one-off VM name outside
+the `breenix-*` cleanup pattern:
+
+```bash
+f27cursor-1776510485
+```
+
+That VM booted, reached bwm, rendered bounce, captured successfully with
+`prlctl capture`, then was stopped and deleted.
+
+Capture artifact, intentionally uncommitted:
+
+```text
+logs/f27-cursor-rendering-regression/capture.png
+logs/f27-cursor-rendering-regression/serial.log
+```
+
+Strict render verdict:
+
+```text
+distinct=2002 dominant=(10, 10, 25) dom_frac=0.0904
+big_color_buckets=12 blue_baseline=False red_baseline=False
+VERDICT=PASS
+```
+
+Cursor glyph detector over the top-left 24x24 pixels:
+
+```text
+top_left_24 white=53 dark=48 near_dark=460 distinct=56
+white_rows_0_15=[0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 5, 5, 3, 2, 2, 0]
+cursor_shape_verdict=PASS
+```
+
+The row counts match the software arrow mask and prove that the captured image
+contains a cursor-shaped region distinct from the surrounding taskbar pixels.
+
+## HID / Movement Probe
+
+A second one-off VM (`f27cursor-move-1776510750`) was used for a best-effort
+movement probe. Serial showed the xHCI mouse path initialized:
+
+```text
+[xhci] HID iface: proto=2 subclass=0 -> mouse (hid_idx=1)
+[xhci] HID iface: proto=2 subclass=0 -> mouse (hid_idx=3)
+[xhci] start_hid_polling: kbd=slot2/dci3 nkro=dci5 mouse=slot1/dci3 mouse2=dci5
+```
+
+The cursor mask detector found the arrow at guest `(1252,392)` in both
+before/after captures from that run:
+
+```text
+before: score=207 body=53 outline=48 base=(1252,392)
+after:  score=207 body=53 outline=48 base=(1252,392)
+```
+
+This proves the cursor is not hard-coded to `(0,0)` and can render at the
+kernel-reported mouse position. The synthetic host pointer movement posted via
+Quartz did not produce an additional position change between the before and
+after captures, so in-boot HID movement is recorded as partial rather than fully
+validated. `prlctl send-key-event` only supports keyboard events; it has no
+mouse injection command.
+
+## Fault Markers
+
+Fault-marker grep over the primary capture serial log was clean:
+
+```bash
+grep -E "SOFT_LOCKUP|SOFT LOCKUP|TIMEOUT|UNHANDLED|DATA_ABORT|FATAL|panic|PANIC" \
+  /tmp/f27cursor-1776510485-serial.log
+```
+
+The command produced no output.

--- a/userspace/programs/src/bwm.rs
+++ b/userspace/programs/src/bwm.rs
@@ -93,6 +93,15 @@ const CLOSE_BTN_TEXT: Color = Color::rgb(255, 255, 255);
 const MINIMIZE_BTN_BG: Color = Color::rgb(80, 85, 100);
 const MINIMIZE_BTN_TEXT: Color = Color::rgb(255, 255, 255);
 
+#[cfg(target_arch = "aarch64")]
+const SOFTWARE_CURSOR_W: usize = 16;
+#[cfg(target_arch = "aarch64")]
+const SOFTWARE_CURSOR_H: usize = 16;
+#[cfg(target_arch = "aarch64")]
+const SOFTWARE_CURSOR_WHITE: u32 = 0x00ff_ffff;
+#[cfg(target_arch = "aarch64")]
+const SOFTWARE_CURSOR_BLACK: u32 = 0x0001_0101;
+
 // ─── Input Parser ────────────────────────────────────────────────────────────
 // Parses stdin bytes (keyboard input) into InputEvents that BWM can either
 // handle internally (F-key focus switching) or route to the focused client
@@ -1213,6 +1222,102 @@ fn blit_window_contents(vram: &mut [u32], screen_w: usize, screen_h: usize, wind
     }
 }
 
+#[cfg(target_arch = "aarch64")]
+fn software_cursor_hotspot(shape: u32) -> (i32, i32) {
+    if shape == graphics::cursor_shape::ARROW {
+        (0, 0)
+    } else {
+        (8, 8)
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn cursor_body_pixel(shape: u32, row: i32, col: i32) -> bool {
+    match shape {
+        graphics::cursor_shape::RESIZE_NS => {
+            (col == 7 && (3..=12).contains(&row))
+                || (row <= 3 && (col - 7).abs() <= 3 - row)
+                || (row >= 12 && (col - 7).abs() <= row - 12)
+        }
+        graphics::cursor_shape::RESIZE_EW => {
+            (row == 7 && (3..=12).contains(&col))
+                || (col <= 3 && (row - 7).abs() <= 3 - col)
+                || (col >= 12 && (row - 7).abs() <= col - 12)
+        }
+        graphics::cursor_shape::RESIZE_NWSE => {
+            ((2..=13).contains(&row) && (col == row || col == row + 1))
+                || (row <= 4 && col <= 4 && row + col <= 5)
+                || (row >= 11 && col >= 11 && row + col >= 25)
+        }
+        graphics::cursor_shape::RESIZE_NESW => {
+            ((2..=13).contains(&row) && (col == 15 - row || col == 14 - row))
+                || (row <= 4 && col >= 11 && col - row >= 11)
+                || (row >= 11 && col <= 4 && row - col >= 11)
+        }
+        _ => {
+            (row <= 9 && col >= 1 && col < row)
+                || (row == 10 && (1..=5).contains(&col))
+                || (row == 11 && ((1..=3).contains(&col) || (4..=5).contains(&col)))
+                || (row == 12 && (4..=6).contains(&col))
+                || ((13..=14).contains(&row) && (5..=6).contains(&col))
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn cursor_pixel(shape: u32, row: usize, col: usize) -> u32 {
+    let row = row as i32;
+    let col = col as i32;
+    if cursor_body_pixel(shape, row, col) {
+        return SOFTWARE_CURSOR_WHITE;
+    }
+
+    for dy in -1..=1 {
+        for dx in -1..=1 {
+            if dx == 0 && dy == 0 {
+                continue;
+            }
+            if cursor_body_pixel(shape, row + dy, col + dx) {
+                return SOFTWARE_CURSOR_BLACK;
+            }
+        }
+    }
+
+    0
+}
+
+#[cfg(target_arch = "aarch64")]
+fn draw_software_cursor(
+    vram: &mut [u32],
+    screen_w: usize,
+    screen_h: usize,
+    mouse_x: i32,
+    mouse_y: i32,
+    shape: u32,
+) {
+    let shape = shape.min(graphics::cursor_shape::RESIZE_NESW);
+    let (hot_x, hot_y) = software_cursor_hotspot(shape);
+    let base_x = mouse_x - hot_x;
+    let base_y = mouse_y - hot_y;
+
+    for row in 0..SOFTWARE_CURSOR_H {
+        let y = base_y + row as i32;
+        if y < 0 || y >= screen_h as i32 {
+            continue;
+        }
+        for col in 0..SOFTWARE_CURSOR_W {
+            let x = base_x + col as i32;
+            if x < 0 || x >= screen_w as i32 {
+                continue;
+            }
+            let pixel = cursor_pixel(shape, row, col);
+            if pixel != 0 {
+                vram[y as usize * screen_w + x as usize] = pixel;
+            }
+        }
+    }
+}
+
 fn restore_full_background(vram: &mut [u32], fb: &mut FrameBuf, bg: &[u32]) {
     if bg.is_empty() {
         paint_background(fb);
@@ -1496,6 +1601,8 @@ fn main() {
     let mut input_parser = InputParser::new();
     let mut mouse_x: i32 = 0;
     let mut mouse_y: i32 = 0;
+    #[cfg(target_arch = "aarch64")]
+    let mut active_cursor_shape = graphics::cursor_shape::ARROW;
     let mut prev_buttons: u32 = 0;
     let mut dragging: Option<(usize, i32, i32)> = None;
     // Active resize: (win_idx, edge, anchor_x, anchor_y, orig_x, orig_y, orig_w, orig_h)
@@ -1529,6 +1636,14 @@ fn main() {
     #[cfg(target_arch = "aarch64")]
     {
         let _ = direct_mapped;
+        draw_software_cursor(
+            composite_buf,
+            screen_w,
+            screen_h,
+            mouse_x,
+            mouse_y,
+            active_cursor_shape,
+        );
         let _ = graphics::virgl_composite(composite_buf, screen_w as u32, screen_h as u32);
     }
     #[cfg(not(target_arch = "aarch64"))]
@@ -1654,6 +1769,8 @@ fn main() {
         let mut dirty_y0 = i32::MAX;
         let mut dirty_x1 = 0i32;
         let mut dirty_y1 = 0i32;
+        #[cfg(target_arch = "aarch64")]
+        let mut cursor_dirty = false;
 
         // ── 4. Process mouse input (only when mouse changed) ──
         let mut mouse_moved_this_frame = false;
@@ -1807,6 +1924,11 @@ fn main() {
                             }
                         }
                         let _ = graphics::set_cursor_shape(hover_shape);
+                        #[cfg(target_arch = "aarch64")]
+                        {
+                            cursor_dirty |= active_cursor_shape != hover_shape;
+                            active_cursor_shape = hover_shape;
+                        }
                     }
                 }
 
@@ -1817,6 +1939,11 @@ fn main() {
                     if let Some((win_idx, _, _, _, _, _, orig_w, orig_h)) = resizing.take() {
                         // Reset cursor shape back to arrow
                         let _ = graphics::set_cursor_shape(graphics::cursor_shape::ARROW);
+                        #[cfg(target_arch = "aarch64")]
+                        {
+                            cursor_dirty |= active_cursor_shape != graphics::cursor_shape::ARROW;
+                            active_cursor_shape = graphics::cursor_shape::ARROW;
+                        }
                         // Resize ended — notify client of new content dimensions
                         let new_cw = windows[win_idx].content_width();
                         let new_ch = windows[win_idx].content_height();
@@ -1955,6 +2082,11 @@ fn main() {
                                     ResizeEdge::TopRight | ResizeEdge::BottomLeft => graphics::cursor_shape::RESIZE_NESW,
                                 };
                                 let _ = graphics::set_cursor_shape(shape);
+                                #[cfg(target_arch = "aarch64")]
+                                {
+                                    cursor_dirty |= active_cursor_shape != shape;
+                                    active_cursor_shape = shape;
+                                }
                                 resizing = Some((
                                     top, edge,
                                     mouse_x, mouse_y,
@@ -2034,9 +2166,29 @@ fn main() {
         // ── 6. Composite to GPU (only when something changed) ──
         #[cfg(target_arch = "aarch64")]
         {
-            if full_redraw || content_dirty || windows_dirty || mouse_moved_this_frame {
+            if full_redraw || content_dirty || windows_dirty || mouse_moved_this_frame || cursor_dirty {
                 let _dirty_rect_snapshot = (dirty_x0, dirty_y0, dirty_x1, dirty_y1);
+                if mouse_moved_this_frame || cursor_dirty {
+                    compose_full_redraw(
+                        composite_buf,
+                        &mut fb,
+                        &mut shadow_fb,
+                        &bg_cache,
+                        &windows,
+                        focused_win,
+                        &clock_text,
+                        &mut ui_font,
+                    );
+                }
                 blit_window_contents(composite_buf, screen_w, screen_h, &windows);
+                draw_software_cursor(
+                    composite_buf,
+                    screen_w,
+                    screen_h,
+                    mouse_x,
+                    mouse_y,
+                    active_cursor_shape,
+                );
                 let _ = graphics::virgl_composite(composite_buf, screen_w as u32, screen_h as u32);
                 full_redraw = false;
                 content_dirty = false;

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -3,7 +3,9 @@
 //! PID 1 - runs bsh (no arguments), then starts background services and reaps zombies.
 //! bsh detects it's the init shell (PID 2) and loads /etc/init.js.
 
-use libbreenix::process::{getpid, spawn, waitpid, yield_now};
+use libbreenix::process::{getpid, spawn, waitpid};
+#[cfg(target_arch = "aarch64")]
+use libbreenix::process::yield_now;
 
 fn main() {
     let pid = getpid().map(|p| p.raw()).unwrap_or(0);


### PR DESCRIPTION
## Summary
- localize the cursor regression to the aarch64 bwm direct VirGL blit path
- draw the cursor in bwm for the aarch64 direct-blit compositor path while preserving the F26 frame path
- record Parallels capture validation with cursor pixel-mask evidence

## Validation
- ./userspace/programs/build.sh --arch aarch64
- cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64
- cargo build --release --features testing,external_test_bins --bin qemu-uefi
- bash scripts/f23-render-verdict.sh /tmp/f27cursor-1776510485-screen.png
- cursor pixel-mask detector: PASS (top_left_24 white=53, outline/dark=48, row ramp matches arrow)

## Notes
- The normal ./run.sh --parallels --test path was blocked by concurrent breenix-* Parallels factory cleanup. Validation used a one-off f27cursor-* VM outside that cleanup pattern and deleted it afterward.
- prlctl exposes keyboard injection only; the host-pointer movement probe rendered the cursor at a non-default kernel-reported location but did not produce a second in-boot movement delta.