### PR TITLE
F30: remove AHCI diagnostic scaffolding

### DIFF
--- a/docs/planning/f30-cleanup/exit.md
+++ b/docs/planning/f30-cleanup/exit.md
@@ -1,0 +1,66 @@
+# F30 Exit — AHCI Diagnostic Scaffolding Cleanup
+
+PR: https://github.com/ryanbreen/breenix/pull/323
+
+## Summary
+
+Removed F8-F17/F19 diagnostic-only scaffolding that was no longer needed after the IRQ admission, AHCI completion, and post-bwm spawn fixes.
+
+Live source sweep after cleanup:
+
+```text
+rg -n "AHCI_TRACE|STUCK_SPI34|STUCK_SPI|GIC_CPU_AUDIT|GICR_MAP|GICR_STATE|UNBLOCK_SCAN|LAST_USER_CTX_WRITE|CI_LOOP|TTWU_LOCAL|RESCHED_CHECK|WAKEBUF_|SGI_ENTRY|SGI_BEFORE_MSR|AHCI_RING|push_ahci_event|hello_raw|hello_println|hello_nostd_padded" kernel userspace libs tests src.legacy xtask Cargo.toml scripts --glob '!target/**'
+```
+
+Result: no matches in live source paths.
+
+## Per-Family Results
+
+1. Survey
+   - Commit: `ebb4db1e docs(f30): survey diagnostic scaffolding`
+   - Output: `docs/planning/f30-cleanup/survey.md`
+
+2. Scheduler/AHCI wake breadcrumbs
+   - Commit: `f573ba8a cleanup(f30): remove scheduler AHCI breadcrumbs`
+   - Removed `UNBLOCK_*`, `TTWU_LOCAL_*`, `RESCHED_CHECK_*`, `WAKEBUF_*`, and related AHCI event pushes from scheduler/completion/IRQ-tail paths.
+   - Validation: clean build and 120s Parallels run, strict verdict PASS, init complete, bounce rendered, no SOFT_LOCKUP.
+
+3. SGI breadcrumbs
+   - Commit: `0b266d9c cleanup(f30): remove SGI trace breadcrumbs`
+   - Removed SGI boundary trace calls/helper.
+   - Validation: clean aarch64 kernel build, clean qemu-uefi build, isolated 120s Parallels run `f30cleanup-sgi-1776511094`, strict verdict PASS, init complete, bounce rendered, no removed markers.
+
+4. GIC diagnostic dumps
+   - Commit: `ea22ada0 cleanup(f30): remove GIC diagnostic dumps`
+   - Removed `[STUCK_SPI*]`, `[GIC_CPU_AUDIT]`, `[GICR_MAP]`, and `[GICR_STATE]` output/dump scaffolding.
+   - Retained post-enable ICC readbacks in `init_gicv3_cpu_interface`; a validation run without those readbacks stalled before init completion, so that ordering is load-bearing rather than removable diagnostic output.
+   - Validation: clean aarch64 kernel build, clean qemu-uefi build, isolated 120s Parallels run `f30cleanup-gic-rd-1776512219`, strict verdict PASS, init complete, bounce rendered, no SOFT_LOCKUP.
+
+5. AHCI trace ring
+   - Commit: `b2ba104d cleanup(f30): remove AHCI trace ring`
+   - Removed `AHCI_TRACE_*` constants, per-CPU ring structures, `push_ahci_event`, `dump_recent_ahci_events`, SGI target collection, and AHCI ISR trace push sites.
+   - Validation: clean aarch64 kernel build, clean qemu-uefi build, isolated 120s Parallels run `f30cleanup-ahci-ring-1776512676`, strict verdict PASS, init complete, bounce rendered, frame #19000 by tick 115000, no removed markers.
+
+6. `hello_raw` probe binary
+   - Commit: `674c85e2 cleanup(f30): remove hello_raw probe binary`
+   - Removed `userspace/programs/src/hello_raw.rs`, Cargo bin registration, and userspace install-list entry.
+   - Validation: `userspace/programs/build.sh --arch aarch64` clean; regenerated ext2 disk had no `hello_raw` entry; clean aarch64 kernel build; clean qemu-uefi build; isolated 120s Parallels run `f30cleanup-hello-1776513117`, strict verdict PASS, init complete, bounce rendered, frame #22000 by tick 140000, no removed markers.
+
+## Final Sweep
+
+Final isolated 120s Parallels sweep:
+
+- VM: `f30cleanup-final-1776513691`
+- Strict verdict: PASS
+- Serial markers:
+  - `[init] Boot script completed`
+  - `[init] bounce started`
+  - no `SOFT_LOCKUP`, panic, or removed diagnostic markers
+- Frame/tick result: last frame `32500`, last tick `195000`, derived FPS `166.67`
+- Final serial line count: `504`
+
+The serial line count is not directly comparable to early failed/shorter runs because the final sweep ran long enough to emit many frame/timer progress lines. The diagnostic marker families themselves were reduced to zero live runtime lines in the final serial output.
+
+## Notes
+
+`./run.sh --parallels` deletes `breenix-*` VMs globally. During this work, sibling factory VMs were active, so validation used isolated `f30cleanup-*` Parallels VMs with the same EFI/ext2 disks and 120s runtime window to avoid disrupting unrelated factory work.

--- a/docs/planning/f30-cleanup/survey.md
+++ b/docs/planning/f30-cleanup/survey.md
@@ -1,0 +1,69 @@
+# F30 Diagnostic Scaffolding Survey
+
+Generated on 2026-04-18 from `ab351efe` on branch `f30-ahci-diagnostic-cleanup`.
+
+Primary survey command:
+
+```bash
+rg -n "AHCI_TRACE|STUCK_SPI34|GIC_CPU_AUDIT|GICR_MAP|GICR_STATE|UNBLOCK_SCAN|LAST_USER_CTX_WRITE|CI_LOOP|TTWU_LOCAL|RESCHED_CHECK|WAKEBUF_|SGI_ENTRY|SGI_BEFORE_MSR|hello_raw|hello_println|hello_nostd_padded" \
+  --glob '!target/**' --glob '!logs/**' --glob '!.factory-runs/**'
+```
+
+Secondary survey commands checked related live scaffolding names:
+
+```bash
+rg -n "GICR_STATE|dump_stuck_state|stuck_state|hello_println|hello_raw_then_println|hello_raw_padded|hello_nostd_padded|AHCI_RING|push_ahci_event|trace_sgi_boundary|dump_ahci_trace|record_gic_cpu|refresh_gicr_rdist_map|dump_gic" \
+  --glob '!target/**' --glob '!logs/**' --glob '!.factory-runs/**'
+rg -n "LAST_USER_CTX_WRITE|last_user_ctx_write|USER_CTX_WRITE" \
+  --glob '!target/**' --glob '!logs/**' --glob '!.factory-runs/**'
+```
+
+## Live Cleanup Targets
+
+| File | Line ranges | Markers / scaffolding |
+| --- | ---: | --- |
+| `kernel/src/drivers/ahci/mod.rs` | 257-294, 334, 341, 363-364, 393-409, 430-465, 475, 529-530, 547, 569, 578-587, 594-595, 605 | AHCI per-CPU trace ring, `AHCI_TRACE_*` constants, `push_ahci_event`, `dump_recent_ahci_events`, SGI target collection |
+| `kernel/src/drivers/ahci/mod.rs` | 2743-2910 | AHCI ISR trace push sites: `ENTER`, `CI_LOOP`, `POST_CLEAR`, `BEFORE_COMPLETE`, `AFTER_COMPLETE`, `RETURN` |
+| `kernel/src/drivers/ahci/mod.rs` | 3066-3067 | AHCI timeout diagnostic caller: `dump_stuck_state_for_spi(34)` plus recent AHCI ring dump |
+| `kernel/src/task/completion.rs` | 497, 511 | Completion wake trace push sites: `WAKE_ENTER`, `WAKE_EXIT` |
+| `kernel/src/task/scheduler.rs` | 164, 947-949, 2571-2583 | F17 reschedule trace budget and `RESCHED_CHECK_DRAINED_WAKE` push site |
+| `kernel/src/task/scheduler.rs` | 2613, 2626-2629, 2642, 2656, 2670, 2684, 2697-2700, 2713, 2729 | `isr_unblock_for_io` breadcrumbs: `UNBLOCK_*`, `TTWU_LOCAL_*`, `WAKEBUF_*` |
+| `kernel/src/arch_impl/aarch64/context_switch.rs` | 63-74 | F17 reschedule trace helper that writes AHCI ring events |
+| `kernel/src/arch_impl/aarch64/context_switch.rs` | 2259, 2279, 2329, 2391, 2406, 2476, 2503, 2526, 2537, 2735 | `RESCHED_CHECK_*` push sites in IRQ-return scheduler path |
+| `kernel/src/arch_impl/aarch64/exception.rs` | 1357-1364 | IRQ-tail `AHCI_TRACE_IRQ_TAIL_CHECK_RESCHED` breadcrumb |
+| `kernel/src/arch_impl/aarch64/gic.rs` | 315-349, 830-1008 | `[STUCK_SPI*]` raw dump helpers and `dump_stuck_state_for_spi` |
+| `kernel/src/arch_impl/aarch64/gic.rs` | 1017-1069 | SGI boundary AHCI trace pushes: `SGI_ENTRY`, `SGI_BEFORE_MSR`, related SGI breadcrumbs |
+| `kernel/src/arch_impl/aarch64/gic.rs` | 1232, 1317-1337, 1395-1396, 1428, 1477-1542 | `GICR_MAP` redistributor map cache/dump scaffolding |
+| `kernel/src/arch_impl/aarch64/gic.rs` | 1545-1575 | `[GICR_STATE]` dump helper |
+| `kernel/src/arch_impl/aarch64/gic.rs` | 1244-1306, 1579-1625, 1858-1868 | `[GIC_CPU_AUDIT]` snapshot storage, recorder, dump function, and record call |
+| `kernel/src/main_aarch64.rs` | 964-969 | Boot-time callers for `[GIC_CPU_AUDIT]` and `[GICR_MAP]` dumps |
+| `kernel/src/arch_impl/aarch64/timer_interrupt.rs` | 283, 740-850 | Existing `dump_gic_state()` diagnostic path; not matched by requested prefixes except related `dump_gic` name in the secondary survey |
+| `userspace/programs/src/hello_raw.rs` | 1-8 | F19 `/bin/hello_raw` userspace probe binary |
+| `userspace/programs/build.sh` | 195 | `hello_raw` included in userspace image build list |
+| `userspace/programs/Cargo.toml` | 339-340 | `hello_raw` bin registration |
+
+## Historical Documentation References
+
+These are planning/history references, not live runtime scaffolding:
+
+| File | Line ranges |
+| --- | ---: |
+| `docs/planning/ARM64_CPU0_SMP_INVESTIGATION.md` | 2113-2127, 2168-2206, 2269-2270, 2319-2335, 2501-2522, 2563-2566, 2726-2759, 2767, 2771, 2778, 2907-2948, 2967-2969, 3039-3068, 3133, 3160-3173, 3200-3222, 3286, 3325-3369, 3430-3548, 3588-3653, 3679-3778, 3829-3830 |
+| `docs/planning/f16-scheduler-audit.md` | 60, 202-205 |
+| `docs/planning/f25-spawn-hang/phase1.md` | 1, 11, 19, 44, 47, 51 |
+| `docs/planning/f25-spawn-hang/exit.md` | 17, 25, 28, 30 |
+
+## Negative Findings
+
+- `LAST_USER_CTX_WRITE`, `last_user_ctx_write`, and `USER_CTX_WRITE` have no current match in the repository outside ignored build/log/factory artifacts.
+- No live `hello_println`, `hello_raw_then_println`, `hello_raw_padded`, or `hello_nostd_padded` source/binary registrations remain. They only appear in historical planning notes.
+- `hello_raw` remains live in `userspace/programs/src/hello_raw.rs`, `userspace/programs/build.sh`, and `userspace/programs/Cargo.toml`.
+
+## Initial Removal Grouping
+
+1. AHCI trace ring and AHCI trace push sites.
+2. Scheduler/completion/context-switch/exception breadcrumbs that only feed the AHCI trace ring.
+3. GIC stuck-state, SGI boundary, GICR map/state, and CPU audit diagnostics.
+4. F19 `hello_raw` probe binary and build registration.
+
+If any candidate is found to be load-bearing during removal or validation, stop and report instead of forcing the deletion.

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -59,30 +59,6 @@ pub(crate) const TRACE_KERNEL_RESUME_IRQ_RESCHED_TAIL: u16 = 3;
 const TRACE_RESCHED_TAIL_BEFORE_RETURN: u16 = 2;
 
 #[inline]
-fn trace_f17_resched_site(site: u32, cpu: usize, tid: u64, switched: bool) {
-    if !crate::task::scheduler::take_f17_resched_trace_budget(cpu) {
-        return;
-    }
-
-    crate::drivers::ahci::push_ahci_event(
-        site,
-        0,
-        0,
-        0,
-        0,
-        0,
-        tid,
-        crate::task::scheduler::isr_wakeup_depth(cpu) as u32,
-        if crate::task::scheduler::is_need_resched() {
-            1
-        } else {
-            0
-        },
-        switched,
-    );
-}
-
-#[inline]
 fn dispatch_spsr(spsr: u64) -> u64 {
     spsr & !SPSR_DAIF_IRQ_BIT
 }
@@ -2254,19 +2230,11 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
     frame: &mut Aarch64ExceptionFrame,
     from_el0: bool,
 ) {
-    let f17_cpu_id = Aarch64PerCpu::cpu_id() as usize;
-    trace_f17_resched_site(
-        crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_ENTRY,
-        f17_cpu_id,
-        0,
-        false,
-    );
-
     crate::task::process_task::drain_deferred_fault_sigsegv_exits();
 
     // ── Lock-free pre-checks ──────────────────────────────────────
     let preempt_count = Aarch64PerCpu::preempt_count();
-    let cpu_id_early = f17_cpu_id;
+    let cpu_id_early = Aarch64PerCpu::cpu_id() as usize;
     if !from_el0 {
         trace_kernel_resume_irq(frame);
     }
@@ -2275,12 +2243,6 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
     if (preempt_count & 0x10000000) != 0 {
         // PREEMPT_ACTIVE: in the middle of returning from a previous
         // exception — don't context switch now.
-        trace_f17_resched_site(
-            crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_RETURN,
-            f17_cpu_id,
-            0,
-            false,
-        );
         return;
     }
 
@@ -2325,12 +2287,6 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
     if !from_el0 && (preempt_count & 0xFF) > 0 {
         // Kernel code holding locks — not safe to preempt.
         // Deferred requeue was already processed above.
-        trace_f17_resched_site(
-            crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_RETURN,
-            cpu_id,
-            0,
-            false,
-        );
         return;
     }
 
@@ -2387,12 +2343,6 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
                 check_and_deliver_signals_for_current_thread_arm64(frame);
                 ensure_user_rsp_scratch_for_el0();
             }
-            trace_f17_resched_site(
-                crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_RETURN,
-                cpu_id,
-                0,
-                false,
-            );
             return;
         }
     }
@@ -2401,15 +2351,7 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
     let mut guard = crate::task::scheduler::lock_for_context_switch();
     let sched = match guard.as_mut() {
         Some(s) => s,
-        None => {
-            trace_f17_resched_site(
-                crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_RETURN,
-                cpu_id,
-                0,
-                false,
-            );
-            return;
-        }
+        None => return,
     };
 
     if exception_cleanup_context {
@@ -2472,12 +2414,6 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
             check_and_deliver_signals_for_current_thread_arm64(frame);
             ensure_user_rsp_scratch_for_el0();
         }
-        trace_f17_resched_site(
-            crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_RETURN,
-            cpu_id,
-            0,
-            false,
-        );
         return;
     }
 
@@ -2499,12 +2435,6 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
             check_and_deliver_signals_for_current_thread_arm64(frame);
             ensure_user_rsp_scratch_for_el0();
         }
-        trace_f17_resched_site(
-            crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_RETURN,
-            cpu_id,
-            0,
-            false,
-        );
         return;
     }
 
@@ -2522,23 +2452,11 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
             check_and_deliver_signals_for_current_thread_arm64(frame);
             ensure_user_rsp_scratch_for_el0();
         }
-        trace_f17_resched_site(
-            crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_RETURN,
-            cpu_id,
-            new_id,
-            false,
-        );
         return;
     }
 
     // 5. Trace context switch + queue state + increment watchdog counter
     trace_ctx_switch(old_id, new_id);
-    trace_f17_resched_site(
-        crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_SWITCHED,
-        cpu_id,
-        new_id,
-        true,
-    );
     crate::tracing::providers::sched::trace_sched_queue_state(
         sched.ready_queue_length() as u16,
         new_id as u16,
@@ -2731,12 +2649,6 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
 
     cpu0_breadcrumb(cpu_id, 106); // before function return
     cpu0_breadcrumb(cpu_id, 14); // return
-    trace_f17_resched_site(
-        crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_RETURN,
-        cpu_id,
-        new_id,
-        true,
-    );
     if let Some(trace_tid) = trace_eret_tid {
         trace_resched_tail(TRACE_RESCHED_TAIL_BEFORE_RETURN, trace_tid);
     }

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -1350,27 +1350,6 @@ pub extern "C" fn handle_irq(frame: *const Aarch64ExceptionFrame) {
 
         // Check if we need to reschedule after handling the interrupt
         // This is the ARM64 equivalent of x86's check_need_resched_and_switch
-        if have_percpu {
-            let cpu = crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as usize;
-            if crate::task::scheduler::take_f17_resched_trace_budget(cpu) {
-                crate::drivers::ahci::push_ahci_event(
-                    crate::drivers::ahci::AHCI_TRACE_IRQ_TAIL_CHECK_RESCHED,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    crate::task::scheduler::isr_wakeup_depth(cpu) as u32,
-                    if crate::task::scheduler::is_need_resched() {
-                        1
-                    } else {
-                        0
-                    },
-                    false,
-                );
-            }
-        }
         check_need_resched_on_irq_exit();
     }
 }

--- a/kernel/src/arch_impl/aarch64/gic.rs
+++ b/kernel/src/arch_impl/aarch64/gic.rs
@@ -206,11 +206,6 @@ const GICC_BPR: usize = 0x008;
 const GICC_IAR: usize = 0x00C;
 /// End of Interrupt Register
 const GICC_EOIR: usize = 0x010;
-/// Running Priority Register
-const GICC_RPR: usize = 0x014;
-/// Highest Priority Pending Interrupt Register
-const GICC_HPPIR: usize = 0x018;
-
 // =============================================================================
 // Constants
 // =============================================================================
@@ -302,55 +297,6 @@ fn gicc_write(offset: usize, value: u32) {
         let addr = (GIC_HHDM + base + offset) as *mut u32;
         core::ptr::write_volatile(addr, value);
     }
-}
-
-#[inline]
-fn gicd_read_u64(offset: usize) -> u64 {
-    let lo = gicd_read(offset) as u64;
-    let hi = gicd_read(offset + 4) as u64;
-    lo | (hi << 32)
-}
-
-#[inline]
-fn raw_dump_prefix(intid: u32) {
-    use crate::arch_impl::aarch64::context_switch::{raw_uart_dec, raw_uart_str};
-
-    raw_uart_str("[STUCK_SPI");
-    raw_uart_dec(intid as u64);
-    raw_uart_str("] ");
-}
-
-#[inline]
-fn raw_dump_u64(intid: u32, label: &str, value: u64) {
-    use crate::arch_impl::aarch64::context_switch::{raw_uart_hex, raw_uart_str};
-
-    raw_dump_prefix(intid);
-    raw_uart_str(label);
-    raw_uart_str("=");
-    raw_uart_hex(value);
-    raw_uart_str("\n");
-}
-
-#[inline]
-fn raw_dump_bool(intid: u32, label: &str, value: bool) {
-    use crate::arch_impl::aarch64::context_switch::raw_uart_str;
-
-    raw_dump_prefix(intid);
-    raw_uart_str(label);
-    raw_uart_str("=");
-    raw_uart_str(if value { "true" } else { "false" });
-    raw_uart_str("\n");
-}
-
-#[inline]
-fn raw_dump_note(intid: u32, label: &str, note: &str) {
-    use crate::arch_impl::aarch64::context_switch::raw_uart_str;
-
-    raw_dump_prefix(intid);
-    raw_uart_str(label);
-    raw_uart_str("=");
-    raw_uart_str(note);
-    raw_uart_str("\n");
 }
 
 /// Read a 32-bit GICR register (GICv3 only).
@@ -552,7 +498,7 @@ impl InterruptController for Gicv2 {
                 // idempotent (guarded by GICR_PROBED), so calling it again
                 // inside init_gicv3_redistributor(0) is a no-op.
                 probe_and_validate_gicr();
-                refresh_gicr_rdist_map(GICR_MAP_SLOTS, false);
+                refresh_gicr_rdist_map(GICR_RDIST_SLOTS);
                 init_gicv3_distributor();
                 init_gicv3_redistributor(0); // CPU 0
                 init_gicv3_cpu_interface();
@@ -822,193 +768,6 @@ pub fn snapshot_pending_spis() -> [u32; 3] {
     ]
 }
 
-/// Dump a read-only GIC stuck-state snapshot for a pending SPI.
-///
-/// This is an observational diagnostic only: it performs volatile MMIO reads
-/// and system-register reads but does not modify distributor or CPU-interface
-/// state.
-pub fn dump_stuck_state_for_spi(intid: u32) {
-    use crate::arch_impl::aarch64::context_switch::{raw_uart_dec, raw_uart_hex, raw_uart_str};
-
-    let cpu_id = get_cpu_id_from_mpidr() as u64;
-    let version = ACTIVE_GIC_VERSION.load(Ordering::Relaxed);
-    let reg_index = intid / 32;
-    let bit_index = intid % 32;
-    let ispendr_reg = gicd_read(GICD_ISPENDR + (reg_index as usize * 4));
-    let isactiver_reg = gicd_read(GICD_ISACTIVER + (reg_index as usize * 4));
-    let pending = (ispendr_reg & (1 << bit_index)) != 0;
-    let active = (isactiver_reg & (1 << bit_index)) != 0;
-
-    let icfgr_reg_index = intid / 16;
-    let icfgr_field_shift = (intid % 16) * 2;
-    let icfgr_reg = gicd_read(GICD_ICFGR + (icfgr_reg_index as usize * 4));
-    let icfgr_bits = (icfgr_reg >> icfgr_field_shift) & 0x3;
-
-    let ipriorityr_reg_index = intid / 4;
-    let ipriorityr_byte_shift = (intid % 4) * 8;
-    let ipriorityr_reg = gicd_read(GICD_IPRIORITYR + (ipriorityr_reg_index as usize * 4));
-    let priority = (ipriorityr_reg >> ipriorityr_byte_shift) & 0xff;
-
-    raw_dump_prefix(intid);
-    raw_uart_str("cpu=");
-    raw_uart_dec(cpu_id);
-    raw_uart_str(" gic_version=");
-    raw_uart_dec(version as u64);
-    raw_uart_str("\n");
-
-    raw_dump_prefix(intid);
-    raw_uart_str("GICD_ISPENDR[");
-    raw_uart_dec(reg_index as u64);
-    raw_uart_str("]=");
-    raw_uart_hex(ispendr_reg as u64);
-    raw_uart_str(" bit=");
-    raw_uart_dec(bit_index as u64);
-    raw_uart_str(" pending=");
-    raw_uart_str(if pending { "true" } else { "false" });
-    raw_uart_str("\n");
-
-    raw_dump_prefix(intid);
-    raw_uart_str("GICD_ISACTIVER[");
-    raw_uart_dec(reg_index as u64);
-    raw_uart_str("]=");
-    raw_uart_hex(isactiver_reg as u64);
-    raw_uart_str(" bit=");
-    raw_uart_dec(bit_index as u64);
-    raw_uart_str(" active=");
-    raw_uart_str(if active { "true" } else { "false" });
-    raw_uart_str("\n");
-
-    raw_dump_prefix(intid);
-    raw_uart_str("GICD_ICFGR[");
-    raw_uart_dec(icfgr_reg_index as u64);
-    raw_uart_str("]=");
-    raw_uart_hex(icfgr_reg as u64);
-    raw_uart_str(" bits=");
-    raw_uart_hex(icfgr_bits as u64);
-    raw_uart_str(" trigger=");
-    raw_uart_str(if (icfgr_bits & 0b10) != 0 {
-        "edge"
-    } else {
-        "level"
-    });
-    raw_uart_str("\n");
-
-    raw_dump_prefix(intid);
-    raw_uart_str("GICD_IPRIORITYR[");
-    raw_uart_dec(intid as u64);
-    raw_uart_str("]=");
-    raw_uart_hex(priority as u64);
-    raw_uart_str("\n");
-
-    let gicd_ctlr = gicd_read(GICD_CTLR);
-    let are_enabled = (gicd_ctlr & GICD_CTLR_ARE_NS) != 0;
-    if version >= 3 || are_enabled {
-        let router = gicd_read_u64(GICD_IROUTER + (intid as usize * 8));
-        raw_dump_prefix(intid);
-        raw_uart_str("GICD_IROUTER[");
-        raw_uart_dec(intid as u64);
-        raw_uart_str("]=");
-        raw_uart_hex(router);
-        raw_uart_str("\n");
-    } else {
-        let target_reg_index = intid / 4;
-        let target_byte_shift = (intid % 4) * 8;
-        let itargetsr_reg = gicd_read(GICD_ITARGETSR + (target_reg_index as usize * 4));
-        let target = (itargetsr_reg >> target_byte_shift) & 0xff;
-        raw_dump_prefix(intid);
-        raw_uart_str("GICD_ITARGETSR[");
-        raw_uart_dec(intid as u64);
-        raw_uart_str("]=");
-        raw_uart_hex(target as u64);
-        raw_uart_str("\n");
-    }
-
-    let current_el: u64;
-    let daif: u64;
-    unsafe {
-        core::arch::asm!("mrs {}, currentel", out(reg) current_el, options(nomem, nostack));
-        core::arch::asm!("mrs {}, daif", out(reg) daif, options(nomem, nostack));
-    }
-
-    let (rpr, pmr, bpr1, hppir1, ap1r0) = if version >= 3 {
-        let rpr: u64;
-        let pmr: u64;
-        let bpr1: u64;
-        let hppir1: u64;
-        let ap1r0: u64;
-        unsafe {
-            core::arch::asm!("mrs {}, S3_0_C12_C11_3", out(reg) rpr, options(nomem, nostack));
-            core::arch::asm!("mrs {}, icc_pmr_el1", out(reg) pmr, options(nomem, nostack));
-            core::arch::asm!("mrs {}, icc_bpr1_el1", out(reg) bpr1, options(nomem, nostack));
-            core::arch::asm!("mrs {}, icc_hppir1_el1", out(reg) hppir1, options(nomem, nostack));
-            core::arch::asm!("mrs {}, icc_ap1r0_el1", out(reg) ap1r0, options(nomem, nostack));
-        }
-        (rpr, pmr, bpr1, hppir1, ap1r0)
-    } else {
-        (
-            gicc_read(GICC_RPR) as u64,
-            gicc_read(GICC_PMR) as u64,
-            gicc_read(GICC_BPR) as u64,
-            gicc_read(GICC_HPPIR) as u64,
-            0,
-        )
-    };
-
-    raw_dump_u64(intid, "ICC_RPR_EL1", rpr);
-    raw_dump_u64(intid, "ICC_PMR_EL1", pmr);
-    raw_dump_u64(intid, "ICC_BPR1_EL1", bpr1);
-    raw_dump_u64(intid, "ICC_HPPIR1_EL1", hppir1);
-    if version >= 3 {
-        raw_dump_u64(intid, "ICC_AP1R0_EL1", ap1r0);
-    } else {
-        raw_dump_note(intid, "ICC_AP1R0_EL1", "unsupported_on_gicv2");
-    }
-    raw_dump_u64(intid, "DAIF", daif);
-    if crate::per_cpu_aarch64::in_interrupt() {
-        let spsr: u64;
-        unsafe {
-            core::arch::asm!("mrs {}, spsr_el1", out(reg) spsr, options(nomem, nostack));
-        }
-        raw_dump_u64(intid, "SPSR_EL1", spsr);
-    } else {
-        raw_dump_note(intid, "SPSR_EL1", "not_in_exception_context");
-    }
-    raw_dump_u64(intid, "CurrentEL", current_el);
-    raw_dump_bool(intid, "peer_cpu_scan", false);
-    raw_dump_note(
-        intid,
-        "peer_cpu_reason",
-        "no_existing_ipi_callback_mechanism",
-    );
-
-    if intid == 34 {
-        let mut sgi_targets = [0u8; 8];
-        let target_count = crate::drivers::ahci::collect_recent_sgi_targets(&mut sgi_targets);
-        for target in sgi_targets.iter().take(target_count) {
-            dump_gicr_state_for_cpu(*target as usize);
-        }
-
-        raw_dump_prefix(intid);
-        raw_uart_str("AHCI_PORT0_IS=");
-        if let Some(port0_is) = crate::drivers::ahci::port0_is_snapshot() {
-            raw_uart_hex(port0_is as u64);
-        } else {
-            raw_uart_str("unavailable");
-        }
-        raw_uart_str("\n");
-        raw_dump_prefix(intid);
-        raw_uart_str("AHCI_PORT1_IS=");
-        if let Some(port1_is) = crate::drivers::ahci::port_is_snapshot(1) {
-            raw_uart_hex(port1_is as u64);
-        } else {
-            raw_uart_str("unavailable");
-        }
-        raw_uart_str("\n");
-
-        crate::drivers::ahci::dump_recent_ahci_events(None, 64);
-    }
-}
-
 /// Send a Software Generated Interrupt (SGI) to a target CPU.
 ///
 /// SGIs are interrupts 0-15 and are used for IPIs.
@@ -1205,31 +964,13 @@ pub fn dump_irq_state(irq: u32) {
 const GICR_FRAME_SIZE: usize = 0x2_0000; // 128KB per CPU (2 x 64KB frames)
 const GICR_SGI_OFFSET: usize = 0x1_0000; // SGI_base is second 64KB frame
 const GICR_TYPER_LAST: u64 = 1 << 4;
-const GICR_MAP_SLOTS: usize = crate::arch_impl::aarch64::smp::MAX_CPUS;
+const GICR_RDIST_SLOTS: usize = crate::arch_impl::aarch64::smp::MAX_CPUS;
 
 /// GICR RD_base registers
-const GICR_CTLR: usize = 0x000;
 const GICR_WAKER: usize = 0x014;
 const GICR_TYPER: usize = 0x008;
-const GICR_SYNCR: usize = 0x0C0;
 
-const LINUX_EXPECTED_SRE_ENABLED: u64 = 1;
-const LINUX_EXPECTED_CTLR_EOIMODE: u64 = 1 << 1;
-const LINUX_EXPECTED_PMR: u64 = 0xF0;
-const LINUX_EXPECTED_IGRPEN1_ENABLED: u64 = 1;
-const GIC_CPU_AUDIT_SLOTS: usize = 8;
-
-static GIC_CPU_AUDIT_VALID: [AtomicBool; GIC_CPU_AUDIT_SLOTS] = [
-    AtomicBool::new(false),
-    AtomicBool::new(false),
-    AtomicBool::new(false),
-    AtomicBool::new(false),
-    AtomicBool::new(false),
-    AtomicBool::new(false),
-    AtomicBool::new(false),
-    AtomicBool::new(false),
-];
-static GIC_CPU_AUDIT_MPIDR: [AtomicU64; GIC_CPU_AUDIT_SLOTS] = [
+static GICR_PER_CPU_BASE: [AtomicU64; GICR_RDIST_SLOTS] = [
     AtomicU64::new(0),
     AtomicU64::new(0),
     AtomicU64::new(0),
@@ -1239,7 +980,7 @@ static GIC_CPU_AUDIT_MPIDR: [AtomicU64; GIC_CPU_AUDIT_SLOTS] = [
     AtomicU64::new(0),
     AtomicU64::new(0),
 ];
-static GIC_CPU_AUDIT_SRE: [AtomicU64; GIC_CPU_AUDIT_SLOTS] = [
+static GICR_PER_CPU_TYPER: [AtomicU64; GICR_RDIST_SLOTS] = [
     AtomicU64::new(0),
     AtomicU64::new(0),
     AtomicU64::new(0),
@@ -1249,68 +990,7 @@ static GIC_CPU_AUDIT_SRE: [AtomicU64; GIC_CPU_AUDIT_SLOTS] = [
     AtomicU64::new(0),
     AtomicU64::new(0),
 ];
-static GIC_CPU_AUDIT_CTLR: [AtomicU64; GIC_CPU_AUDIT_SLOTS] = [
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-];
-static GIC_CPU_AUDIT_PMR: [AtomicU64; GIC_CPU_AUDIT_SLOTS] = [
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-];
-static GIC_CPU_AUDIT_IGRPEN1: [AtomicU64; GIC_CPU_AUDIT_SLOTS] = [
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-];
-static GIC_CPU_AUDIT_MISMATCH: [AtomicU8; GIC_CPU_AUDIT_SLOTS] = [
-    AtomicU8::new(0),
-    AtomicU8::new(0),
-    AtomicU8::new(0),
-    AtomicU8::new(0),
-    AtomicU8::new(0),
-    AtomicU8::new(0),
-    AtomicU8::new(0),
-    AtomicU8::new(0),
-];
-
-static GICR_PER_CPU_BASE: [AtomicU64; GICR_MAP_SLOTS] = [
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-];
-static GICR_PER_CPU_TYPER: [AtomicU64; GICR_MAP_SLOTS] = [
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-];
-static GICR_PER_CPU_AFFINITY: [AtomicU64; GICR_MAP_SLOTS] = [
+static GICR_PER_CPU_AFFINITY: [AtomicU64; GICR_RDIST_SLOTS] = [
     AtomicU64::new(0),
     AtomicU64::new(0),
     AtomicU64::new(0),
@@ -1351,14 +1031,6 @@ fn get_cpu_id_from_mpidr() -> usize {
     (mpidr & 0xFF) as usize
 }
 
-fn read_mpidr_el1() -> u64 {
-    let mpidr: u64;
-    unsafe {
-        core::arch::asm!("mrs {}, mpidr_el1", out(reg) mpidr, options(nomem, nostack));
-    }
-    mpidr
-}
-
 fn mpidr_to_gicr_affinity(mpidr: u64) -> u32 {
     let aff0 = mpidr & 0xff;
     let aff1 = (mpidr >> 8) & 0xff;
@@ -1368,11 +1040,7 @@ fn mpidr_to_gicr_affinity(mpidr: u64) -> u32 {
 }
 
 fn expected_gicr_affinity_for_cpu(cpu_id: usize) -> u32 {
-    if cpu_id < GIC_CPU_AUDIT_SLOTS && GIC_CPU_AUDIT_VALID[cpu_id].load(Ordering::Acquire) {
-        mpidr_to_gicr_affinity(GIC_CPU_AUDIT_MPIDR[cpu_id].load(Ordering::Acquire))
-    } else {
-        mpidr_to_gicr_affinity(cpu_id as u64)
-    }
+    mpidr_to_gicr_affinity(cpu_id as u64)
 }
 
 #[inline]
@@ -1401,7 +1069,7 @@ fn gicr_read_u64_at_rd_base(rd_base_phys: usize, offset: usize) -> u64 {
 
 #[inline]
 fn gicr_rd_base_for_cpu(cpu_id: usize) -> Option<usize> {
-    if cpu_id >= GICR_MAP_SLOTS {
+    if cpu_id >= GICR_RDIST_SLOTS {
         return None;
     }
 
@@ -1450,15 +1118,12 @@ fn validate_gicr_range_for_cpu(cpu_id: usize) -> bool {
     true
 }
 
-fn refresh_gicr_rdist_map(max_cpus: usize, emit_logs: bool) {
+fn refresh_gicr_rdist_map(max_cpus: usize) {
     if !GICR_VALID.load(Ordering::Acquire) {
-        if emit_logs {
-            crate::serial_println!("[GICR_MAP] unavailable=gicr_not_valid");
-        }
         return;
     }
 
-    let target_cpus = max_cpus.min(GICR_MAP_SLOTS);
+    let target_cpus = max_cpus.min(GICR_RDIST_SLOTS);
     for cpu_id in 0..target_cpus {
         GICR_PER_CPU_BASE[cpu_id].store(0, Ordering::Release);
         GICR_PER_CPU_TYPER[cpu_id].store(0, Ordering::Release);
@@ -1470,7 +1135,7 @@ fn refresh_gicr_rdist_map(max_cpus: usize, emit_logs: bool) {
     let max_frames = if gicr_size > 0 {
         (gicr_size / GICR_FRAME_SIZE).max(1)
     } else {
-        GICR_MAP_SLOTS
+        GICR_RDIST_SLOTS
     };
 
     for frame in 0..max_frames {
@@ -1492,113 +1157,14 @@ fn refresh_gicr_rdist_map(max_cpus: usize, emit_logs: bool) {
         }
     }
 
-    if emit_logs {
-        for cpu_id in 0..target_cpus {
-            let rd_base = GICR_PER_CPU_BASE[cpu_id].load(Ordering::Acquire);
-            if rd_base == 0 {
-                crate::serial_println!("[GICR_MAP] cpu={} NOT_FOUND", cpu_id);
-            } else {
-                crate::serial_println!(
-                    "[GICR_MAP] cpu={} rd_base={:#x} typer={:#x} affinity={:#x}",
-                    cpu_id,
-                    rd_base,
-                    GICR_PER_CPU_TYPER[cpu_id].load(Ordering::Acquire),
-                    GICR_PER_CPU_AFFINITY[cpu_id].load(Ordering::Acquire)
-                );
-            }
-        }
-    }
 }
 
-/// Build and emit the Linux-style redistributor map.
+/// Build the Linux-style redistributor map.
 ///
 /// Linux walks each 128KB redistributor frame and matches `GICR_TYPER[63:32]`
 /// to the CPU affinity value; see irq-gic-v3.c `gic_populate_rdist()`.
 pub fn init_gicr_rdist_map(max_cpus: usize) {
-    refresh_gicr_rdist_map(max_cpus, true);
-}
-
-pub fn dump_gicr_state_for_cpu(target_cpu: usize) {
-    use crate::arch_impl::aarch64::context_switch::{raw_uart_dec, raw_uart_hex, raw_uart_str};
-
-    raw_uart_str("[GICR_STATE] cpu=");
-    raw_uart_dec(target_cpu as u64);
-
-    if !GICR_VALID.load(Ordering::Relaxed) {
-        raw_uart_str(" unavailable=gicr_not_valid\n");
-        return;
-    }
-
-    let Some(rd_base) = gicr_rd_base_for_cpu(target_cpu) else {
-        raw_uart_str(" unavailable=rdist_not_found\n");
-        return;
-    };
-
-    let waker = gicr_read_at_rd_base(rd_base, GICR_WAKER);
-    let ctlr = gicr_read_at_rd_base(rd_base, GICR_CTLR);
-    let typer = gicr_read_u64_at_rd_base(rd_base, GICR_TYPER);
-    let syncr = gicr_read_at_rd_base(rd_base, GICR_SYNCR);
-
-    raw_uart_str(" rd_base=");
-    raw_uart_hex(rd_base as u64);
-    raw_uart_str(" waker=");
-    raw_uart_hex(waker as u64);
-    raw_uart_str(" ctlr=");
-    raw_uart_hex(ctlr as u64);
-    raw_uart_str(" typer=");
-    raw_uart_hex(typer);
-    raw_uart_str(" syncr=");
-    raw_uart_hex(syncr as u64);
-    raw_uart_str("\n");
-}
-
-fn record_gic_cpu_audit(
-    cpu_id: usize,
-    mpidr: u64,
-    sre: u64,
-    ctlr: u64,
-    pmr: u64,
-    igrpen1: u64,
-    mismatch: bool,
-) {
-    if cpu_id >= GIC_CPU_AUDIT_SLOTS {
-        return;
-    }
-
-    GIC_CPU_AUDIT_MPIDR[cpu_id].store(mpidr, Ordering::Release);
-    GIC_CPU_AUDIT_SRE[cpu_id].store(sre, Ordering::Release);
-    GIC_CPU_AUDIT_CTLR[cpu_id].store(ctlr, Ordering::Release);
-    GIC_CPU_AUDIT_PMR[cpu_id].store(pmr, Ordering::Release);
-    GIC_CPU_AUDIT_IGRPEN1[cpu_id].store(igrpen1, Ordering::Release);
-    GIC_CPU_AUDIT_MISMATCH[cpu_id].store(if mismatch { 1 } else { 0 }, Ordering::Release);
-    GIC_CPU_AUDIT_VALID[cpu_id].store(true, Ordering::Release);
-}
-
-/// Emit CPU-interface audit values captured when each CPU initialized ICC state.
-///
-/// Secondary CPU boot.S emits raw UART breadcrumbs before Rust reaches the serial
-/// lock, so printing these lines directly from each secondary can corrupt the
-/// `[GIC_CPU_AUDIT]` prefix. This CPU0-owned snapshot keeps the required audit
-/// rows parseable while preserving init-time register values.
-pub fn dump_gic_cpu_audit_snapshot(max_cpus: usize) {
-    let count = max_cpus.min(GIC_CPU_AUDIT_SLOTS);
-    for cpu_id in 0..count {
-        if !GIC_CPU_AUDIT_VALID[cpu_id].load(Ordering::Acquire) {
-            crate::serial_println!("[GIC_CPU_AUDIT] cpu={} missing=1", cpu_id);
-            continue;
-        }
-
-        crate::serial_println!(
-            "[GIC_CPU_AUDIT] cpu={} mpidr={:#x} sre={:#x} ctlr={:#x} pmr={:#x} igrpen1={:#x} mismatch={}",
-            cpu_id,
-            GIC_CPU_AUDIT_MPIDR[cpu_id].load(Ordering::Acquire),
-            GIC_CPU_AUDIT_SRE[cpu_id].load(Ordering::Acquire),
-            GIC_CPU_AUDIT_CTLR[cpu_id].load(Ordering::Acquire),
-            GIC_CPU_AUDIT_PMR[cpu_id].load(Ordering::Acquire),
-            GIC_CPU_AUDIT_IGRPEN1[cpu_id].load(Ordering::Acquire),
-            GIC_CPU_AUDIT_MISMATCH[cpu_id].load(Ordering::Acquire)
-        );
-    }
+    refresh_gicr_rdist_map(max_cpus);
 }
 
 /// Initialize GICv3 Distributor (GICD).
@@ -1816,6 +1382,9 @@ fn init_gicv3_cpu_interface() {
 
         core::arch::asm!("isb", options(nomem, nostack));
 
+        // Parallels requires these ICC readbacks after enabling Group 1. They
+        // are not diagnostic output; removing them has caused userspace spawn
+        // progress to stall after early compositor frames.
         let sre_readback: u64;
         let ctlr_readback: u64;
         let pmr_readback: u64;
@@ -1824,26 +1393,12 @@ fn init_gicv3_cpu_interface() {
         core::arch::asm!("mrs {}, icc_ctlr_el1", out(reg) ctlr_readback, options(nomem, nostack));
         core::arch::asm!("mrs {}, icc_pmr_el1", out(reg) pmr_readback, options(nomem, nostack));
         core::arch::asm!("mrs {}, icc_igrpen1_el1", out(reg) igrpen1_readback, options(nomem, nostack));
-        {
-            let cpu_id = get_cpu_id_from_mpidr();
-            let mpidr = read_mpidr_el1();
-            let sre_enabled = sre_readback & 1;
-            let igrpen1_enabled = igrpen1_readback & 1;
-            let mismatch = sre_enabled != LINUX_EXPECTED_SRE_ENABLED
-                || (ctlr_readback & LINUX_EXPECTED_CTLR_EOIMODE) != LINUX_EXPECTED_CTLR_EOIMODE
-                || pmr_readback != LINUX_EXPECTED_PMR
-                || igrpen1_enabled != LINUX_EXPECTED_IGRPEN1_ENABLED;
-
-            record_gic_cpu_audit(
-                cpu_id,
-                mpidr,
-                sre_readback,
-                ctlr_readback,
-                pmr_readback,
-                igrpen1_readback,
-                mismatch,
-            );
-        }
+        core::hint::black_box((
+            sre_readback,
+            ctlr_readback,
+            pmr_readback,
+            igrpen1_readback,
+        ));
     }
 }
 

--- a/kernel/src/arch_impl/aarch64/gic.rs
+++ b/kernel/src/arch_impl/aarch64/gic.rs
@@ -1014,9 +1014,7 @@ pub fn dump_stuck_state_for_spi(intid: u32) {
 /// SGIs are interrupts 0-15 and are used for IPIs.
 /// `target_cpu` is the CPU ID (0-7), NOT a bitmask.
 pub fn send_sgi(sgi_id: u8, target_cpu: u8) {
-    trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_ENTRY, target_cpu);
     if sgi_id > 15 {
-        trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_EXIT, target_cpu);
         return;
     }
 
@@ -1032,41 +1030,19 @@ pub fn send_sgi(sgi_id: u8, target_cpu: u8) {
         // Bits 27:24 = INTID (SGI number)
         // For simple SMP (CPUs 0-7 in same affinity group):
         let target_list = 1u64 << (target_cpu as u64);
-        trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_AFTER_MPIDR, target_cpu);
         let sgir = ((sgi_id as u64) << 24) | target_list;
-        trace_sgi_boundary(
-            crate::drivers::ahci::AHCI_TRACE_SGI_AFTER_COMPOSE,
-            target_cpu,
-        );
-        trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_BEFORE_MSR, target_cpu);
         unsafe {
             core::arch::asm!("msr icc_sgi1r_el1, {}", in(reg) sgir, options(nomem, nostack));
         }
-        trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_AFTER_MSR, target_cpu);
         unsafe {
             core::arch::asm!("isb", options(nomem, nostack));
         }
-        trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_AFTER_ISB, target_cpu);
     } else {
         // GICv2: Write GICD_SGIR
         let target_mask = 1u32 << (target_cpu as u32);
-        trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_AFTER_MPIDR, target_cpu);
         let sgir = (target_mask << 16) | (sgi_id as u32);
-        trace_sgi_boundary(
-            crate::drivers::ahci::AHCI_TRACE_SGI_AFTER_COMPOSE,
-            target_cpu,
-        );
-        trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_BEFORE_MSR, target_cpu);
         gicd_write(0xF00, sgir);
-        trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_AFTER_MSR, target_cpu);
-        trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_AFTER_ISB, target_cpu);
     }
-    trace_sgi_boundary(crate::drivers::ahci::AHCI_TRACE_SGI_EXIT, target_cpu);
-}
-
-#[inline(always)]
-fn trace_sgi_boundary(site: u32, target_cpu: u8) {
-    crate::drivers::ahci::push_ahci_event(site, 0, 0, 0, 0, 0, 0, target_cpu as u32, 0, false);
 }
 
 /// Check if GIC is initialized

--- a/kernel/src/drivers/ahci/mod.rs
+++ b/kernel/src/drivers/ahci/mod.rs
@@ -3062,10 +3062,6 @@ impl BlockDevice for AhciBlockDevice {
                         chunk,
                         e
                     );
-                    if e == "AHCI: command timeout" {
-                        crate::arch_impl::aarch64::gic::dump_stuck_state_for_spi(34);
-                        dump_recent_ahci_events(Some(self.port_num as u8), 16);
-                    }
                 }
                 BlockError::IoError
             });

--- a/kernel/src/drivers/ahci/mod.rs
+++ b/kernel/src/drivers/ahci/mod.rs
@@ -254,387 +254,6 @@ static AHCI_LAST_ISR_COMPLETE_CMD: AtomicU32 = AtomicU32::new(0);
 static AHCI_LAST_ISR_COMPLETE_WAITER: AtomicU64 = AtomicU64::new(0);
 static AHCI_TIMEOUT_TRACE_DUMPED: AtomicBool = AtomicBool::new(false);
 
-const AHCI_TRACE_CPUS: usize = 8;
-const AHCI_TRACE_LEN: usize = 64;
-pub(crate) const AHCI_TRACE_ENTER: u32 = 1;
-pub(crate) const AHCI_TRACE_POST_CLEAR: u32 = 2;
-pub(crate) const AHCI_TRACE_RETURN: u32 = 3;
-pub(crate) const AHCI_TRACE_BEFORE_COMPLETE: u32 = 4;
-pub(crate) const AHCI_TRACE_AFTER_COMPLETE: u32 = 5;
-pub(crate) const AHCI_TRACE_WAKE_ENTER: u32 = 6;
-pub(crate) const AHCI_TRACE_WAKE_EXIT: u32 = 7;
-pub(crate) const AHCI_TRACE_UNBLOCK_ENTRY: u32 = 8;
-pub(crate) const AHCI_TRACE_UNBLOCK_AFTER_CPU: u32 = 9;
-pub(crate) const AHCI_TRACE_UNBLOCK_AFTER_BUFFER: u32 = 10;
-pub(crate) const AHCI_TRACE_UNBLOCK_AFTER_NEED_RESCHED: u32 = 11;
-pub(crate) const AHCI_TRACE_UNBLOCK_BEFORE_SGI_SCAN: u32 = 12;
-pub(crate) const AHCI_TRACE_UNBLOCK_PER_SGI: u32 = 13;
-pub(crate) const AHCI_TRACE_UNBLOCK_EXIT: u32 = 14;
-pub(crate) const AHCI_TRACE_SGI_ENTRY: u32 = 15;
-pub(crate) const AHCI_TRACE_SGI_AFTER_MPIDR: u32 = 16;
-pub(crate) const AHCI_TRACE_SGI_AFTER_COMPOSE: u32 = 17;
-pub(crate) const AHCI_TRACE_SGI_BEFORE_MSR: u32 = 18;
-pub(crate) const AHCI_TRACE_SGI_AFTER_MSR: u32 = 19;
-pub(crate) const AHCI_TRACE_SGI_AFTER_ISB: u32 = 20;
-pub(crate) const AHCI_TRACE_SGI_EXIT: u32 = 21;
-pub(crate) const AHCI_TRACE_WAKEBUF_BEFORE_PUSH: u32 = 22;
-pub(crate) const AHCI_TRACE_WAKEBUF_AFTER_PUSH: u32 = 23;
-pub(crate) const AHCI_TRACE_SCAN_START: u32 = 24;
-pub(crate) const AHCI_TRACE_SCAN_CPU: u32 = 25;
-pub(crate) const AHCI_TRACE_SCAN_DONE: u32 = 26;
-pub(crate) const AHCI_TRACE_UNBLOCK_BEFORE_SEND_SGI: u32 = 27;
-pub(crate) const AHCI_TRACE_UNBLOCK_AFTER_SEND_SGI: u32 = 28;
-pub(crate) const AHCI_TRACE_TTWU_LOCAL_ENTRY: u32 = 29;
-pub(crate) const AHCI_TRACE_TTWU_LOCAL_SET_RESCHED: u32 = 30;
-pub(crate) const AHCI_TRACE_IRQ_TAIL_CHECK_RESCHED: u32 = 31;
-pub(crate) const AHCI_TRACE_RESCHED_CHECK_ENTRY: u32 = 32;
-pub(crate) const AHCI_TRACE_RESCHED_CHECK_DRAINED_WAKE: u32 = 33;
-pub(crate) const AHCI_TRACE_RESCHED_CHECK_SWITCHED: u32 = 34;
-pub(crate) const AHCI_TRACE_RESCHED_CHECK_RETURN: u32 = 35;
-pub(crate) const AHCI_TRACE_CI_LOOP: u32 = 36;
-
-struct AhciTraceSlot {
-    site: AtomicU32,
-    port: AtomicU32,
-    is: AtomicU32,
-    ci: AtomicU32,
-    sact: AtomicU32,
-    serr: AtomicU32,
-    slot_mask: AtomicU32,
-    cpu_id: AtomicU32,
-    token: AtomicU32,
-    wake_success: AtomicU32,
-    nsec: AtomicU64,
-    waiter_tid: AtomicU64,
-    seq: AtomicU64,
-}
-
-impl AhciTraceSlot {
-    const fn new() -> Self {
-        Self {
-            site: AtomicU32::new(0),
-            port: AtomicU32::new(0),
-            is: AtomicU32::new(0),
-            ci: AtomicU32::new(0),
-            sact: AtomicU32::new(0),
-            serr: AtomicU32::new(0),
-            slot_mask: AtomicU32::new(0),
-            cpu_id: AtomicU32::new(0),
-            token: AtomicU32::new(0),
-            wake_success: AtomicU32::new(0),
-            nsec: AtomicU64::new(0),
-            waiter_tid: AtomicU64::new(0),
-            seq: AtomicU64::new(0),
-        }
-    }
-}
-
-struct AhciTraceRing {
-    head: AtomicU64,
-    slots: [AhciTraceSlot; AHCI_TRACE_LEN],
-}
-
-impl AhciTraceRing {
-    const fn new() -> Self {
-        Self {
-            head: AtomicU64::new(0),
-            slots: [const { AhciTraceSlot::new() }; AHCI_TRACE_LEN],
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-struct AhciTraceSnapshot {
-    site: u32,
-    port: u32,
-    is: u32,
-    ci: u32,
-    sact: u32,
-    serr: u32,
-    slot_mask: u32,
-    cpu_id: u32,
-    token: u32,
-    wake_success: u32,
-    nsec: u64,
-    waiter_tid: u64,
-    seq: u64,
-}
-
-static AHCI_TRACE_RINGS: [AhciTraceRing; AHCI_TRACE_CPUS] =
-    [const { AhciTraceRing::new() }; AHCI_TRACE_CPUS];
-
-#[inline]
-fn current_trace_cpu() -> usize {
-    #[cfg(target_arch = "aarch64")]
-    {
-        let mpidr: u64;
-        unsafe {
-            core::arch::asm!("mrs {}, mpidr_el1", out(reg) mpidr, options(nomem, nostack));
-        }
-        (mpidr & 0xff) as usize
-    }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        0
-    }
-}
-
-#[inline]
-fn trace_now_ns() -> u64 {
-    let (cnt, freq) = read_cntpct_and_freq();
-    if freq == 0 {
-        0
-    } else {
-        ((cnt as u128 * 1_000_000_000u128) / freq as u128) as u64
-    }
-}
-
-#[inline]
-pub(crate) fn push_ahci_event(
-    site: u32,
-    port: u32,
-    is: u32,
-    ci: u32,
-    sact: u32,
-    serr: u32,
-    waiter_tid: u64,
-    slot_mask: u32,
-    token: u32,
-    wake_success: bool,
-) {
-    let actual_cpu = current_trace_cpu() as u32;
-    let ring_cpu = actual_cpu as usize % AHCI_TRACE_CPUS;
-    let ring = &AHCI_TRACE_RINGS[ring_cpu];
-    let seq = ring.head.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
-    let slot = &ring.slots[(seq as usize - 1) % AHCI_TRACE_LEN];
-
-    slot.site.store(0, Ordering::Release);
-    slot.port.store(port, Ordering::Relaxed);
-    slot.is.store(is, Ordering::Relaxed);
-    slot.ci.store(ci, Ordering::Relaxed);
-    slot.sact.store(sact, Ordering::Relaxed);
-    slot.serr.store(serr, Ordering::Relaxed);
-    slot.slot_mask.store(slot_mask, Ordering::Relaxed);
-    slot.cpu_id.store(actual_cpu, Ordering::Relaxed);
-    slot.token.store(token, Ordering::Relaxed);
-    slot.wake_success
-        .store(if wake_success { 1 } else { 0 }, Ordering::Relaxed);
-    slot.nsec.store(trace_now_ns(), Ordering::Relaxed);
-    slot.waiter_tid.store(waiter_tid, Ordering::Relaxed);
-    slot.seq.store(seq, Ordering::Relaxed);
-    slot.site.store(site, Ordering::Release);
-}
-
-fn ahci_trace_site_name(site: u32) -> &'static str {
-    match site {
-        AHCI_TRACE_ENTER => "ENTER",
-        AHCI_TRACE_POST_CLEAR => "POST_CLEAR",
-        AHCI_TRACE_RETURN => "RETURN",
-        AHCI_TRACE_BEFORE_COMPLETE => "BEFORE_COMPLETE",
-        AHCI_TRACE_AFTER_COMPLETE => "AFTER_COMPLETE",
-        AHCI_TRACE_WAKE_ENTER => "WAKE_ENTER",
-        AHCI_TRACE_WAKE_EXIT => "WAKE_EXIT",
-        AHCI_TRACE_UNBLOCK_ENTRY => "UNBLOCK_ENTRY",
-        AHCI_TRACE_UNBLOCK_AFTER_CPU => "UNBLOCK_AFTER_CPU",
-        AHCI_TRACE_UNBLOCK_AFTER_BUFFER => "UNBLOCK_AFTER_BUFFER",
-        AHCI_TRACE_UNBLOCK_AFTER_NEED_RESCHED => "UNBLOCK_AFTER_NEED_RESCHED",
-        AHCI_TRACE_UNBLOCK_BEFORE_SGI_SCAN => "UNBLOCK_BEFORE_SGI_SCAN",
-        AHCI_TRACE_UNBLOCK_PER_SGI => "UNBLOCK_PER_SGI",
-        AHCI_TRACE_UNBLOCK_EXIT => "UNBLOCK_EXIT",
-        AHCI_TRACE_SGI_ENTRY => "SGI_ENTRY",
-        AHCI_TRACE_SGI_AFTER_MPIDR => "SGI_AFTER_MPIDR",
-        AHCI_TRACE_SGI_AFTER_COMPOSE => "SGI_AFTER_COMPOSE",
-        AHCI_TRACE_SGI_BEFORE_MSR => "SGI_BEFORE_MSR",
-        AHCI_TRACE_SGI_AFTER_MSR => "SGI_AFTER_MSR",
-        AHCI_TRACE_SGI_AFTER_ISB => "SGI_AFTER_ISB",
-        AHCI_TRACE_SGI_EXIT => "SGI_EXIT",
-        AHCI_TRACE_WAKEBUF_BEFORE_PUSH => "WAKEBUF_BEFORE_PUSH",
-        AHCI_TRACE_WAKEBUF_AFTER_PUSH => "WAKEBUF_AFTER_PUSH",
-        AHCI_TRACE_SCAN_START => "UNBLOCK_SCAN_START",
-        AHCI_TRACE_SCAN_CPU => "UNBLOCK_SCAN_CPU",
-        AHCI_TRACE_SCAN_DONE => "UNBLOCK_SCAN_DONE",
-        AHCI_TRACE_UNBLOCK_BEFORE_SEND_SGI => "UNBLOCK_BEFORE_SEND_SGI",
-        AHCI_TRACE_UNBLOCK_AFTER_SEND_SGI => "UNBLOCK_AFTER_SEND_SGI",
-        AHCI_TRACE_TTWU_LOCAL_ENTRY => "TTWU_LOCAL_ENTRY",
-        AHCI_TRACE_TTWU_LOCAL_SET_RESCHED => "TTWU_LOCAL_SET_RESCHED",
-        AHCI_TRACE_IRQ_TAIL_CHECK_RESCHED => "IRQ_TAIL_CHECK_RESCHED",
-        AHCI_TRACE_RESCHED_CHECK_ENTRY => "RESCHED_CHECK_ENTRY",
-        AHCI_TRACE_RESCHED_CHECK_DRAINED_WAKE => "RESCHED_CHECK_DRAINED_WAKE",
-        AHCI_TRACE_RESCHED_CHECK_SWITCHED => "RESCHED_CHECK_SWITCHED",
-        AHCI_TRACE_RESCHED_CHECK_RETURN => "RESCHED_CHECK_RETURN",
-        AHCI_TRACE_CI_LOOP => "CI_LOOP",
-        _ => "UNKNOWN",
-    }
-}
-
-fn load_ahci_trace_slot(
-    cpu: usize,
-    index: usize,
-    port_filter: Option<u8>,
-) -> Option<AhciTraceSnapshot> {
-    let slot = &AHCI_TRACE_RINGS[cpu].slots[index];
-    let site = slot.site.load(Ordering::Acquire);
-    if site == 0 {
-        return None;
-    }
-
-    let port = slot.port.load(Ordering::Relaxed);
-    if let Some(filter) = port_filter {
-        if port != filter as u32 {
-            return None;
-        }
-    }
-
-    Some(AhciTraceSnapshot {
-        site,
-        port,
-        is: slot.is.load(Ordering::Relaxed),
-        ci: slot.ci.load(Ordering::Relaxed),
-        sact: slot.sact.load(Ordering::Relaxed),
-        serr: slot.serr.load(Ordering::Relaxed),
-        slot_mask: slot.slot_mask.load(Ordering::Relaxed),
-        cpu_id: slot.cpu_id.load(Ordering::Relaxed),
-        token: slot.token.load(Ordering::Relaxed),
-        wake_success: slot.wake_success.load(Ordering::Relaxed),
-        nsec: slot.nsec.load(Ordering::Relaxed),
-        waiter_tid: slot.waiter_tid.load(Ordering::Relaxed),
-        seq: slot.seq.load(Ordering::Relaxed),
-    })
-}
-
-fn trace_is_before_cursor(event: AhciTraceSnapshot, cursor: Option<(u64, u32, u64)>) -> bool {
-    if let Some((cursor_nsec, cursor_cpu, cursor_seq)) = cursor {
-        event.nsec < cursor_nsec
-            || (event.nsec == cursor_nsec
-                && (event.cpu_id < cursor_cpu
-                    || (event.cpu_id == cursor_cpu && event.seq < cursor_seq)))
-    } else {
-        true
-    }
-}
-
-fn trace_is_after(left: AhciTraceSnapshot, right: AhciTraceSnapshot) -> bool {
-    left.nsec > right.nsec
-        || (left.nsec == right.nsec
-            && (left.cpu_id > right.cpu_id
-                || (left.cpu_id == right.cpu_id && left.seq > right.seq)))
-}
-
-pub fn dump_recent_ahci_events(port_filter: Option<u8>, n: usize) {
-    let mut cursor: Option<(u64, u32, u64)> = None;
-    let mut emitted = 0usize;
-
-    while emitted < n {
-        let mut best: Option<AhciTraceSnapshot> = None;
-        for cpu in 0..AHCI_TRACE_CPUS {
-            for index in 0..AHCI_TRACE_LEN {
-                if let Some(event) = load_ahci_trace_slot(cpu, index, port_filter) {
-                    if trace_is_before_cursor(event, cursor) {
-                        best = match best {
-                            Some(current) if trace_is_after(current, event) => Some(current),
-                            _ => Some(event),
-                        };
-                    }
-                }
-            }
-        }
-
-        let Some(event) = best else {
-            break;
-        };
-
-        crate::serial_println!(
-            "[AHCI_RING] nsec={} site={} cpu={} port={} IS={:#x} CI={:#x} SACT={:#x} SERR={:#x} waiter_tid={} slot_mask={:#x} token={} wake_success={} seq={}",
-            event.nsec,
-            ahci_trace_site_name(event.site),
-            event.cpu_id,
-            event.port,
-            event.is,
-            event.ci,
-            event.sact,
-            event.serr,
-            event.waiter_tid,
-            event.slot_mask,
-            event.token,
-            event.wake_success,
-            event.seq,
-        );
-
-        cursor = Some((event.nsec, event.cpu_id, event.seq));
-        emitted += 1;
-    }
-
-    if emitted == 0 {
-        crate::serial_println!(
-            "[AHCI_RING] no events port_filter={}",
-            port_filter.map_or(255u32, |port| port as u32)
-        );
-    }
-}
-
-fn is_sgi_target_trace_site(site: u32) -> bool {
-    matches!(
-        site,
-        AHCI_TRACE_UNBLOCK_PER_SGI
-            | AHCI_TRACE_UNBLOCK_BEFORE_SEND_SGI
-            | AHCI_TRACE_UNBLOCK_AFTER_SEND_SGI
-            | AHCI_TRACE_SGI_ENTRY
-            | AHCI_TRACE_SGI_AFTER_MPIDR
-            | AHCI_TRACE_SGI_AFTER_COMPOSE
-            | AHCI_TRACE_SGI_BEFORE_MSR
-            | AHCI_TRACE_SGI_AFTER_MSR
-            | AHCI_TRACE_SGI_AFTER_ISB
-            | AHCI_TRACE_SGI_EXIT
-    )
-}
-
-pub(crate) fn collect_recent_sgi_targets(out: &mut [u8]) -> usize {
-    let mut count = 0usize;
-
-    for cpu in 0..AHCI_TRACE_CPUS {
-        for index in 0..AHCI_TRACE_LEN {
-            let Some(event) = load_ahci_trace_slot(cpu, index, None) else {
-                continue;
-            };
-
-            if !is_sgi_target_trace_site(event.site) {
-                continue;
-            }
-
-            let target = event.slot_mask as usize;
-            if target >= AHCI_TRACE_CPUS {
-                continue;
-            }
-
-            if out[..count].iter().any(|seen| *seen as usize == target) {
-                continue;
-            }
-
-            if count == out.len() {
-                return count;
-            }
-
-            out[count] = target as u8;
-            count += 1;
-        }
-    }
-
-    count
-}
-
-pub fn port0_is_snapshot() -> Option<u32> {
-    port_is_snapshot(0)
-}
-
-pub fn port_is_snapshot(port: usize) -> Option<u32> {
-    let abar = AHCI_ABAR.load(Ordering::Relaxed);
-    if abar == 0 {
-        None
-    } else {
-        Some(port_read(abar, port, PORT_IS))
-    }
-}
-
 /// Per-port I/O serialisation lock.
 ///
 /// Serialises transitions of `PORT_IO_IN_PROGRESS` and short setup/finish
@@ -2738,20 +2357,6 @@ pub fn handle_interrupt() {
         if is == 0 && (active_entry & !ci_entry) == 0 {
             continue;
         }
-        let sact_entry = port_read(abar, port, PORT_SACT);
-        let serr_entry = port_read(abar, port, PORT_SERR);
-        push_ahci_event(
-            AHCI_TRACE_ENTER,
-            port as u32,
-            is,
-            ci_entry,
-            sact_entry,
-            serr_entry,
-            AHCI_COMPLETIONS[port][0].waiter_tid(),
-            active_entry,
-            PORT_ACTIVE_CMD_NUM[port].load(Ordering::Acquire),
-            false,
-        );
         if is != 0 {
             AHCI_ISR_PORT_HIT[port].fetch_add(1, Ordering::Relaxed);
         }
@@ -2759,9 +2364,6 @@ pub fn handle_interrupt() {
             AHCI_LAST_ISR_PORT1_IS.store(is, Ordering::Relaxed);
         }
 
-        let mut waiter_tid = 0u64;
-        let mut wake_success = false;
-        let mut slots_processed = 0u32;
         let mut loop_iterations = 0u32;
         // Slot 0 is the only issued slot today. Defer the wake until after
         // PORT_IS has been acknowledged and the CI drain loop is stable, so the
@@ -2769,15 +2371,8 @@ pub fn handle_interrupt() {
         // is still asserted.
         let mut pending_cmd_num = 0u32;
         let mut pending_waiter_tid = 0u64;
-        let mut pending_slot_bit = 0u32;
-        let mut pending_is = 0u32;
-        let mut pending_ci = 0u32;
-        let mut pending_sact = 0u32;
-        let mut pending_serr = 0u32;
         let mut is_after_clear: u32;
         let mut ci_after_clear: u32;
-        let mut sact_after_clear: u32;
-        let mut serr_after_clear: u32;
 
         loop {
             loop_iterations += 1;
@@ -2788,24 +2383,9 @@ pub fn handle_interrupt() {
             }
 
             let ci = port_read(abar, port, PORT_CI);
-            let sact = port_read(abar, port, PORT_SACT);
-            let serr = port_read(abar, port, PORT_SERR);
             let active_mask =
                 PORT_ACTIVE_MASK[port].load(Ordering::Acquire) & AHCI_TRACKED_SLOT_MASK;
             let completed_slots = detect_completed_slots(active_mask, ci, sampled_is);
-
-            push_ahci_event(
-                AHCI_TRACE_CI_LOOP,
-                port as u32,
-                sampled_is,
-                ci,
-                sact,
-                serr,
-                AHCI_COMPLETIONS[port][0].waiter_tid(),
-                completed_slots,
-                loop_iterations,
-                completed_slots != 0,
-            );
 
             let mut remaining = completed_slots;
             while remaining != 0 {
@@ -2819,8 +2399,6 @@ pub fn handle_interrupt() {
                     continue;
                 }
 
-                slots_processed += 1;
-
                 // The current driver issues only slot 0. The arrays are sized
                 // for future multi-slot work, but only slot 0 has a command
                 // token to publish back to wait_cmd_slot0().
@@ -2829,39 +2407,18 @@ pub fn handle_interrupt() {
                     if port == 1 {
                         AHCI_LAST_ISR_PORT1_CMD_NUM.store(cmd_num, Ordering::Relaxed);
                     }
-                    waiter_tid = AHCI_COMPLETIONS[port][slot].waiter_tid();
                     if cmd_num != 0 {
                         pending_cmd_num = cmd_num;
-                        pending_waiter_tid = waiter_tid;
-                        pending_slot_bit = slot_bit;
-                        pending_is = sampled_is;
-                        pending_ci = ci;
-                        pending_sact = sact;
-                        pending_serr = serr;
+                        pending_waiter_tid = AHCI_COMPLETIONS[port][slot].waiter_tid();
                     }
                 }
             }
 
             is_after_clear = port_read(abar, port, PORT_IS);
             ci_after_clear = port_read(abar, port, PORT_CI);
-            sact_after_clear = port_read(abar, port, PORT_SACT);
-            serr_after_clear = port_read(abar, port, PORT_SERR);
             let active_after =
                 PORT_ACTIVE_MASK[port].load(Ordering::Acquire) & AHCI_TRACKED_SLOT_MASK;
             let completed_after_clear = active_after & !ci_after_clear;
-
-            push_ahci_event(
-                AHCI_TRACE_POST_CLEAR,
-                port as u32,
-                is_after_clear,
-                ci_after_clear,
-                sact_after_clear,
-                serr_after_clear,
-                waiter_tid,
-                completed_after_clear,
-                loop_iterations,
-                completed_after_clear != 0,
-            );
 
             if loop_iterations >= AHCI_CI_COMPLETION_LOOP_LIMIT {
                 break;
@@ -2876,48 +2433,9 @@ pub fn handle_interrupt() {
             AHCI_LAST_ISR_COMPLETE_PORT.store(port as u32, Ordering::Relaxed);
             AHCI_LAST_ISR_COMPLETE_CMD.store(pending_cmd_num, Ordering::Relaxed);
             AHCI_LAST_ISR_COMPLETE_WAITER.store(pending_waiter_tid, Ordering::Relaxed);
-            push_ahci_event(
-                AHCI_TRACE_BEFORE_COMPLETE,
-                port as u32,
-                pending_is,
-                pending_ci,
-                pending_sact,
-                pending_serr,
-                pending_waiter_tid,
-                pending_slot_bit,
-                pending_cmd_num,
-                false,
-            );
             AHCI_COMPLETIONS[port][0].complete(pending_cmd_num);
-            push_ahci_event(
-                AHCI_TRACE_AFTER_COMPLETE,
-                port as u32,
-                pending_is,
-                pending_ci,
-                pending_sact,
-                pending_serr,
-                pending_waiter_tid,
-                pending_slot_bit,
-                pending_cmd_num,
-                false,
-            );
             AHCI_ISR_COMPLETE_HIT[port].fetch_add(1, Ordering::Relaxed);
-            waiter_tid = pending_waiter_tid;
-            wake_success |= pending_waiter_tid != 0;
         }
-
-        push_ahci_event(
-            AHCI_TRACE_RETURN,
-            port as u32,
-            is_after_clear,
-            ci_after_clear,
-            sact_after_clear,
-            serr_after_clear,
-            waiter_tid,
-            slots_processed,
-            loop_iterations,
-            wake_success,
-        );
     }
 
     // For edge-triggered MSI: clear the SPI pending bit to re-arm.

--- a/kernel/src/main_aarch64.rs
+++ b/kernel/src/main_aarch64.rs
@@ -961,9 +961,6 @@ pub extern "C" fn kernel_main(hw_config_ptr: u64) -> ! {
             "[smp] {} CPUs online",
             kernel::arch_impl::aarch64::smp::cpus_online()
         );
-        kernel::arch_impl::aarch64::gic::dump_gic_cpu_audit_snapshot(
-            kernel::arch_impl::aarch64::smp::cpus_online() as usize,
-        );
         kernel::arch_impl::aarch64::gic::init_gicr_rdist_map(
             kernel::arch_impl::aarch64::smp::cpus_online() as usize,
         );

--- a/kernel/src/task/completion.rs
+++ b/kernel/src/task/completion.rs
@@ -492,33 +492,7 @@ impl Completion {
 
         let tid = self.waiter.load(Ordering::Acquire);
         if tid != 0 {
-            #[cfg(target_arch = "aarch64")]
-            crate::drivers::ahci::push_ahci_event(
-                crate::drivers::ahci::AHCI_TRACE_WAKE_ENTER,
-                0,
-                0,
-                0,
-                0,
-                0,
-                tid,
-                0,
-                token,
-                false,
-            );
             crate::task::scheduler::isr_unblock_for_io(tid);
-            #[cfg(target_arch = "aarch64")]
-            crate::drivers::ahci::push_ahci_event(
-                crate::drivers::ahci::AHCI_TRACE_WAKE_EXIT,
-                0,
-                0,
-                0,
-                0,
-                0,
-                tid,
-                0,
-                token,
-                false,
-            );
         }
     }
 }

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -160,18 +160,6 @@ static CPU_IS_IDLE: [AtomicBool; MAX_CPUS] = [
     AtomicBool::new(false),
 ];
 
-#[cfg(target_arch = "aarch64")]
-static F17_RESCHED_TRACE_BUDGET: [AtomicU64; MAX_CPUS] = [
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-    AtomicU64::new(0),
-];
-
 /// Counter for unblock() calls - used for testing pipe wake mechanism
 /// This is a global atomic because:
 /// 1. unblock() is called via with_scheduler() which already holds the scheduler lock
@@ -939,24 +927,8 @@ impl Scheduler {
             for buf in ISR_WAKEUP_BUFFERS.iter() {
                 buf.drain(&mut wakeups);
             }
-            let drained_count = wakeups.len();
             for tid in wakeups {
                 self.unblock_for_io(tid);
-            }
-            #[cfg(target_arch = "aarch64")]
-            if take_f17_resched_trace_budget(cpu) {
-                crate::drivers::ahci::push_ahci_event(
-                    crate::drivers::ahci::AHCI_TRACE_RESCHED_CHECK_DRAINED_WAKE,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    drained_count as u64,
-                    self.ready_queue_length() as u32,
-                    if is_need_resched() { 1 } else { 0 },
-                    drained_count != 0,
-                );
             }
         }
 
@@ -2567,36 +2539,6 @@ pub fn isr_wakeup_depth(cpu: usize) -> usize {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
-pub fn arm_f17_resched_trace(cpu: usize) {
-    if cpu < F17_RESCHED_TRACE_BUDGET.len() {
-        F17_RESCHED_TRACE_BUDGET[cpu].store(16, Ordering::Release);
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-pub fn take_f17_resched_trace_budget(cpu: usize) -> bool {
-    if cpu >= F17_RESCHED_TRACE_BUDGET.len() {
-        return false;
-    }
-
-    let budget = &F17_RESCHED_TRACE_BUDGET[cpu];
-    let mut current = budget.load(Ordering::Acquire);
-    while current != 0 {
-        match budget.compare_exchange_weak(
-            current,
-            current - 1,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
-            Ok(_) => return true,
-            Err(next) => current = next,
-        }
-    }
-
-    false
-}
-
 /// Lock-free ISR wakeup: push thread ID to per-CPU wakeup buffer.
 ///
 /// Called from the AHCI ISR (via `Completion::complete()`) instead of
@@ -2608,135 +2550,14 @@ pub fn take_f17_resched_trace_budget(cpu: usize) -> bool {
 /// The scheduler drains the buffer under its own lock at the top of every
 /// `schedule_deferred_requeue()` / `schedule()` call.
 pub fn isr_unblock_for_io(tid: u64) {
-    #[cfg(target_arch = "aarch64")]
-    crate::drivers::ahci::push_ahci_event(
-        crate::drivers::ahci::AHCI_TRACE_UNBLOCK_ENTRY,
-        0,
-        0,
-        0,
-        0,
-        0,
-        tid,
-        0,
-        0,
-        false,
-    );
     let cpu = current_cpu_id_raw();
-    #[cfg(target_arch = "aarch64")]
-    arm_f17_resched_trace(cpu);
-    #[cfg(target_arch = "aarch64")]
-    crate::drivers::ahci::push_ahci_event(
-        crate::drivers::ahci::AHCI_TRACE_TTWU_LOCAL_ENTRY,
-        0,
-        0,
-        0,
-        0,
-        0,
-        tid,
-        isr_wakeup_depth(cpu) as u32,
-        if is_need_resched() { 1 } else { 0 },
-        false,
-    );
-    #[cfg(target_arch = "aarch64")]
-    crate::drivers::ahci::push_ahci_event(
-        crate::drivers::ahci::AHCI_TRACE_UNBLOCK_AFTER_CPU,
-        0,
-        0,
-        0,
-        0,
-        0,
-        tid,
-        0,
-        0,
-        false,
-    );
     if cpu < ISR_WAKEUP_BUFFERS.len() {
-        #[cfg(target_arch = "aarch64")]
-        crate::drivers::ahci::push_ahci_event(
-            crate::drivers::ahci::AHCI_TRACE_WAKEBUF_BEFORE_PUSH,
-            0,
-            0,
-            0,
-            0,
-            0,
-            tid,
-            0,
-            0,
-            false,
-        );
         ISR_WAKEUP_BUFFERS[cpu].push(tid);
-        #[cfg(target_arch = "aarch64")]
-        crate::drivers::ahci::push_ahci_event(
-            crate::drivers::ahci::AHCI_TRACE_WAKEBUF_AFTER_PUSH,
-            0,
-            0,
-            0,
-            0,
-            0,
-            tid,
-            0,
-            0,
-            false,
-        );
     }
-    #[cfg(target_arch = "aarch64")]
-    crate::drivers::ahci::push_ahci_event(
-        crate::drivers::ahci::AHCI_TRACE_UNBLOCK_AFTER_BUFFER,
-        0,
-        0,
-        0,
-        0,
-        0,
-        tid,
-        0,
-        0,
-        false,
-    );
     set_need_resched();
-    #[cfg(target_arch = "aarch64")]
-    arm_f17_resched_trace(cpu);
-    #[cfg(target_arch = "aarch64")]
-    crate::drivers::ahci::push_ahci_event(
-        crate::drivers::ahci::AHCI_TRACE_TTWU_LOCAL_SET_RESCHED,
-        0,
-        0,
-        0,
-        0,
-        0,
-        tid,
-        isr_wakeup_depth(cpu) as u32,
-        if is_need_resched() { 1 } else { 0 },
-        true,
-    );
-    #[cfg(target_arch = "aarch64")]
-    crate::drivers::ahci::push_ahci_event(
-        crate::drivers::ahci::AHCI_TRACE_UNBLOCK_AFTER_NEED_RESCHED,
-        0,
-        0,
-        0,
-        0,
-        0,
-        tid,
-        0,
-        0,
-        false,
-    );
     // The current CPU will drain the wake buffer on IRQ-return scheduling.
     // Avoid broadcasting reschedule SGIs from hard IRQ context; Linux's TTWU
     // path queues wake work to a selected target CPU rather than scanning idle CPUs.
-    #[cfg(target_arch = "aarch64")]
-    crate::drivers::ahci::push_ahci_event(
-        crate::drivers::ahci::AHCI_TRACE_UNBLOCK_EXIT,
-        0,
-        0,
-        0,
-        0,
-        0,
-        tid,
-        0,
-        0,
-        false,
-    );
 }
 
 /// Read the current CPU ID directly from hardware (MPIDR_EL1 on ARM64).

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -336,10 +336,6 @@ name = "hello_time"
 path = "src/hello_time.rs"
 
 [[bin]]
-name = "hello_raw"
-path = "src/hello_raw.rs"
-
-[[bin]]
 name = "http_test"
 path = "src/http_test.rs"
 

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -192,7 +192,6 @@ STD_BINARIES=(
     "simple_exit"
     "counter"
     "spinner"
-    "hello_raw"
     "hello_time"
     "fbinfo_test"
     "demo"

--- a/userspace/programs/src/hello_raw.rs
+++ b/userspace/programs/src/hello_raw.rs
@@ -1,9 +1,0 @@
-//! Minimal raw-write post-exec diagnostic for ARM64.
-
-use libbreenix::{io, process, Fd};
-
-fn main() {
-    let _ = io::write(Fd::STDOUT, b"[hello_raw] start\n");
-    process::exit(42);
-}
-


### PR DESCRIPTION
## Summary
- surveyed F30 diagnostic scaffolding in docs/planning/f30-cleanup/survey.md
- removed scheduler/AHCI breadcrumb pushes, SGI trace boundaries, GIC stuck/audit/map dump output, AHCI trace ring, and hello_raw probe registration
- retained post-enable ICC readbacks after validation showed removing them stalls boot before init completion

## Validation
- cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64
- cargo build --release --features testing,external_test_bins --bin qemu-uefi
- userspace/programs/build.sh --arch aarch64
- scripts/create_ext2_disk.sh --arch aarch64 (confirmed no hello_raw in rebuilt ext2 log)
- final isolated 120s Parallels sweep: strict verdict PASS, [init] Boot script completed, bounce started, no SOFT_LOCKUP/panic/removed diagnostic markers, frame #32500 at tick 195000 => 166.67 FPS

Note: isolated f30cleanup-* VMs were used instead of run.sh during validation to avoid deleting sibling factory breenix-* VMs.