### PR TITLE
docs(kernel): F32i CPU0 WFI wake diagnosis

### DIFF
--- a/docs/planning/f32-waitqueue/design.md
+++ b/docs/planning/f32-waitqueue/design.md
@@ -1,0 +1,333 @@
+# F32 WaitQueue Design
+
+## Context
+
+F32 replaces the compositor's ad-hoc waiting protocol with a scheduler-integrated
+waitqueue primitive. The immediate target is `compositor_wait` in
+`kernel/src/syscall/graphics.rs`, which currently publishes
+`COMPOSITOR_WAITING_THREAD`, blocks with `BlockedOnTimer`, and relies on a 5 ms
+fallback timer when an event wake is missed.
+
+F31 established that F28's seqlock-style wake handshake was the wrong layer. It
+sat outside the scheduler's existing `BlockedOnIO` and `isr_unblock_for_io`
+machinery, so waiter publication and wake delivery disagreed under AArch64 SMP.
+The replacement should look more like Linux waitqueues: the waiter is enrolled
+and put into a scheduler sleep state before the condition is rechecked, and the
+waker drives the scheduler's normal wake path.
+
+## Linux Reference
+
+Linux splits waitqueues into two structures:
+
+- `wait_queue_head`: a spinlock plus a linked list of wait entries.
+- `wait_queue_entry`: a per-waiter node containing the task pointer, flags, wake
+  function, and list linkage.
+
+The important semantics are in `prepare_to_wait`, `finish_wait`, and
+`__wake_up`:
+
+1. `prepare_to_wait` takes the waitqueue lock, adds the entry if it is not
+   already queued, sets the task state, then unlocks. Linux intentionally sets
+   the task state after queue insertion so the state-setting barrier pairs with
+   wake-side checks.
+2. The waiter checks the condition after `prepare_to_wait`.
+3. If the condition is still false, the waiter calls `schedule`.
+4. `wake_up` takes the same queue lock and calls each waiter's wake function.
+   The default wake function routes through the scheduler's task wake path.
+5. `finish_wait` sets the current task running and removes the wait entry if it
+   remains queued.
+
+The race closure is structural: a wake that lands after queue insertion but
+before the condition check sets the task runnable. The later `schedule` does not
+sleep a runnable task.
+
+## Breenix Existing Primitives
+
+### Thread States
+
+`kernel/src/task/thread.rs` currently has:
+
+- `Running`
+- `Ready`
+- `Blocked`
+- `BlockedOnSignal`
+- `BlockedOnChildExit`
+- `BlockedOnTimer`
+- `BlockedOnIO`
+- `Terminated`
+
+For F32, waitqueues should initially use `BlockedOnIO` for event-driven
+syscall waits. This is not semantically perfect for compositor events, but it is
+the only state today with the correct F16 wake delivery path:
+
+- `Scheduler::block_current_for_io_with_timeout(None)` marks the current thread
+  `BlockedOnIO`, sets `blocked_in_syscall = true`, clears `wake_time_ns`, and
+  removes it from ready queues.
+- `Scheduler::unblock_for_io(tid)` transitions `BlockedOnIO` to `Ready`, keeps
+  `blocked_in_syscall` set for the waiter to clear after resuming, avoids
+  double-scheduling if the thread is still current on a CPU or in deferred
+  requeue, sends a reschedule IPI on AArch64, and sets `need_resched`.
+- `isr_unblock_for_io(tid)` is the lock-free ISR entry point. It enqueues the
+  TID into per-CPU atomic wake buffers that the scheduler drains before making a
+  scheduling decision.
+
+### Completion
+
+`kernel/src/task/completion.rs` already implements a one-waiter special case
+that resembles a waitqueue:
+
+- A `done` token is published before wake.
+- A `waiter` TID is stored before sleeping.
+- The syscall sleep path uses `block_current_for_io_with_timeout`.
+- `complete()` wakes with `isr_unblock_for_io(tid)`.
+
+Completion should not be migrated in the first F32 implementation unless the
+waitqueue primitive proves stable under the compositor migration. It carries
+timeout and early-boot spin paths that would expand the blast radius.
+
+### Current Compositor Wait
+
+The compositor path has two separate waits:
+
+- Client-side frame pacing in op 15 (`mark_window_dirty`) blocks the client
+  until BWM consumes the frame. It currently stores `waiting_thread_id` in the
+  `WindowBuffer` and sleeps with `block_current_for_compositor(timeout_ns)`,
+  which is a `BlockedOnTimer` fallback path.
+- BWM-side op 23 (`compositor_wait`) blocks until a dirty window, mouse input,
+  keyboard/input latch, or registry change. It currently uses
+  `COMPOSITOR_WAITING_THREAD`, `COMPOSITOR_DIRTY_WAKE`, and
+  `block_current_for_compositor(timeout_ns)`.
+
+F32's required migration target is the BWM-side `compositor_wait` and its wake
+producers. The client frame-pacing path is adjacent and still timer-backed; it
+should remain out of scope unless the migration explicitly expands after the
+required validation passes.
+
+## Proposed API
+
+Add `kernel/src/task/waitqueue.rs`:
+
+```rust
+pub struct WaitQueueHead {
+    waiters: SpinLock<WaitQueueState>,
+}
+
+struct WaitQueueState {
+    waiters: VecDeque<Waiter>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Waiter {
+    tid: u64,
+}
+```
+
+The user request names `IntrusiveList<Waiter>`. Breenix does not currently have
+a general intrusive list primitive in `kernel/src`, and a waitqueue entry whose
+lifetime lives on the caller's stack is awkward in safe Rust. The first
+implementation should use a bounded, duplicate-free queue of TIDs behind a
+spinlock. That preserves the Linux semantics that matter for Breenix:
+
+- one logical wait entry per waiting thread per queue;
+- queue mutation is serialized;
+- wake routes to the scheduler;
+- finish removes a stale waiter.
+
+If waitqueue contention or allocation becomes a concern, the internals can later
+be replaced with an intrusive node type without changing callers.
+
+Public methods:
+
+```rust
+impl WaitQueueHead {
+    pub const fn new() -> Self;
+    pub fn prepare_to_wait(&self, state: ThreadState) -> Option<u64>;
+    pub fn finish_wait(&self);
+    pub fn wake_up(&self);
+    pub fn wake_up_one(&self);
+    pub fn has_waiters(&self) -> bool;
+}
+```
+
+`prepare_to_wait` returns the current TID on success so callers can keep local
+diagnostics if needed. It accepts a `ThreadState` because Linux accepts a task
+state, but F32 should only support `ThreadState::BlockedOnIO` initially. Other
+states can return `None` or fall back to a private scheduler method only when
+there is a concrete caller. Supporting every blocked state on day one would
+duplicate scheduler policy.
+
+## Prepare, Schedule, Finish Semantics
+
+Breenix callers should follow this pattern:
+
+```rust
+loop {
+    waitq.prepare_to_wait(ThreadState::BlockedOnIO);
+    if condition_is_ready() {
+        break;
+    }
+    waitqueue::schedule_current_wait();
+}
+waitq.finish_wait();
+```
+
+`prepare_to_wait(BlockedOnIO)` must perform the queue insertion and scheduler
+state transition without a missed-wake gap:
+
+1. Get `current_thread_id`.
+2. Take the waitqueue lock and insert the TID if it is not already present.
+3. While still in the same high-level prepare operation, call
+   `scheduler::with_scheduler` and set the current thread to `BlockedOnIO`.
+4. The caller checks the condition after prepare.
+
+There are two lock-order options:
+
+- Waitqueue lock then scheduler lock.
+- Scheduler lock then waitqueue lock.
+
+F32 should use waitqueue lock then scheduler lock and document that scheduler
+code must not call back into waitqueue while holding `SCHEDULER`. Wakers do not
+take the scheduler lock directly when using `isr_unblock_for_io`; they only push
+TIDs into F16's lock-free ISR buffer. That keeps wake paths compatible with IRQ
+context and avoids adding a scheduler-lock dependency to input handlers.
+
+After the condition check, `schedule_current_wait()` should enable preemption
+for syscall callers and enter the same sleep path used by completion:
+
+- On AArch64, use `schedule_from_kernel()` for a true scheduler switch where
+  possible.
+- On non-AArch64, use `halt_with_interrupts()`.
+
+The existing compositor code currently loops around `yield_current()` and
+`arch_halt_with_interrupts()`. That path specifically needs validation because
+F31 called out `Aarch64Cpu::halt_with_interrupts()` as a failure path for long
+syscall waits. The waitqueue primitive should provide a shared helper so the
+compositor does not hand-roll another wait loop.
+
+`finish_wait` should:
+
+1. Remove the current TID from the queue if still present.
+2. If the current thread is still in the wait state, mark it `Ready`.
+3. Clear `blocked_in_syscall` only after the caller has resumed and is ready to
+   return from the syscall.
+
+The final state normalization mirrors Linux `finish_wait`, but in Breenix the
+`blocked_in_syscall` flag is deliberately owned by the sleeping syscall, not by
+the wake side.
+
+## Wake-Up Integration With F16
+
+`wake_up` and `wake_up_one` should be implemented as queue operations plus F16
+wake delivery:
+
+1. Take the waitqueue lock.
+2. Pop all waiters for `wake_up`, or one waiter for `wake_up_one`.
+3. Drop the waitqueue lock.
+4. For each TID, call `scheduler::isr_unblock_for_io(tid)`.
+
+Using `isr_unblock_for_io` even from non-ISR contexts is intentional for the
+first version:
+
+- It is lock-free and therefore safe for input interrupt producers.
+- It centralizes wake delivery in the scheduler drain path.
+- It avoids calling `Scheduler::unblock` from graphics/input code while holding
+  unrelated locks.
+- It preserves F16's deferred-requeue and current-on-CPU safety checks.
+
+The tradeoff is wake latency: the TID becomes runnable when the scheduler next
+drains the ISR wake buffers. Existing F16 paths already depend on that behavior,
+and `isr_unblock_for_io` requests rescheduling on AArch64.
+
+## Compositor Migration Plan
+
+Add:
+
+```rust
+#[cfg(target_arch = "aarch64")]
+static COMPOSITOR_FRAME_WQ: WaitQueueHead = WaitQueueHead::new();
+```
+
+Replace `COMPOSITOR_WAITING_THREAD` as the BWM-side waiter registry:
+
+| Current path | F32 path |
+| --- | --- |
+| `wake_compositor_if_waiting()` loads `COMPOSITOR_WAITING_THREAD` and calls `sched.unblock(tid)` | call `COMPOSITOR_FRAME_WQ.wake_up()` |
+| op 12 registry change manually unblocks BWM | bump `REGISTRY_GENERATION`, call `COMPOSITOR_FRAME_WQ.wake_up()` |
+| op 15 dirty wake stores `COMPOSITOR_DIRTY_WAKE` and manually unblocks BWM | store `COMPOSITOR_DIRTY_WAKE`, call `COMPOSITOR_FRAME_WQ.wake_up()` |
+| `cleanup_windows_for_pid` wakes via `wake_compositor_if_waiting()` | call the same waitqueue-backed helper |
+| op 23 publishes `COMPOSITOR_WAITING_THREAD`, blocks with `block_current_for_compositor(timeout_ns)`, waits for timeout or wake | prepare on `COMPOSITOR_FRAME_WQ`, recheck dirty/input/registry, schedule only if still not ready, finish |
+
+The 5 ms fallback timer must be removed from op 23. `timeout_ms` can remain an
+ABI argument, but the migrated implementation should not convert it into a
+fallback timer for the compositor wait. The syscall should block until an actual
+dirty/input/registry event wakes the waitqueue, then recheck and return the
+ready bitmask.
+
+The existing `COMPOSITOR_LAST_WAKE_NS` / `MIN_FRAME_INTERVAL_NS` pacing sleep is
+separate from the missed-wake fallback. It is CPU/FPS pacing, not event
+delivery. For the strictest reading of "remove the 5ms fallback timer entirely,"
+F32 should remove only the event wait fallback and keep pacing only if it does
+not block event wake delivery. If validation shows pacing sleep can mask event
+wakes, it should also move to a waitqueue-aware sleep or be removed.
+
+## Race Closure
+
+For `compositor_wait`, the race-safe sequence is:
+
+1. Compute current condition bits.
+2. If nonzero, return.
+3. `COMPOSITOR_FRAME_WQ.prepare_to_wait(BlockedOnIO)`.
+4. Recompute condition bits.
+5. If nonzero, `finish_wait` and return.
+6. Enable preemption and schedule/halt until the scheduler wake path changes
+   this thread back to `Ready`.
+7. Disable preemption, restore address space, `finish_wait`.
+8. Recompute condition bits and return.
+
+If a producer wakes between steps 3 and 4, the queue contains this TID and the
+thread is already `BlockedOnIO`. `wake_up` removes the TID and pushes it through
+`isr_unblock_for_io`; when drained, `unblock_for_io` marks the thread `Ready`.
+The post-prepare condition check sees the event. If the caller still reaches the
+schedule helper before the scheduler drain, the scheduler drain executes before
+the next scheduling decision and makes the thread runnable.
+
+## Tests
+
+Unit-level coverage should focus on queue semantics that can be checked without
+booting QEMU:
+
+- duplicate `prepare_to_wait` for the same TID does not duplicate queue entries;
+- `wake_up_one` removes one waiter;
+- `wake_up` drains all waiters;
+- `finish_wait` removes the current waiter if still queued.
+
+The true race closure is a system property involving scheduler state,
+preemption, and AArch64 wake delivery. It must be validated by the Phase 4 boot
+sweep rather than treated as proven by unit tests.
+
+## Migration Candidates Beyond Compositor
+
+| Path | Candidate? | Notes |
+| --- | --- | --- |
+| BWM `compositor_wait` | Yes, Phase 3 target | Direct event wait with current missed-wake fallback. |
+| Compositor input/registry/dirty producers | Yes, Phase 3 target | Wakers should use `wake_up`. |
+| `Completion` | Maybe, Phase 5 only | Already uses `BlockedOnIO` and `isr_unblock_for_io`, but includes token, timeout, signal, and early-boot spin behavior. |
+| Socket accept/recv waits | Later | Good fit after waitqueue survives compositor validation. |
+| Pipes/stdin waiters | Later | Likely fit, but may need wake-one semantics and signal interruption. |
+| Child exit and signal waits | Later | Need state-specific semantics; do not fold into first waitqueue patch. |
+
+## Validation Requirements
+
+Phase 4 must prove that F32 did not repeat F28:
+
+- clean AArch64 build;
+- five 120-second Parallels runs, all passing the requested serial and FPS
+  criteria;
+- CPU0 `tick_count > 1000` in the end-state audit;
+- no AHCI timeout;
+- `scripts/f23-render-verdict.sh` passes;
+- a long syscall-wait smoke that exercises `Aarch64Cpu::halt_with_interrupts()`
+  while bounce is rendering.
+
+If any sweep run fails, the branch should stop before PR/merge and record the
+failure signature.

--- a/docs/planning/f32-waitqueue/exit.md
+++ b/docs/planning/f32-waitqueue/exit.md
@@ -1,0 +1,125 @@
+# F32 WaitQueue Factory Exit
+
+Date: 2026-04-18
+Branch: `f32-waitqueue-compositor`
+Base: `dedbbb88`
+
+## Result
+
+F32 did not pass the Phase 4 validation gate. The branch contains the design,
+waitqueue primitive, and compositor migration commits, but it must not be
+merged.
+
+Validation stopped after the first rebuilt 120-second Parallels run because the
+boot reached BWM and bsshd, then stalled while spawning `/bin/bounce`. This
+violates the hard lifecycle requirement for bounce and leaves no valid FPS or
+CPU0 end-state audit sample.
+
+## Commits Completed
+
+| Phase | Commit | Status |
+| --- | --- | --- |
+| Phase 1 design | `f7fcc191 design(kernel): F32 waitqueue design document` | Complete |
+| Phase 2 primitive | `653d7253 feat(kernel): F32 WaitQueueHead primitive` | Builds clean |
+| Phase 3 migration | `8a2e9885 feat(gui): F32 migrate compositor wait to waitqueue` | Builds clean, validation failed |
+| Phase 5 optional migration | none | Deferred |
+
+## Design Excerpt
+
+From `docs/planning/f32-waitqueue/design.md`:
+
+> F32 replaces the compositor's ad-hoc waiting protocol with a scheduler-integrated
+> waitqueue primitive. The immediate target is `compositor_wait` in
+> `kernel/src/syscall/graphics.rs`, which currently publishes
+> `COMPOSITOR_WAITING_THREAD`, blocks with `BlockedOnTimer`, and relies on a 5 ms
+> fallback timer when an event wake is missed.
+
+The implemented primitive followed the design direction:
+
+- `WaitQueueHead` stores duplicate-free waiter TIDs behind a spin lock.
+- `prepare_to_wait(ThreadState::BlockedOnIO)` enrolls the current thread and
+  uses the scheduler's existing `BlockedOnIO` state.
+- `wake_up` and `wake_up_one` route through F16's `isr_unblock_for_io`.
+- `schedule_current_wait` uses the scheduler wait path instead of adding a
+  polling timer.
+
+## Migration Table
+
+| Path | Before | F32 branch change |
+| --- | --- | --- |
+| BWM `compositor_wait` op 23 | `COMPOSITOR_WAITING_THREAD` plus timer-backed compositor block | `COMPOSITOR_FRAME_WQ.prepare_to_wait`, condition recheck, scheduler wait, `finish_wait` |
+| Dirty-window wake | Direct thread ID signal | `COMPOSITOR_FRAME_WQ.wake_up()` |
+| Registry/input/cleanup wakes | Direct compositor signal | `COMPOSITOR_FRAME_WQ.wake_up()` |
+| Client frame pacing op 15 | `block_current_for_compositor` with 5 ms fallback | `CLIENT_FRAME_WQ` wait until BWM consumes/presents the frame |
+| VirGL present path | No client waitqueue notification | Wakes `CLIENT_FRAME_WQ` after successful `virgl_composite_frame` when a waiting frame was sampled |
+| `Completion` | Independent single-shot wait primitive | Not migrated |
+
+## Validation
+
+Clean builds completed before the Parallels gate:
+
+| Command | Result |
+| --- | --- |
+| `cargo build --release --features testing,external_test_bins --bin qemu-uefi` | Pass, no warnings/errors |
+| `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` | Pass, no warnings/errors |
+| `userspace/programs/build.sh --arch aarch64` | Pass |
+
+120-second Parallels sweep:
+
+| Run | Boot marker | bsshd | bounce | CPU0 tick audit | AHCI timeout | FPS >= 160 | Render verdict | Result |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Pass | Pass | Fail: serial stops at `spawn path='/bin/bounce'` | Missing | None seen | Missing, only frames 0-1 logged | Pass | Fail |
+| 2 | Not run | Not run | Not run | Not run | Not run | Not run | Not run | Stopped after run 1 failure |
+| 3 | Not run | Not run | Not run | Not run | Not run | Not run | Not run | Stopped after run 1 failure |
+| 4 | Not run | Not run | Not run | Not run | Not run | Not run | Not run | Stopped after run 1 failure |
+| 5 | Not run | Not run | Not run | Not run | Not run | Not run | Not run | Stopped after run 1 failure |
+
+Artifacts:
+
+- Serial log: `.factory-runs/f32-waitqueue-20260418-115626/rebuilt-run1.serial.log`
+- Screenshot: `.factory-runs/f32-waitqueue-20260418-115626/rebuilt-run1.png`
+- Render verdict: `.factory-runs/f32-waitqueue-20260418-115626/rebuilt-run1.verdict.txt`
+
+Relevant serial tail:
+
+```text
+[init] Boot script completed
+[spawn] path='/bin/bsshd'
+bsshd: starting on port 2222
+bsshd: listening on 0.0.0.0:2222
+[init] bsshd started (PID 4)
+[spawn] path='/bin/bounce'
+```
+
+There were no `SOFT LOCKUP`, `AHCI TIMEOUT`, `DATA_ABORT`, `panic`, or `PANIC`
+markers in the captured serial log. The failure signature is a forward-progress
+stall before bounce process creation logs begin.
+
+## PR
+
+No PR was opened and no merge was attempted. Phase 4 failed on run 1/5, so the
+factory stop condition applied.
+
+## Next Investigation
+
+The next pass should start from the run 1 stall rather than from FPS or render
+quality. Suggested first checks:
+
+- Use GDB on the rebuilt branch and break around the `/bin/bounce`
+  `create_process_with_argv` path to identify which CPU/thread is stuck after
+  init prints `spawn path='/bin/bounce'`.
+- Inspect whether BWM is sleeping in `COMPOSITOR_FRAME_WQ` while init is waiting
+  on filesystem/process creation, or whether the waitqueue lock/scheduler lock
+  order is blocking a later syscall path.
+- Verify the client frame wait migration did not introduce a dependency where
+  init can block behind a compositor/client wake that never arrives.
+- Keep the no-polling constraint: do not restore the 5 ms fallback timer.
+
+## Self-Audit
+
+- No polling fallback was added.
+- No Tier 1 prohibited files were modified.
+- F16 `isr_unblock_for_io` remains the wake delivery mechanism.
+- F1-F30 commits were not reverted.
+- Completion migration was deferred to avoid expanding the blast radius after
+  the failed gate.

--- a/docs/planning/f32c-waitqueue/exit.md
+++ b/docs/planning/f32c-waitqueue/exit.md
@@ -1,0 +1,126 @@
+# F32c Waitqueue Exit
+
+Date: 2026-04-18
+
+## Status
+
+F32c did not meet the acceptance gate. Phase 1, Phase 2, and Phase 3 were
+completed and committed, but Phase 4 failed on the first normal 120s Parallels
+run. Per the F32c instruction, implementation stopped after that failure. No PR
+was opened or merged.
+
+## Commits
+
+| Phase | Commit | Summary |
+| --- | --- | --- |
+| Phase 1 | `ede4a4e0` | `test(kernel): F32c wait_stress reproducer for waitqueue race` |
+| Phase 2 | `eaa4fef6` | `docs(kernel): F32c waitqueue ordering audit` |
+| Phase 3 | `1f6ae288` | `fix(kernel): serialize waitqueue prepare with blocked state` |
+
+## Reproducer
+
+Phase 1 added an opt-in userspace binary, `/bin/wait_stress`, enabled at boot by
+creating `/etc/wait_stress.enabled` with `BREENIX_WAIT_STRESS=1`.
+
+The harness forks:
+
+- a waiter that repeatedly calls FBDRAW op 28, which prepares and schedules on a
+  dedicated waitqueue with no persistent condition;
+- a waker that repeatedly calls FBDRAW op 29, which wakes the same queue;
+- a monitor parent that samples op 30 every 100 ms and reports a stall if wakes
+  advance while wait returns stop advancing.
+
+Before the fix, the reproducer failed deterministically:
+
+```text
+WAIT_STRESS_STALL sample=3 entered=269 returned=268 wakes=17280 waiters=0
+```
+
+Artifact: `.factory-runs/f32c-waitqueue-20260418/phase1-wait-stress-stall.serial.log`.
+
+After the Phase 3 fix, the 60s reproducer reached the end without a stall:
+
+```text
+WAIT_STRESS_PROGRESS sample=600 entered=90983 returned=90982 wakes=3245248 waiters=0
+WAIT_STRESS_PASS entered=90983 returned=90982 wakes=3245248 waiters=0
+```
+
+The `WAIT_STRESS_PASS` line in the raw serial is interleaved by concurrent serial
+writers; the preceding progress line preserves the full final counter values.
+
+Artifact: `.factory-runs/f32c-waitqueue-20260418/phase4-wait-stress-60.serial.log`.
+
+## Ordering Audit
+
+The audit is in `docs/planning/f32c-waitqueue/ordering-audit.md`.
+
+| Invariant | Linux v6.8 | F32 before fix | Phase 3 fix |
+| --- | --- | --- | --- |
+| Enqueue and state publication are serialized by the same waitqueue lock. | `prepare_to_wait` locks `wq_head->lock`, adds the entry, calls `set_current_state(state)`, then unlocks (`/tmp/linux-v6.8/kernel/sched/wait.c:233-238`). | Breenix added the TID under the waitqueue lock, released it, then set `BlockedOnIO` (`kernel/src/task/waitqueue.rs:58-66` before `1f6ae288`). | `prepare_to_wait` now holds the waitqueue lock across duplicate-free enqueue and `sched.block_current_for_io()`. |
+| Blocked-state publication has a full barrier. | `set_current_state` is `smp_store_mb(current->__state, state)` (`/tmp/linux-v6.8/include/linux/sched.h:227-231`). | No explicit barrier tied to the waitqueue critical section. | `prepare_to_wait` now executes a full `SeqCst` fence before releasing the waitqueue lock. |
+| Wakeup serializes on the same waitqueue lock. | `__wake_up` takes `wq_head->lock` via `__wake_up_common_lock` (`/tmp/linux-v6.8/kernel/sched/wait.c:99-127`). | Wakeup drained the TID under the queue lock, but could do so before the waiter became `BlockedOnIO`. | A wake that drains a TID can no longer run until `BlockedOnIO` is visible. |
+| If wake wins before schedule, scheduling is a no-op. | `try_to_wake_up` pairs with the waiter barrier (`/tmp/linux-v6.8/kernel/sched/core.c:4247-4255`); `__schedule` does not deactivate `TASK_RUNNING` (`core.c:6653-6681`). | `schedule_current_wait` had the no-op check, but the wake could be ignored before state publication. | The no-op check is now reachable for the original lost-wake race. |
+
+## Phase 4 Validation
+
+| Gate | Command | Result | Evidence |
+| --- | --- | --- | --- |
+| aarch64 kernel build | `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` | PASS | `.factory-runs/f32c-waitqueue-20260418/phase3-aarch64-build.log`; no warnings in output |
+| 60s waitqueue stress | `BREENIX_WAIT_STRESS=1 ./run.sh --parallels --test 150` | PASS for waitqueue stress, then failed later in normal boot | `WAIT_STRESS_PASS`; after stress, boot hit AHCI timeouts when spawning BWM/bsshd/bounce |
+| Normal 120s Parallels run | `./run.sh --parallels --test 120` | FAIL | Serial stopped at `[spawn] path='/bin/bwm'`; no bsshd, no bounce, no FPS sample |
+
+Post-stress failure signature:
+
+```text
+[spawn] path='/bin/bwm'
+[ahci] Port 1 TIMEOUT (5s): CI=0x0 IS=0x1 TFD=0x40 HBA_IS=0x2
+[ahci]   cpu0_last_timer_elr=0xffff00004010c5e8 cpu0_breadcrumb=107 ...
+[ahci]   tick_count=[43299,52636,53017,53569,53820,53854,53798,55002]
+```
+
+Normal-run failure signature:
+
+```text
+[init] Breenix init starting (PID 1)
+T5[spawn] path='/bin/bwm'
+T6T7T8T9T0
+```
+
+Artifact: `.factory-runs/f32c-waitqueue-20260418/phase4-normal-run1.serial.log`.
+
+## Sweep Table
+
+The required 5 x 120s sweep was not continued after run 1 failed.
+
+| Run | Result | bsshd | bounce | CPU0 tick_count > 1000 | FPS >= 160 | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | FAIL | No | No | Not established | No sample | Stopped at BWM spawn |
+| 2 | Not run | - | - | - | - | Stopped per F32c failure rule |
+| 3 | Not run | - | - | - | - | Stopped per F32c failure rule |
+| 4 | Not run | - | - | - | - | Stopped per F32c failure rule |
+| 5 | Not run | - | - | - | - | Stopped per F32c failure rule |
+
+## Fallback Audit
+
+No timer fallback was added for the waitqueue fix. The compositor wait path
+(`op=23`) still uses `COMPOSITOR_FRAME_WQ.prepare_to_wait`,
+`schedule_current_wait`, and `finish_wait`. The client frame-pacing path
+(`op=15`) still uses `CLIENT_FRAME_WQ` and explicitly documents that there is no
+timer fallback.
+
+`rg "BlockedOnTimer|fallback" kernel/src/syscall/graphics.rs` still finds the
+older blocking window-input path (`op=19`) and unrelated userspace font/input
+comments. That is not the compositor wait path, but the grep is not globally
+clean in `graphics.rs`.
+
+## PR
+
+No PR was opened. No merge was attempted.
+
+## Next Investigation
+
+The waitqueue lost-wake race is fixed for the dedicated reproducer, but the
+normal compositor boot still fails before the acceptance sweep. The next attempt
+should start from these artifacts and determine whether `1f6ae288` exposed a
+separate CPU0/scheduler bug, or whether the stricter Linux-style waitqueue
+ordering introduces a lock-order/preemption interaction during BWM startup.

--- a/docs/planning/f32c-waitqueue/ordering-audit.md
+++ b/docs/planning/f32c-waitqueue/ordering-audit.md
@@ -1,0 +1,84 @@
+# F32c Waitqueue Ordering Audit
+
+Date: 2026-04-18
+
+## Scope
+
+This audit compares F32's Breenix `WaitQueueHead` against Linux v6.8 waitqueue
+ordering. Phase 1 produced a deterministic lost-wake reproducer:
+
+```text
+WAIT_STRESS_STALL sample=3 entered=269 returned=268 wakes=17280 waiters=0
+```
+
+The important detail is `waiters=0`: the waker observed and drained the waiter
+from the queue, but the waiter still became permanently blocked. That points at
+the transition between queue enrollment and scheduler state publication.
+
+## Linux Reference
+
+Linux's waitqueue contract is split across these source locations:
+
+- `/tmp/linux-v6.8/kernel/sched/wait.c:217-238`: `prepare_to_wait`
+- `/tmp/linux-v6.8/kernel/sched/wait.c:270-300`: `prepare_to_wait_event`
+- `/tmp/linux-v6.8/kernel/sched/wait.c:99-127`: `__wake_up_common_lock`
+- `/tmp/linux-v6.8/include/linux/sched.h:184-231`: `set_current_state`
+- `/tmp/linux-v6.8/kernel/sched/core.c:4247-4255`: `try_to_wake_up`
+- `/tmp/linux-v6.8/kernel/sched/core.c:6653-6681`: `__schedule`
+- `/tmp/linux-v6.8/kernel/sched/wait.c:356-379`: `finish_wait`
+
+## Side-by-Side Audit
+
+| Invariant | Linux v6.8 | Breenix F32 | Verdict |
+| --- | --- | --- | --- |
+| Queue enrollment and blocked-state publication are serialized by the waitqueue lock. | `prepare_to_wait` takes `wq_head->lock`, adds the wait entry, calls `set_current_state(state)`, then unlocks (`wait.c:233-238`). `prepare_to_wait_event` uses the same pattern (`wait.c:275-300`). | `WaitQueueHead::prepare_to_wait` adds the TID under `waiters` lock (`waitqueue.rs:58-62`), releases that lock, and only then calls `sched.block_current_for_io()` (`waitqueue.rs:64-66`). | **Fail.** There is an unlocked window where a waker can drain the queued TID before the thread state is `BlockedOnIO`. |
+| The blocked-state store has a barrier before the waiter retests the condition or schedules. | `set_current_state` is `smp_store_mb(current->__state, state)` (`sched.h:227-231`). Linux explicitly documents that the barrier serializes the state write with the subsequent condition test (`sched.h:184-208`). | `block_current_for_io` writes `thread.state = ThreadState::BlockedOnIO` under the scheduler lock (`scheduler.rs:1617-1631`), but this write is not inside the waitqueue critical section and has no explicit waitqueue-paired full barrier. | **Fail.** The state write is neither protected by the same lock as queue enrollment nor documented with the Linux-equivalent full barrier. |
+| Wake-up observes the same serialization point used by prepare. | `__wake_up` calls `__wake_up_common_lock`; that takes `wq_head->lock`, scans the wait list, and invokes each wake function while still holding the lock (`wait.c:99-127`). `prepare_to_wait_event` relies on this exact fact: wakeup locks and unlocks the same `wq_head->lock`, so the caller cannot miss the event (`wait.c:281-283`). | `wake_up` drains the waitqueue under the `waiters` lock (`waitqueue.rs:93-98`, `119-121`) but calls `isr_unblock_for_io` after the waiter has been drained. Because `prepare_to_wait` does not publish `BlockedOnIO` until after releasing the same lock, `unblock_for_io` can later see a still-running thread and decide there is nothing to wake (`scheduler.rs:1653-1668`). | **Fail.** The list operation is serialized, but the scheduler-state handoff is not. The Phase 1 `waiters=0` stall is this failure mode. |
+| If wake wins before schedule, schedule becomes a no-op. | `try_to_wake_up` pairs with `set_current_state` using a full barrier before checking task state (`core.c:4247-4255`). Later, `__schedule` reads `prev->__state`; if it is `TASK_RUNNING` (`0`), it does not deactivate the task (`core.c:6653-6681`). | `schedule_current_wait` has the right shape: it checks current state and only schedules while state remains `BlockedOnIO` (`waitqueue.rs:166-183`). However, in the lost-wake window the wake is ignored before `BlockedOnIO` is set, so this check later sees `BlockedOnIO` and sleeps. | **Partial.** The schedule-side no-op exists, but it depends on a wake being able to flip the state before schedule. The prepare/wake race prevents that. |
+| Finish path normalizes state and removes any leftover waiter. | Linux `finish_wait` sets the task running and removes a still-queued entry under the waitqueue lock if needed (`wait.c:356-379`). | `finish_wait` removes the TID and sets the current thread ready if it is still `BlockedOnIO` (`waitqueue.rs:75-90`). | **Pass for this race.** The reproducer never reaches `finish_wait` for the stuck waiter. |
+
+## Lost-Wake Timeline
+
+The deterministic reproducer can fail with this interleaving:
+
+1. Waiter enters `prepare_to_wait`.
+2. Waiter adds its TID to `WAIT_STRESS_WQ` and releases `waiters` lock
+   (`waitqueue.rs:58-62`).
+3. Waker calls `wake_up`, takes the same `waiters` lock, drains that TID, releases
+   the lock, and queues `isr_unblock_for_io` (`waitqueue.rs:93-98`).
+4. Scheduler wake processing reaches `unblock_for_io(tid)` before the waiter has
+   run `block_current_for_io`; the thread is not `BlockedOnIO`, so
+   `should_queue` is false (`scheduler.rs:1653-1668`).
+5. Waiter resumes and sets itself `BlockedOnIO` (`scheduler.rs:1617-1631`).
+6. `schedule_current_wait` observes `BlockedOnIO` and sleeps (`waitqueue.rs:166-183`).
+7. The waitqueue is empty and the wake was already discarded, so the waiter never
+   returns.
+
+This is the exact condition Phase 1 reported: one more wait entered than returned,
+many wake attempts, and zero queued waiters.
+
+## Required Fix
+
+F32c must restore the Linux ordering invariant:
+
+1. Hold the waitqueue lock across both waiter insertion and the current-thread
+   `BlockedOnIO` state publication.
+2. Publish the state with a Linux-equivalent full barrier before releasing the
+   waitqueue lock. Linux uses `smp_store_mb` in `set_current_state`
+   (`sched.h:227-231`).
+3. Keep wake-up serialized on the same waitqueue lock. A wake must not be able to
+   remove a waiter until the waiter's scheduler state is visible as blocked.
+4. Preserve `schedule_current_wait`'s no-op behavior when a wake wins before the
+   explicit schedule call.
+
+The minimal Breenix change is therefore in `WaitQueueHead::prepare_to_wait`:
+perform the duplicate-free enqueue and `sched.block_current_for_io()` inside the
+same `with_waiters` critical section, followed by a full fence before unlocking.
+With that ordering, any `wake_up` that drains the TID must happen after the waiter
+is already `BlockedOnIO`, so `unblock_for_io` can mark it ready. If the wake wins
+before `schedule_current_wait`, the schedule-side state check becomes a no-op, as
+in Linux.
+
+No compositor fallback, timer polling, or arbitrary timeout is involved in this
+fix. It is a lock-ordering and memory-ordering repair to match Linux's waitqueue
+contract.

--- a/docs/planning/f32c-waitqueue/reproducer.md
+++ b/docs/planning/f32c-waitqueue/reproducer.md
@@ -1,0 +1,71 @@
+# F32c WaitQueue Reproducer
+
+## Purpose
+
+`wait_stress` is an opt-in userspace reproducer for the F32 waitqueue race. It
+uses a dedicated kernel waitqueue exposed through FBDRAW test ops 27-30 so it
+can stress `WaitQueueHead::prepare_to_wait()` and `schedule_current_wait()`
+without BWM, window registry state, or compositor readiness conditions.
+
+The reproducer intentionally waits without a persistent condition. That is the
+minimal Linux waitqueue race case: a wake that lands after queue enrollment must
+make the later schedule operation a no-op. If wake delivery observes the waiter
+before the scheduler state is set, the waiter can sleep forever.
+
+## How to Run
+
+```bash
+BREENIX_WAIT_STRESS=1 ./run.sh --parallels --test 90
+```
+
+`BREENIX_WAIT_STRESS=1` makes `scripts/create_ext2_disk.sh` create
+`/etc/wait_stress.enabled`. ARM64 init checks for that file and runs:
+
+```text
+/bin/wait_stress 60
+```
+
+before starting BWM. Normal Parallels validation boots are unchanged when the
+flag is absent.
+
+## Phase 1 Evidence
+
+Run:
+
+```bash
+BREENIX_WAIT_STRESS=1 ./run.sh --parallels --test 90
+```
+
+Serial evidence from `/tmp/breenix-parallels-serial.log`:
+
+```text
+[init] wait_stress enabled; starting 60s waitqueue stress
+[spawn] path='/bin/wait_stress'
+WAIT_STRESS_START duration=60s sample=100ms
+WAIT_STRESS: forked waiter pid=3
+WAIT_STRESS: forked waker pid=4
+WAIT_STRESS_STALL sample=3 entered=269 returned=268 wakes=17280 waiters=0
+[syscall] exit(4) pid=2 name=wait_stress
+[init] wait_stress exited pid=2 code=4
+[init] Boot script completed
+```
+
+Interpretation: wakes continued (`wakes=17280`) while one wait remained
+unreturned (`entered=269`, `returned=268`). `waiters=0` shows the wake side had
+already drained the queue entry, matching a lost wake between queue enrollment
+and the later blocked scheduler state.
+
+## Validation
+
+These checks passed with no compiler warnings:
+
+```bash
+cargo build --release --target aarch64-breenix.json \
+  -Z build-std=core,alloc \
+  -Z build-std-features=compiler-builtins-mem \
+  -p kernel --bin kernel-aarch64
+
+userspace/programs/build.sh --arch aarch64
+
+cargo build --release --features testing,external_test_bins --bin qemu-uefi
+```

--- a/docs/planning/f32e-linux-prepare-to-wait/audit.md
+++ b/docs/planning/f32e-linux-prepare-to-wait/audit.md
@@ -1,0 +1,59 @@
+# F32e Linux `prepare_to_wait_event` Audit
+
+Date: 2026-04-18
+
+## Scope
+
+This audit compares Linux v6.8's waitqueue sleep pattern against Breenix's F32c
+`WaitQueueHead` implementation. F32c closed the lost-wake reproducer by holding
+the waitqueue lock across `Scheduler::block_current_for_io()`, but that critical
+section is larger than Linux's `prepare_to_wait_event` pattern.
+
+## Linux Reference
+
+| Mechanism | Linux v6.8 file:line evidence |
+| --- | --- |
+| Waiter insertion, state publish, unlock | `/tmp/linux-v6.8/kernel/sched/wait.c:270-300`: `prepare_to_wait_event` takes `wq_head->lock`, adds the entry if needed, calls `set_current_state(state)`, then unlocks. The simpler `prepare_to_wait` has the same lock scope at `/tmp/linux-v6.8/kernel/sched/wait.c:233-238`. |
+| Why `set_current_state` is after list insertion | `/tmp/linux-v6.8/kernel/sched/wait.c:216-227`: Linux documents that the state store needs a memory barrier after the waitqueue add so wakeups either see the queued waiter or the waiter sees the wake. |
+| State-store barrier | `/tmp/linux-v6.8/include/linux/sched.h:184-231`: `set_current_state(state)` uses `smp_store_mb(current->__state, state)`; `__set_current_state` is only a `WRITE_ONCE`. |
+| Wake takes same waitqueue lock | `/tmp/linux-v6.8/kernel/sched/wait.c:99-108`: `__wake_up_common_lock` takes `wq_head->lock`, calls `__wake_up_common`, then unlocks. `/tmp/linux-v6.8/kernel/sched/wait.c:120-127` notes a wake executes a full memory barrier before task-state access. |
+| Wake/state barrier pairing | `/tmp/linux-v6.8/kernel/sched/core.c:4247-4255`: `try_to_wake_up` executes `smp_mb__after_spinlock()` before checking `p->__state`, pairing with `set_current_state()`'s `smp_store_mb`. |
+| Schedule state check | `/tmp/linux-v6.8/kernel/sched/core.c:6653-6681`: `__schedule` reads `prev->__state` once; if `prev_state` is zero (`TASK_RUNNING`), it does not deactivate the task as sleeping. |
+
+## Side-by-Side
+
+| Question | Linux v6.8 | Breenix F32c | Finding |
+| --- | --- | --- | --- |
+| 1. Does Breenix's `set_state(BlockedOnIO)` carry the equivalent of `smp_store_mb`? | `set_current_state` is a state store plus full barrier (`sched.h:227-231`), and Linux explains the barrier serializes the store with the following condition check (`sched.h:184-208`). | `WaitQueueHead::prepare_to_wait` calls `sched.block_current_for_io()` while holding the waitqueue lock, then executes a `SeqCst` fence before leaving that waitqueue critical section (`kernel/src/task/waitqueue.rs:58-72`). `block_current_for_io_with_timeout` writes `thread.state = ThreadState::BlockedOnIO` and `blocked_in_syscall = true` (`kernel/src/task/scheduler.rs:1617-1631`). | **Partial pass.** The F32c ordering provides a full fence after the blocked-state write while the waitqueue lock is still held, which is Linux-like for the race. It is not a named state-publish primitive, and the state field itself is not an atomic store-release. |
+| 2. Does Breenix's wake path take the same waitqueue lock that the waiter took? | Wake takes `wq_head->lock` around the list walk and wake callbacks (`wait.c:99-108`). `prepare_to_wait_event` relies on wake locking/unlocking the same lock so the caller cannot miss the event (`wait.c:281-283`). | `wake_up` drains waiters under the same `waiters` lock via `drain_waiters()` (`kernel/src/task/waitqueue.rs:99-103`, `kernel/src/task/waitqueue.rs:125-137`), then calls `scheduler::isr_unblock_for_io()` after the lock has been released (`kernel/src/task/waitqueue.rs:100-103`). | **Partial pass.** The list removal is serialized by the same lock, so F32c closes the original lost-wake window. It is not exact Linux because the wake action is queued after releasing the waitqueue lock. Since `isr_unblock_for_io` is lock-free (`kernel/src/task/scheduler.rs:2542-2561`), Breenix can move that wake publication into the same waitqueue critical section without taking the scheduler lock. |
+| 3. Does Breenix's equivalent of `schedule()` re-check state before actually blocking? | `__schedule` checks `prev->__state`; `TASK_RUNNING` is not deactivated (`core.c:6653-6681`). This is what makes a wake between `prepare_to_wait_event` and `schedule()` turn `schedule()` into a no-op sleep-wise. | `schedule_current_wait` checks the current thread state under the scheduler lock and only calls `schedule_from_kernel()` while it remains `BlockedOnIO` (`kernel/src/task/waitqueue.rs:166-189`). However, the lower-level AArch64 `scheduler::schedule()` wrapper always enters `schedule_from_kernel()` (`kernel/src/task/scheduler.rs:2205-2209`), and `prepare_to_wait` currently performs the heavyweight `block_current_for_io()` before the caller can reach that state check (`kernel/src/task/waitqueue.rs:63-72`). | **Pass at wrapper level, missing as a primitive split.** Breenix has the no-op state re-check in `schedule_current_wait`, but the Linux pattern is obscured because `prepare_to_wait` uses the full block operation under the waitqueue lock. F32e should split this into: publish `BlockedOnIO` under the waitqueue lock, unlock, then call a state-checking schedule helper that returns immediately if a wake already made the thread `Ready`. |
+
+## Required F32e Change
+
+F32e should keep the race-closure invariant from F32c but shrink the waitqueue
+critical section to the exact Linux shape:
+
+1. Under the waitqueue lock, add the current TID if absent and publish
+   `ThreadState::BlockedOnIO`.
+2. Use an explicit full barrier before unlocking, mirroring Linux's
+   `smp_store_mb` in `set_current_state` (`/tmp/linux-v6.8/include/linux/sched.h:227-231`).
+3. Move the lock-free `isr_unblock_for_io` wake publication under the same
+   waitqueue lock, mirroring Linux's same-lock wake path
+   (`/tmp/linux-v6.8/kernel/sched/wait.c:99-108`), without taking the scheduler
+   lock from the waitqueue critical section.
+4. Keep scheduling outside the waitqueue lock and rely on `schedule_current_wait`
+   to re-check state before calling into the architecture scheduler, matching
+   Linux's `__schedule` state check (`/tmp/linux-v6.8/kernel/sched/core.c:6653-6681`).
+
+The key implementation difference from F32c is replacing
+`block_current_for_io()` in `prepare_to_wait` with a lightweight publish-only
+primitive. The publish primitive may charge outgoing CPU ticks and mark
+`blocked_in_syscall`, but it must not scan all per-CPU ready queues or otherwise
+extend the waitqueue critical section beyond Linux's add-entry + state-publish
+scope.
+
+## Non-Goals Confirmed
+
+- No timer fallback or arbitrary timeout is part of the F32e waitqueue fix.
+- No CPU0 EL0 routing workaround from F32d is part of this branch.
+- No Tier 1 prohibited file needs to change for this design.

--- a/docs/planning/f32e-linux-prepare-to-wait/exit.md
+++ b/docs/planning/f32e-linux-prepare-to-wait/exit.md
@@ -1,0 +1,116 @@
+# F32e Exit - Linux `prepare_to_wait_event` Pattern
+
+Date: 2026-04-18
+
+## Verdict
+
+FAIL. F32e completed the audit and implemented a closer Linux-style waitqueue
+prepare path, and `/bin/wait_stress` still passed for 60 seconds with 0 stalls.
+The required Parallels gate did not pass, so no PR was opened and no merge was
+attempted.
+
+Per the F32e contract, validation stopped after the first normal 120s Parallels
+run failed to reach the required bsshd/bounce/render/FPS milestones.
+
+## What I Built
+
+| File | Purpose |
+| --- | --- |
+| `docs/planning/f32e-linux-prepare-to-wait/audit.md` | Side-by-side Linux vs Breenix audit for waitqueue lock scope, state-publish barrier, same-lock wake path, and scheduler state re-check. |
+| `kernel/src/task/scheduler.rs` | Added `publish_current_io_wait_state()` so waitqueues can publish `BlockedOnIO` with a full fence without running the heavier queue-pruning block path. |
+| `kernel/src/task/waitqueue.rs` | Changed `prepare_to_wait` to enqueue + publish state under the waitqueue lock, then unlock before scheduling; moved lock-free wake publication under the same waitqueue lock. |
+
+## Linux Cites Used
+
+| Decision | Linux v6.8 evidence |
+| --- | --- |
+| Hold waitqueue lock only across enqueue + state publish, not schedule | `/tmp/linux-v6.8/kernel/sched/wait.c:270-300` (`prepare_to_wait_event`) and `/tmp/linux-v6.8/kernel/sched/wait.c:233-238` (`prepare_to_wait`). |
+| State publish needs full barrier | `/tmp/linux-v6.8/include/linux/sched.h:184-231`; `set_current_state()` is `smp_store_mb(current->__state, state)`. |
+| Wake serializes on same waitqueue lock | `/tmp/linux-v6.8/kernel/sched/wait.c:99-108`; `__wake_up_common_lock` takes `wq_head->lock` around wake traversal. |
+| Schedule must re-check state | `/tmp/linux-v6.8/kernel/sched/core.c:6653-6681`; `__schedule` reads `prev->__state` and does not deactivate `TASK_RUNNING`. |
+| Wake barrier pairs with state publish | `/tmp/linux-v6.8/kernel/sched/core.c:4247-4255`; `try_to_wake_up` executes a full barrier before checking task state. |
+
+## Audit Findings
+
+The Phase 1 audit found that F32c had closed the original lost-wake reproducer by
+holding the waitqueue lock across `block_current_for_io()`, but that differed
+from Linux because the critical section included Breenix-specific scheduler work
+instead of only wait-list insertion plus state publication.
+
+The audit also found that Breenix already had a wrapper-level no-op check in
+`schedule_current_wait()` (`kernel/src/task/waitqueue.rs`) before entering the
+architecture scheduler. The missing split was narrower than the initial expected
+finding: Breenix needed a publish-only wait-state primitive so the caller could
+release the waitqueue lock before scheduling.
+
+Validation shows the audit is still incomplete for the broader Parallels failure.
+The waitqueue reproducer remains fixed, but bwm/bsshd/bounce still do not reach
+the full acceptance gate. One likely area for the next audit pass is the remaining
+difference from Linux's immediate `try_to_wake_up` state transition: Breenix
+`wake_up` still publishes to the lock-free ISR wake buffer rather than directly
+setting the task runnable under the waitqueue wake traversal. I did not change
+that further because the contract forbids workarounds and says to return to the
+audit when Parallels fails.
+
+## Commits
+
+| Commit | Summary |
+| --- | --- |
+| `e29d5abd` | `docs(kernel): F32e audit Linux waitqueue parity` |
+| `3d0acbd3` | `fix(kernel): F32e shrink waitqueue critical section to Linux pattern` |
+
+## Validation
+
+| Gate | Command | Result | Evidence |
+| --- | --- | --- | --- |
+| Standard release build | `cargo build --release --features testing,external_test_bins --bin qemu-uefi` | PASS | `/tmp/f32e-build.log`; no `warning` or `error` lines. |
+| aarch64 kernel build | `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` | PASS | `/tmp/f32e-aarch64-build.log`; no `warning` or `error` lines. |
+| wait_stress 60s | `BREENIX_WAIT_STRESS=1 ./run.sh --parallels --test 150` | PASS for wait_stress | `WAIT_STRESS_PROGRESS sample=600 entered=147525 returned=147525 wakes=6800321 waiters=0`; `WAIT_STRESS_PASS`; no `WAIT_STRESS_STALL`. |
+| post-stress boot | Same as above | FAIL after stress | After `WAIT_STRESS_PASS`, `/bin/bwm` hit `AHCI Port 1 TIMEOUT`; bsshd and bounce failed to start. |
+| normal Parallels run 1 | `./run.sh --parallels --test 120` | FAIL | Serial reached `/bin/bwm`, `TELNETD_LISTENING`, and `[init] Boot script completed`, then ended at `[spawn] path='/bin/bsshd'`; no bsshd success, no bounce, no render verdict, no FPS sample. |
+
+Artifacts:
+
+```text
+.factory-runs/f32e-linux-prepare-to-wait-20260418T203720Z/wait-stress.log
+.factory-runs/f32e-linux-prepare-to-wait-20260418T203720Z/wait-stress.serial.log
+.factory-runs/f32e-linux-prepare-to-wait-20260418T203720Z/parallels-run1.log
+.factory-runs/f32e-linux-prepare-to-wait-20260418T203720Z/parallels-run1.serial.log
+```
+
+## Sweep Table
+
+| Run | Result | bsshd | bounce | CPU0 tick_count > 1000 | FPS >= 160 | Strict render | AHCI TIMEOUT | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| wait_stress | PASS for stress, FAIL after stress | No | No | Yes in timeout dump (`tick_count[0]=2148`) | No sample | No verdict | Yes | Stress itself passed with 6.8M wakes and 0 stalls; post-stress `/bin/bwm` and later service spawns hit AHCI timeouts. |
+| 1 | FAIL | No success line | Not reached | Not established | No sample | No verdict | No timeout observed in 120s serial | Serial ended at `[spawn] path='/bin/bsshd'`. |
+| 2 | Not run | - | - | - | - | - | - | Stopped after run 1 failed, per contract. |
+| 3 | Not run | - | - | - | - | - | - | Stopped after run 1 failed, per contract. |
+| 4 | Not run | - | - | - | - | - | - | Stopped after run 1 failed, per contract. |
+| 5 | Not run | - | - | - | - | - | - | Stopped after run 1 failed, per contract. |
+
+## Self-Audit
+
+- No timer-driven wake fallback was added.
+- No arbitrary timeout was added.
+- No CPU0 EL0 routing workaround was added.
+- No Tier 1 prohibited files were modified.
+- No F1-F30 or F32c commits were reverted.
+- The code builds cleanly with zero warnings in the commands listed above.
+
+## What I Did Not Build
+
+I did not open a PR, merge, or continue the Parallels sweep. The contract requires
+5/5 successful normal Parallels runs before PR/merge, and run 1 failed.
+
+## PR
+
+N/A. No PR was opened.
+
+## Recommended Next Step
+
+Return to Phase 1 with the new evidence. In particular, compare Linux's
+`try_to_wake_up` immediate state transition against Breenix's deferred
+`isr_unblock_for_io` wake buffer in the waitqueue path, and verify whether the
+architecture scheduler's state re-check after draining deferred wakeups is truly
+equivalent under the bwm/bsshd spawn workload.

--- a/docs/planning/f32f-immediate-wake/audit.md
+++ b/docs/planning/f32f-immediate-wake/audit.md
@@ -1,0 +1,41 @@
+# F32f Audit - Immediate Wake Under Waitqueue Lock
+
+## Linux Citations
+
+Linux waitqueue wake traversal is synchronous with the waitqueue lock. `__wake_up_common_lock` takes `wq_head->lock`, calls `__wake_up_common`, then unlocks (`/tmp/linux-v6.8/kernel/sched/wait.c:99-108`). `__wake_up_common` asserts that lock is held, iterates entries, and invokes each waiter's wake function while still inside that lock (`/tmp/linux-v6.8/kernel/sched/wait.c:73-96`).
+
+The default wait entry installed by `init_wait_entry` is `autoremove_wake_function` (`/tmp/linux-v6.8/kernel/sched/wait.c:261-266`). That function calls `default_wake_function` and removes the wait-list entry only if the wake succeeds (`/tmp/linux-v6.8/kernel/sched/wait.c:382-389`). This means a successful Linux waitqueue wake both transitions the task and removes it before the wake call returns.
+
+`try_to_wake_up` states its conceptual contract directly: if the requested state matches the task state, set it to `TASK_RUNNING`, and if the task was not queued/runnable, place it back on a runqueue (`/tmp/linux-v6.8/kernel/sched/core.c:4186-4197`). It also states it is atomic against `schedule()` and issues a full memory barrier before accessing task state (`/tmp/linux-v6.8/kernel/sched/core.c:4197-4203`).
+
+The Linux state-transition point is inside `try_to_wake_up`: after taking `p->pi_lock`, it executes `smp_mb__after_spinlock()` and tests state with `ttwu_state_match` (`/tmp/linux-v6.8/kernel/sched/core.c:4247-4256`). If the task is not already runnable, the SMP path writes `TASK_WAKING` before enqueue work (`/tmp/linux-v6.8/kernel/sched/core.c:4312-4319`), then calls `ttwu_queue` to enqueue the task (`/tmp/linux-v6.8/kernel/sched/core.c:4354-4369`). The local `ttwu_queue` path takes the target runqueue lock and activates the task before returning (`/tmp/linux-v6.8/kernel/sched/core.c:4038-4049`).
+
+Linux's cross-CPU signaling is a delivery optimization after the state decision, not a substitute for it. The remote wake-list path queues wake work and causes an IPI when needed (`/tmp/linux-v6.8/kernel/sched/core.c:3930-3944`), while the direct path enqueues under the runqueue lock (`/tmp/linux-v6.8/kernel/sched/core.c:4038-4049`). The lock nesting is waitqueue lock outside, task/runqueue scheduler locks inside: waitqueue traversal holds `wq_head->lock` while invoking the wake function (`/tmp/linux-v6.8/kernel/sched/wait.c:73-108`), and `try_to_wake_up` then uses `p->pi_lock` plus at most one runqueue lock (`/tmp/linux-v6.8/kernel/sched/core.c:4202-4214`).
+
+Linux prepare-side comments rely on that same-lock wake behavior. `prepare_to_wait_event` says the caller cannot miss the event because wakeup locks and unlocks the same `wq_head->lock` (`/tmp/linux-v6.8/kernel/sched/wait.c:275-300`).
+
+## Breenix Findings
+
+`WaitQueueHead::prepare_to_wait` now matches F32e's tighter prepare/schedule split: it records the current TID under the waitqueue lock, calls `publish_current_io_wait_state`, removes the waiter if publication fails, and returns before the caller schedules (`kernel/src/task/waitqueue.rs:51-80`). The actual wait schedule remains outside the waitqueue lock in `schedule_current_wait`, which re-checks whether the current thread is still `BlockedOnIO` before entering the architecture scheduler (`kernel/src/task/waitqueue.rs:177-205`).
+
+`WaitQueueHead::wake_up` and `wake_up_one` still do not perform the scheduler state transition inline. They hold the waitqueue lock, pop waiters, and call `scheduler::isr_unblock_for_io` for each popped TID (`kernel/src/task/waitqueue.rs:104-119`). `isr_unblock_for_io` writes the TID into a per-CPU lock-free buffer and sets `need_resched`; it does not mutate the thread state or enqueue the thread (`kernel/src/task/scheduler.rs:2564-2583`).
+
+The `BlockedOnIO -> Ready` transition happens later, when scheduler code drains the ISR wake buffers and calls `unblock_for_io`. On x86_64-style `Scheduler::schedule`, the drain happens at the top of `schedule()` (`kernel/src/task/scheduler.rs:671-680`). On AArch64, the drain happens at the top of `schedule_deferred_requeue` (`kernel/src/task/scheduler.rs:921-933`), which is called by the inline kernel scheduling path (`kernel/src/arch_impl/aarch64/context_switch.rs:2862-2909`) and by IRQ-return scheduling after `check_need_resched_and_switch_arm64` takes the scheduler lock and reaches the scheduling decision (`kernel/src/arch_impl/aarch64/context_switch.rs:2229-2420`).
+
+`Scheduler::unblock_for_io` is the real wake operation. It changes `BlockedOnIO` to `Ready`, clears `wake_time_ns`, conditionally adds the thread to a per-CPU ready queue, sends an AArch64 reschedule IPI when it enqueues, and sets `need_resched` (`kernel/src/task/scheduler.rs:1675-1717`). AArch64 SGI reschedule delivery sets the receiver's per-CPU `need_resched` flag (`kernel/src/arch_impl/aarch64/exception.rs:1243-1248`), and `send_resched_ipi` sends SGI 0 to idle CPUs after queue insertion (`kernel/src/task/scheduler.rs:1296-1328`).
+
+The deferred ISR ring is correct for genuine interrupt completion paths. `Completion::complete` explicitly documents that it may run from ISR context and therefore stores the waiter TID through `isr_unblock_for_io` instead of taking the scheduler lock (`kernel/src/task/completion.rs:466-496`). The scheduler comments give the same reason: the AHCI ISR must not spin on the global scheduler mutex with IRQs masked (`kernel/src/task/scheduler.rs:61-73`, `kernel/src/task/scheduler.rs:2564-2573`).
+
+The same deferral is not Linux-equivalent for task-context waitqueue wakers. Graphics syscall paths call `COMPOSITOR_FRAME_WQ.wake_up`, `CLIENT_FRAME_WQ.wake_up`, and `WAIT_STRESS_WQ.wake_up` from ordinary syscall/task context after publishing readiness (`kernel/src/syscall/graphics.rs:186-210`, `kernel/src/syscall/graphics.rs:958-1010`, `kernel/src/syscall/graphics.rs:1328-1375`, `kernel/src/syscall/graphics.rs:1620-1624`). Those task-context callers can safely acquire the scheduler lock through `with_scheduler`, but today they still route through the ISR-only ring.
+
+## Answers
+
+1. Breenix waitqueue waiters actually transition from `BlockedOnIO` to `Ready` in `Scheduler::unblock_for_io`, not inline under `WaitQueueHead::wake_up`. The current waitqueue wake path only removes entries from the wait list and publishes TIDs to the ISR wake buffer before returning (`kernel/src/task/waitqueue.rs:104-119`, `kernel/src/task/scheduler.rs:2564-2583`).
+
+2. The drain can run on any CPU that enters the scheduler path. On x86_64 it runs inside `Scheduler::schedule` (`kernel/src/task/scheduler.rs:671-680`). On AArch64 it runs inside `schedule_deferred_requeue` (`kernel/src/task/scheduler.rs:921-933`), reached from explicit task-context scheduling via `schedule_from_kernel` (`kernel/src/arch_impl/aarch64/context_switch.rs:2862-2909`) and from IRQ-return scheduling via `check_need_resched_and_switch_arm64` (`kernel/src/arch_impl/aarch64/context_switch.rs:2229-2420`). It is therefore not timer-IRQ-only, but it is still deferred until a scheduler entry occurs.
+
+3. There is an architectural latency window between "waitqueue wake returned" and "waiter is runnable": the window starts after `WaitQueueHead::wake_up` pushes the TID into the ISR buffer and ends only after a later scheduler drain calls `unblock_for_io`. Under CPU0 AHCI/timer/syscall contention this can be milliseconds, because the wake can sit in the per-CPU ring until scheduler entry. Task-context waitqueue callers do not need this route; the ISR ring exists to keep hard IRQ handlers away from the scheduler lock, while Linux's waitqueue wake performs the state transition synchronously under the waitqueue traversal.
+
+## Conclusion
+
+The likely F32f gap is real: Breenix's waitqueue wake path is still using an ISR-only deferred delivery mechanism for task-context wakeups. The Linux-equivalent repair is to keep F32e's prepare-side lock scope, but make task-context `WaitQueueHead::wake_up` call a scheduler immediate I/O wake while still inside the waitqueue lock. Genuine ISR completion paths should continue using `isr_unblock_for_io`.

--- a/docs/planning/f32f-immediate-wake/audit.md
+++ b/docs/planning/f32f-immediate-wake/audit.md
@@ -39,3 +39,11 @@ The same deferral is not Linux-equivalent for task-context waitqueue wakers. Gra
 ## Conclusion
 
 The likely F32f gap is real: Breenix's waitqueue wake path is still using an ISR-only deferred delivery mechanism for task-context wakeups. The Linux-equivalent repair is to keep F32e's prepare-side lock scope, but make task-context `WaitQueueHead::wake_up` call a scheduler immediate I/O wake while still inside the waitqueue lock. Genuine ISR completion paths should continue using `isr_unblock_for_io`.
+
+## Post-Implementation Evidence
+
+F32f implemented that repair. `WaitQueueHead::wake_up` and `wake_up_one` now pop waiters under the waitqueue lock and call `wake_waiter` before returning (`kernel/src/task/waitqueue.rs:105-120`). `wake_waiter` keeps genuine interrupt-context callers on `isr_unblock_for_io`, but routes task-context callers to `scheduler::wake_waitqueue_thread` (`kernel/src/task/waitqueue.rs:172-188`). The scheduler helper performs the `BlockedOnIO -> Ready` transition through `wake_io_thread_locked`, queues the thread when safe, sets `need_resched`, and sends a targeted AArch64 reschedule SGI when the target CPU is remote (`kernel/src/task/scheduler.rs:1713-1772`, `kernel/src/task/scheduler.rs:1346-1362`, `kernel/src/task/scheduler.rs:2467-2473`).
+
+Validation disproved wake latency as the remaining bwm/bsshd/bounce failure. The wait-stress reproducer passed after the immediate wake change with `WAIT_STRESS_PASS entered=596936 returned=596935 wakes=700683 waiters=0` and no `WAIT_STRESS_STALL` (`.factory-runs/f32f-immediate-wake/wait-stress.serial.log:417`). The first required 120s normal Parallels boot still failed the gate: serial output reached `bsshd: listening on 0.0.0.0:2222` and `[init] bsshd started (PID 4)`, then stopped at `[spawn] path='/bin/bounce'` without `[init] bounce started`, `[bounce] Window mode`, sustained frame output, or CPU0 tick evidence (`.factory-runs/f32f-immediate-wake/parallels-run1.serial.log:387-390`). There were no AHCI timeout markers, and the screenshot verdict was `PASS`, but the lifecycle/FPS/CPU0 criteria were not met.
+
+Per the F32f run instructions, this means the remaining Parallels boot gap is not the task-context waitqueue wake latency gap audited above. Stop here rather than iterating a fourth scheduler mechanism change.

--- a/docs/planning/f32f-immediate-wake/decisions.md
+++ b/docs/planning/f32f-immediate-wake/decisions.md
@@ -4,3 +4,8 @@
 **Choice:** Keep this run scoped to auditing and implementing Linux-parity immediate task-context waitqueue wake only.
 **Alternatives considered:** Broader AHCI, CPU routing, timer fallback, or Parallels-specific mechanisms.
 **Evidence:** The task contract explicitly identifies deferred waitqueue wake latency as the remaining Linux-parity gap and prohibits those alternative mechanisms.
+
+## 2026-04-18T22:22:00Z - Immediate Wake Routing
+**Choice:** Route waitqueue wakes through an immediate scheduler helper only when not in interrupt context; keep hard IRQ completion and interrupt-origin waitqueue wakes on `isr_unblock_for_io`.
+**Alternatives considered:** Convert all `isr_unblock_for_io` callers to immediate wake, or leave waitqueue wake fully deferred.
+**Evidence:** Linux waitqueue wake invokes the wake function while holding `wq_head->lock` (`wait.c:73-108`), while Breenix completion wakes explicitly require the lock-free ISR buffer (`completion.rs:466-496`, `scheduler.rs:2564-2573`).

--- a/docs/planning/f32f-immediate-wake/decisions.md
+++ b/docs/planning/f32f-immediate-wake/decisions.md
@@ -1,0 +1,6 @@
+# Decisions - F32f Immediate Wake Under Waitqueue Lock
+
+## 2026-04-18T22:02:39Z - Initial Factory Scope
+**Choice:** Keep this run scoped to auditing and implementing Linux-parity immediate task-context waitqueue wake only.
+**Alternatives considered:** Broader AHCI, CPU routing, timer fallback, or Parallels-specific mechanisms.
+**Evidence:** The task contract explicitly identifies deferred waitqueue wake latency as the remaining Linux-parity gap and prohibits those alternative mechanisms.

--- a/docs/planning/f32f-immediate-wake/exit.md
+++ b/docs/planning/f32f-immediate-wake/exit.md
@@ -1,0 +1,81 @@
+# F32f Exit - Immediate Wake Under Waitqueue Lock
+
+## Status
+
+Stopped after Phase 3 Run 1 failed the Parallels boot gate. Do not merge this branch as a completed F32f fix.
+
+Implemented work remains useful evidence:
+
+- Audit committed: `acbe68d7 docs(kernel): F32f audit Linux immediate wake path`
+- Immediate task-context waitqueue wake committed: `7674d3c5 fix(kernel): F32f immediate waitqueue wake from task context`
+
+## Original Ask
+
+F32f tested whether Breenix's remaining bwm/bsshd Parallels stall was caused by a Linux-parity gap in the waitqueue wake path. Linux calls `try_to_wake_up` from waitqueue traversal under `wq_head->lock`, while Breenix F32e deferred waitqueue wakes through the ISR wake ring. The requested change was to wake task-context waitqueue callers inline and keep the deferred ring only for genuine interrupt-context wakers.
+
+## Audit Findings
+
+Linux `__wake_up_common_lock` holds `wq_head->lock`, calls `__wake_up_common`, then releases the lock (`/tmp/linux-v6.8/kernel/sched/wait.c:99-108`). `__wake_up_common` invokes each waiter's wake function while that lock is held (`/tmp/linux-v6.8/kernel/sched/wait.c:73-96`).
+
+Linux `autoremove_wake_function` calls `default_wake_function` and removes the wait-list entry only after a successful wake (`/tmp/linux-v6.8/kernel/sched/wait.c:382-389`). `try_to_wake_up` documents the contract: if the requested state matches, set the task to running and enqueue it if needed (`/tmp/linux-v6.8/kernel/sched/core.c:4186-4197`).
+
+Linux takes scheduler locks inside the waitqueue traversal, not the other way around: `try_to_wake_up` uses `p->pi_lock`, state matching, optional `TASK_WAKING`, and `ttwu_queue` while the waitqueue wake function is still executing (`/tmp/linux-v6.8/kernel/sched/core.c:4247-4369`). Remote delivery uses wake-list/IPI machinery as delivery support after the state decision (`/tmp/linux-v6.8/kernel/sched/core.c:3930-3944`), while local enqueue takes the runqueue lock directly (`/tmp/linux-v6.8/kernel/sched/core.c:4038-4049`).
+
+Breenix F32e was not equivalent for task-context waitqueue callers: `WaitQueueHead::wake_up` removed waiters and pushed their TIDs into `isr_unblock_for_io`; the real `BlockedOnIO -> Ready` transition occurred only later when a scheduler drain called `unblock_for_io`.
+
+## Implementation
+
+`WaitQueueHead::wake_up` and `wake_up_one` now pop waiters while holding the waitqueue lock and call `wake_waiter` inline (`kernel/src/task/waitqueue.rs:105-120`).
+
+`wake_waiter` checks interrupt context. Interrupt-context callers still use `scheduler::isr_unblock_for_io`; task-context callers use `scheduler::wake_waitqueue_thread` (`kernel/src/task/waitqueue.rs:172-188`).
+
+`Scheduler::wake_waitqueue_thread` reuses the common I/O wake transition path, which sets `BlockedOnIO` threads ready, clears `wake_time_ns`, queues them when their old CPU no longer owns the thread, sets `need_resched`, and sends a targeted AArch64 reschedule IPI for remote targets (`kernel/src/task/scheduler.rs:1713-1772`, `kernel/src/task/scheduler.rs:1346-1362`, `kernel/src/task/scheduler.rs:2467-2473`).
+
+The ISR wake path remains in place for AHCI/completion-style hard IRQ callers (`kernel/src/task/scheduler.rs:2626-2645`).
+
+## Validation
+
+Build gates passed clean:
+
+- `cargo build --release --features testing,external_test_bins --bin qemu-uefi`
+- `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64`
+
+Formatting note: full-workspace `cargo fmt` is blocked by pre-existing trailing whitespace in unrelated test files. The changed kernel files were formatted with targeted `rustfmt`, and `git diff --check` passed.
+
+Wait-stress passed:
+
+- Command: `BREENIX_WAIT_STRESS=1 ./run.sh --parallels --test 150`
+- Evidence: `WAIT_STRESS_PASS entered=596936 returned=596935 wakes=700683 waiters=0`
+- No `WAIT_STRESS_STALL`
+- No AHCI timeout markers
+- Strict screenshot verdict: `PASS`
+
+Parallels normal boot failed on the first 120s run:
+
+- Command: `./run.sh --parallels --test 120`
+- bsshd launched and listened
+- Serial stopped at `[spawn] path='/bin/bounce'`
+- Missing `[init] bounce started`
+- Missing `[bounce] Window mode`
+- Missing sustained `Frame #...` cadence for FPS validation
+- Missing CPU0 tick evidence
+- No AHCI timeout markers
+- Strict screenshot verdict: `PASS`
+
+## Sweep Table
+
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| Standard x86_64 build | PASS | `/tmp/f32f-build-clean.log` |
+| AArch64 kernel build | PASS | `/tmp/f32f-aarch64-build-clean.log` |
+| wait_stress 60s+ | PASS | `.factory-runs/f32f-immediate-wake/wait-stress.serial.log:417` |
+| Parallels 120s run 1 | FAIL | `.factory-runs/f32f-immediate-wake/parallels-run1.serial.log:387-390` |
+| Parallels runs 2-5 | NOT RUN | Stopped per F32f instruction after run 1 failed |
+
+## Decision
+
+The immediate-wake Linux-parity gap existed and was closed, but the required Parallels boot sweep did not pass. Since wait-stress passed and the normal Parallels boot still failed, the remaining issue is not waitqueue wake latency. Per the run instructions, stop here and do not iterate another mechanism change.
+
+## PR
+
+No PR opened. The 5/5 Parallels requirement was not met.

--- a/docs/planning/f32f-immediate-wake/plan.md
+++ b/docs/planning/f32f-immediate-wake/plan.md
@@ -1,0 +1,27 @@
+# Plan - F32f Immediate Wake Under Waitqueue Lock
+
+## Milestones
+
+### M1. Linux/Breenix Wake Audit
+- Files: `docs/planning/f32f-immediate-wake/audit.md`, `scratchpad.md`, `decisions.md`
+- Description: Read Linux `try_to_wake_up`, Linux waitqueue wake code, and Breenix waitqueue/scheduler/interrupt paths. Document where state changes occur, who drains deferred wakes, and whether task-context callers are unnecessarily routed through the ISR ring.
+- Validation command: `test -s docs/planning/f32f-immediate-wake/audit.md && rg "Linux citations|Breenix findings|Conclusion" docs/planning/f32f-immediate-wake/audit.md`
+- Maps to deliverable: Phase 1 audit.
+
+### M2. Immediate Task-Context Wake
+- Files: `kernel/src/task/waitqueue.rs`, `kernel/src/task/scheduler.rs`, possible narrowly scoped scheduler helpers
+- Description: Add a task-context wake path that removes waiters under the waitqueue lock and transitions/enqueues them immediately, keeping genuine IRQ wakeups on the existing deferred path.
+- Validation command: `cargo build --release --features testing,external_test_bins --bin qemu-uefi`
+- Maps to deliverable: Phase 2 fix.
+
+### M3. Required Validation
+- Files: `docs/planning/f32f-immediate-wake/exit.md`, `scratchpad.md`
+- Description: Run wait-stress and Parallels boot gates. If pass criteria are not met, document the evidence and stop.
+- Validation command: `cargo run -p xtask -- boot-stages`
+- Maps to deliverable: Phase 3 validation and Phase 4 decision.
+
+### M4. Merge Or Stop
+- Files: issue tracker, git branch, PR
+- Description: If all gates pass, push, open PR, merge, return to `main`, and close Beads. If not, commit exit documentation and stop.
+- Validation command: `git status --short --branch`
+- Maps to deliverable: Phase 4 merge or honest stop.

--- a/docs/planning/f32f-immediate-wake/prompt.md
+++ b/docs/planning/f32f-immediate-wake/prompt.md
@@ -1,0 +1,29 @@
+# Factory: F32f Immediate Wake Under Waitqueue Lock
+
+## Goals
+- Audit Linux waitqueue wake semantics against Breenix's current waitqueue wake path.
+- Implement immediate task-context waitqueue wake while preserving the deferred ISR wake path.
+- Validate that waitqueue stress remains race-free and that Parallels boot no longer stalls.
+
+## Hard Constraints
+- Preserve F32e's lock scope: hold the waitqueue lock only across enqueue/state publication, never across schedule.
+- Do not modify Tier 1 prohibited files.
+- Do not add timer-driven wake fallbacks, arbitrary timeouts, CPU routing workarounds, or Parallels-specific workarounds.
+- Cite Linux file:line evidence for semantic choices.
+- If validation does not reach the requested pass criteria, stop and write honest exit documentation.
+
+## Deliverables
+- `docs/planning/f32f-immediate-wake/audit.md` with Linux and Breenix wake-path findings.
+- A task-context immediate waitqueue wake implementation, if the audit confirms the deferred gap.
+- Validation evidence for `wait_stress` and Parallels boot gates.
+- `docs/planning/f32f-immediate-wake/exit.md` with final status, evidence, and PR URL if merged.
+
+## Done When
+- Audit committed with Linux citations.
+- Fix committed with Linux citations.
+- `wait_stress` 60 seconds passes with zero stalls.
+- 5 out of 5 Parallels 120-second boots pass the requested lifecycle, CPU tick, FPS, render, and AHCI checks.
+- PR is opened, merged, and the checkout is back on `main`; otherwise exit documentation explains the stopping point.
+
+## Runbook
+Follow `/Users/wrb/getfastr/code/fastr-ai-skills/general-dev/factory-orchestration/implement.md`.

--- a/docs/planning/f32f-immediate-wake/scratchpad.md
+++ b/docs/planning/f32f-immediate-wake/scratchpad.md
@@ -14,3 +14,12 @@ Starting M2. I will leave `Completion::complete` and `isr_unblock_for_io` untouc
 
 ## 2026-04-18T22:39:00Z
 M2 implementation done in `kernel/src/task/waitqueue.rs` and `kernel/src/task/scheduler.rs`. Standard release build passed with no warning/error lines in `/tmp/f32f-build-clean.log`; aarch64 kernel build passed with no warning/error lines in `/tmp/f32f-aarch64-build-clean.log`. `cargo fmt` across the workspace is blocked by pre-existing trailing whitespace in unrelated tests, so I used targeted `rustfmt` on the changed kernel files and verified `git diff --check`.
+
+## 2026-04-18T22:11:18Z
+Starting M3 wait-stress validation. Command: `BREENIX_WAIT_STRESS=1 ./run.sh --parallels --test 150`. I cleaned QEMU processes first per repo protocol, even though this gate uses Parallels.
+
+## 2026-04-18T22:15:00Z
+Wait-stress gate passed. Serial evidence: `WAIT_STRESS_PASS entered=596936 returned=596935 wakes=700683 waiters=0`, no `WAIT_STRESS_STALL`. Strict screenshot verdict also passed. Next: normal Parallels `./run.sh --parallels --test 120` runs, stopping on the first failed gate.
+
+## 2026-04-18T22:19:08Z
+Parallels normal boot run 1 failed the gate. Serial reached `bsshd: listening on 0.0.0.0:2222` and `[init] bsshd started (PID 4)`, then stopped at `[spawn] path='/bin/bounce'`. Missing bounce lifecycle, sustained frame cadence/FPS evidence, and CPU0 tick evidence. No AHCI timeout markers; strict screenshot verdict was `PASS`. Per F32f instructions, stop and document that the remaining Parallels issue is not task-context waitqueue wake latency.

--- a/docs/planning/f32f-immediate-wake/scratchpad.md
+++ b/docs/planning/f32f-immediate-wake/scratchpad.md
@@ -1,0 +1,10 @@
+# Scratchpad - F32f Immediate Wake Under Waitqueue Lock
+
+## 2026-04-18T22:02:39Z
+Starting M1. I will collect line-numbered Linux evidence for `try_to_wake_up`, `__wake_up_common`, and `autoremove_wake_function`, then map the current Breenix waitqueue wake path through scheduler drain sites and interrupt/task context callers.
+
+## 2026-04-18T22:12:00Z
+M1 findings: Linux `__wake_up_common_lock` holds `wq_head->lock` while invoking each waiter's wake function (`wait.c:99-108`), `autoremove_wake_function` calls `default_wake_function` and removes the entry only on successful wake (`wait.c:382-389`), and `try_to_wake_up` performs the state match/state transition and runqueue enqueue before returning (`core.c:4186-4375`). Breenix `WaitQueueHead::wake_up` currently pops waiters under the waitqueue lock and calls `isr_unblock_for_io` (`waitqueue.rs:104-119`), while the scheduler drains the ring and calls `unblock_for_io` later from `schedule()`/`schedule_deferred_requeue()` (`scheduler.rs:671-680`, `scheduler.rs:921-933`).
+
+## 2026-04-18T22:17:00Z
+M1 validation passed with `test -s docs/planning/f32f-immediate-wake/audit.md && rg "Linux Citations|Breenix Findings|Conclusion" docs/planning/f32f-immediate-wake/audit.md`. Next I will commit the audit docs, then start M2 by adding a scheduler helper for immediate task-context waitqueue wake.

--- a/docs/planning/f32f-immediate-wake/scratchpad.md
+++ b/docs/planning/f32f-immediate-wake/scratchpad.md
@@ -8,3 +8,9 @@ M1 findings: Linux `__wake_up_common_lock` holds `wq_head->lock` while invoking 
 
 ## 2026-04-18T22:17:00Z
 M1 validation passed with `test -s docs/planning/f32f-immediate-wake/audit.md && rg "Linux Citations|Breenix Findings|Conclusion" docs/planning/f32f-immediate-wake/audit.md`. Next I will commit the audit docs, then start M2 by adding a scheduler helper for immediate task-context waitqueue wake.
+
+## 2026-04-18T22:22:00Z
+Starting M2. I will leave `Completion::complete` and `isr_unblock_for_io` untouched for hard IRQ completion wakes, add an immediate waitqueue wake wrapper around the existing scheduler `unblock_for_io` state transition, and have `WaitQueueHead::wake_up` choose immediate vs deferred based on interrupt context.
+
+## 2026-04-18T22:39:00Z
+M2 implementation done in `kernel/src/task/waitqueue.rs` and `kernel/src/task/scheduler.rs`. Standard release build passed with no warning/error lines in `/tmp/f32f-build-clean.log`; aarch64 kernel build passed with no warning/error lines in `/tmp/f32f-aarch64-build-clean.log`. `cargo fmt` across the workspace is blocked by pre-existing trailing whitespace in unrelated tests, so I used targeted `rustfmt` on the changed kernel files and verified `git diff --check`.

--- a/docs/planning/f32h-ahci-wake/audit.md
+++ b/docs/planning/f32h-ahci-wake/audit.md
@@ -1,0 +1,145 @@
+# F32h Linux AHCI Wake Audit
+
+## Question
+
+Linux completes AHCI I/O from interrupt context and can wake the blocked task
+directly from that context. Breenix currently defers AHCI completion wakeups
+through `isr_unblock_for_io()`. This audit checks whether the deferred ring was
+introduced for a still-valid reason and what Linux does instead.
+
+## Linux AHCI Completion Path
+
+Linux AHCI IRQ handling reads the port status, acknowledges it, and completes
+commands while still in the interrupt path:
+
+- `/tmp/linux-v6.8/drivers/ata/libahci.c:1963-1966`: `ahci_port_intr()` reads
+  `PORT_IRQ_STAT`, writes the value back to acknowledge, then calls
+  `ahci_handle_port_interrupt()`.
+- `/tmp/linux-v6.8/drivers/ata/libahci.c:1975-1980`:
+  `ahci_multi_irqs_intr_hard()` does the same under `spin_lock(ap->lock)`.
+- `/tmp/linux-v6.8/drivers/ata/libahci.c:1863-1888`: `ahci_qc_complete()`
+  reads `PORT_SCR_ACT` and/or `PORT_CMD_ISSUE` to compute the still-active
+  command mask, then calls `ata_qc_complete_multiple(ap, qc_active)`.
+- `/tmp/linux-v6.8/drivers/ata/libahci.c:1896-1955`:
+  `ahci_handle_port_interrupt()` handles error/SDB cases and then calls
+  `ahci_qc_complete()` for completed commands.
+
+Linux libata's multiple-completion helper is explicitly intended for IRQ
+handlers:
+
+- `/tmp/linux-v6.8/drivers/ata/libata-sata.c:630-641` documents
+  `ata_qc_complete_multiple()` as the helper for completing in-flight commands
+  from a low-level driver's interrupt routine.
+- `/tmp/linux-v6.8/drivers/ata/libata-sata.c:664-685` computes `done_mask` and
+  calls `ata_qc_complete(qc)` for each completed tag.
+- `/tmp/linux-v6.8/drivers/ata/libata-core.c:4870-4872` documents
+  `ata_qc_complete()` locking as `spin_lock_irqsave(host lock)`.
+- `/tmp/linux-v6.8/drivers/ata/libata-core.c:4966-4969` reaches
+  `__ata_qc_complete(qc)` for normal completion.
+- `/tmp/linux-v6.8/drivers/ata/libata-core.c:4798-4834` clears active state and
+  calls `qc->complete_fn(qc)`.
+
+The block layer then ends the request and bios:
+
+- `/tmp/linux-v6.8/block/blk-mq.c:1058-1063`: `blk_mq_end_request()` calls
+  `blk_update_request()` and `__blk_mq_end_request()`.
+- `/tmp/linux-v6.8/block/blk-mq.c:895-987`: `blk_update_request()` advances
+  request bios and calls `req_bio_endio()`.
+- `/tmp/linux-v6.8/block/blk-mq.c:765-793`: `req_bio_endio()` calls
+  `bio_endio()` when a bio is fully consumed.
+- `/tmp/linux-v6.8/block/bio.c:1576-1608`: `bio_endio()` invokes
+  `bio->bi_end_io(bio)`.
+- `/tmp/linux-v6.8/block/bio.c:1352-1355`: `submit_bio_wait_endio()` wakes the
+  waiter by calling `complete(bio->bi_private)`.
+
+## Linux completion() Wake Path
+
+Linux `complete()` is IRQ-safe because it uses raw spinlocks and the scheduler's
+real wake path:
+
+- `/tmp/linux-v6.8/kernel/sched/completion.c:16-25`:
+  `complete_with_flags()` takes `x->wait.lock` with `raw_spin_lock_irqsave()`,
+  increments `x->done`, calls `swake_up_locked()`, then unlocks.
+- `/tmp/linux-v6.8/kernel/sched/completion.c:45-48`: `complete()` is a thin
+  wrapper around `complete_with_flags(x, 0)`.
+- `/tmp/linux-v6.8/kernel/sched/swait.c:21-30`: `swake_up_locked()` selects the
+  first waiter and calls `try_to_wake_up(curr->task, TASK_NORMAL, wake_flags)`
+  before removing it from the wait list.
+- `/tmp/linux-v6.8/kernel/sched/swait.c:38-40` explicitly notes that the locked
+  all-waiters variant is designed for hard interrupt context and interrupt
+  disabled regions.
+- `/tmp/linux-v6.8/kernel/sched/core.c:4186-4222`: `try_to_wake_up()` is the
+  core wake operation, documented as atomically changing a matching task state
+  to runnable and enqueueing it if it is not already queued/runnable.
+- `/tmp/linux-v6.8/kernel/sched/core.c:4253-4369`: the implementation uses
+  `p->pi_lock`, memory barriers, `p->on_rq`/`p->on_cpu` ordering, and runqueue
+  queueing rather than deferring to an out-of-band ring.
+- `/tmp/linux-v6.8/kernel/sched/core.c:4499-4507`: `wake_up_process()` and
+  `wake_up_state()` are direct wrappers over `try_to_wake_up()`.
+
+The key Linux property is not merely "wake from IRQ". It is "wake from IRQ while
+holding only scheduler-designed raw spinlocks and using the same state/on-rq
+protocol as normal task wakeups."
+
+## Why Breenix Introduced the Deferred Ring
+
+Git history shows the reason directly:
+
+- Commit `4caa26395bae48ea134b30867099f38c82704514`
+  (`perf: lock-free ISR wakeup buffer to eliminate SCHEDULER contention from
+  ISR`) introduced the current `isr_unblock_for_io()` buffer.
+- The commit message says the AHCI ISR previously called
+  `with_scheduler(|s| s.unblock_for_io(tid))`, spinning on the global
+  `SCHEDULER` mutex with IRQs masked on CPU0. Contention from seven other CPUs
+  kept CPU0 IRQ-masked for milliseconds, starving its timer (`5 ticks in 30s`
+  versus roughly 4000 expected) and stalling AHCI SPI34.
+- The replacement was a per-CPU atomic slot buffer: the ISR pushes the tid,
+  sets reschedule state, and the scheduler drains all buffers later under its
+  normal lock.
+
+That reason was valid at introduction time. Breenix did not have Linux's
+fine-grained IRQ-safe scheduler wake machinery. Calling through the global
+scheduler mutex from hard IRQ context was not equivalent to Linux
+`try_to_wake_up()`; it was an IRQ-masked spin on a contended global lock.
+
+## Is The Reason Still Valid?
+
+Partly yes, partly no.
+
+Still valid:
+
+- Breenix still has a global `SCHEDULER: Mutex<Option<Scheduler>>` for broad
+  scheduler state. Reintroducing `with_scheduler()` from AHCI hard IRQ would
+  recreate the exact `4caa2639` failure mode.
+- Linux's direct IRQ wake is safe because the locks are raw spinlocks designed
+  for IRQ context (`completion.c:20`, `swait.c:21-30`, `core.c:4253-4369`), not
+  because immediate wakeups are inherently safe.
+
+Not sufficient anymore:
+
+- F32e/F32f moved task-context waitqueue wake toward Linux parity, including a
+  tighter prepare-to-wait sequence and immediate task-context wake. That leaves
+  the ISR completion path as the outlier.
+- F32h evidence shows the deferred buffer can drain promptly in the captured
+  failures, but the architecture still has a semantic mismatch with Linux:
+  completion wake is not one atomic scheduler wake operation. It is split into
+  "publish tid into side buffer" and "some later scheduler entry converts state
+  and queues the task."
+- That split creates extra states Linux avoids. A task can be completed but not
+  yet scheduler-visible until a drain runs, and the drain depends on scheduler
+  progress on some CPU. The captured F32h failures show CPU0/global tick
+  progress stops while other timer IRQs continue, so the design still depends on
+  exactly the progress mechanism that is suspect.
+
+## Audit Conclusion
+
+Linux's AHCI path completes I/O in IRQ context and reaches `complete()`, which
+immediately calls the scheduler wake path (`try_to_wake_up(..., TASK_NORMAL, ...)`)
+through IRQ-safe raw spinlocks.
+
+Breenix's deferred ISR wake buffer was introduced for a real reason: avoiding
+global scheduler mutex contention from hard IRQ context. The fix should not
+revert to the old `with_scheduler()` call. However, the deferred ring is also not
+Linux parity. The Linux-parity direction is an IRQ-safe immediate wake path that
+uses a scheduler-safe lock subset, not the global mutex and not an unbounded
+deferred side channel.

--- a/docs/planning/f32h-ahci-wake/evidence.md
+++ b/docs/planning/f32h-ahci-wake/evidence.md
@@ -1,0 +1,236 @@
+# F32h AHCI Wake Evidence
+
+## Capture Method
+
+F32h used temporary in-memory tracing probes only. No serial breadcrumbs were
+added near spawn, AHCI IRQ handling, completion wake, or scheduler wake paths.
+The probes wrote `F32H_*` records into the existing per-CPU trace buffers and
+were dumped only after a soft-lockup detector fired. The temporary probes were
+removed before committing this document.
+
+The all-CPU soft-lockup trigger used for these captures was also temporary. Run
+1 reproduced the original no-progress spawn stall at `[spawn] path='/bin/bwm'`,
+but CPU0 did not emit a lockup dump within 120s. That is itself useful evidence:
+the old CPU0-only dump path misses the same signature where CPU0 stops making
+timer progress.
+
+Raw artifacts are under:
+
+- `.factory-runs/f32h-ahci-wake-20260419_050419/parallels-run1/serial.log`
+- `.factory-runs/f32h-ahci-wake-20260419_050419/parallels-run3/serial.log`
+- `.factory-runs/f32h-ahci-wake-20260419_050419/parallels-run4/serial.log`
+
+## Summary Finding
+
+The two trace-backed failing Parallels runs do not show an unconsumed ISR wake
+ring entry. For the observed ext2 reads, the chain completes:
+
+`wait blocks -> AHCI IRQ fires -> command completion sees waiter tid 10 ->
+isr_unblock_for_io(10) pushes the ISR buffer -> scheduler drains it -> wake_io
+sees BlockedOnIO -> task is made runnable/enqueued`.
+
+The break seen in these captures is after wake/enqueue, in scheduler or timer
+progress. This does not prove the deferred ring is correct in every interleaving,
+but it disproves "ring write not consumed" for the captured failures.
+
+## Run 3: Failure After bsshd, Before Normal bounce Startup
+
+Serial progression:
+
+- `serial.log:372`: `[spawn] path='/bin/bsshd'`
+- `serial.log:381`: bsshd process creation succeeds
+- `serial.log:386`: `[init] bsshd started (PID 4)`
+- `serial.log:389`: soft lockup dump starts before normal bounce startup
+
+At the first dump:
+
+- Ready queue length is 0 (`serial.log:392`).
+- CPU0 is idle-current with init as previous: `CPU 0: current=0 previous=10`
+  (`serial.log:396`).
+- Init, tid 10, is not stranded as BlockedOnIO at the dump. In the first dump it
+  is `state=T` (BlockedOnTimer) (`serial.log:415`); later dumps show tid 10 as
+  `state=R` (`serial.log:920`, `serial.log:5665`, `serial.log:10400`).
+- The global tick counter is stuck at 147 while aggregate timer IRQs continue:
+  `TIMER_TICK_TOTAL: 7473`, later `129474`, `287417`, `407140`, while
+  `Global ticks: 147` remains unchanged (`serial.log:5608-5615`,
+  `10353-10360`, `19818-19825`, `38738-38745`).
+
+Representative ext2/AHCI completion chain for command token 794:
+
+```text
+serial.log:446  CPU0 ts=63702363 F32H_WAIT_ENTRY expected_token=794
+serial.log:447  CPU0 ts=63702363 F32H_WAIT_WAITER_SET tid=10
+serial.log:448  CPU0 ts=63702388 F32H_WAIT_BLOCK tid=10
+serial.log:461  CPU0 ts=63702923 F32H_AHCI_IRQ_HBA_IS hba_is=2
+serial.log:462  CPU0 ts=63703054 F32H_AHCI_PORT_IS port_is=1 flags=0x1
+serial.log:463  CPU0 ts=63703054 F32H_AHCI_PORT_CI port_ci=0 flags=0x1
+serial.log:464  CPU0 ts=63703054 F32H_AHCI_ACTIVE active_mask=1 flags=0x1
+serial.log:465  CPU0 ts=63703168 F32H_AHCI_COMPLETED completed_slots=1 flags=0x1
+serial.log:466  CPU0 ts=63703168 F32H_AHCI_CMD cmd_num=794 flags=0x1
+serial.log:467  CPU0 ts=63703168 F32H_AHCI_WAITER waiter_tid=10 flags=0x1
+serial.log:468  CPU0 ts=63703231 F32H_AHCI_COMPLETE_CALL cmd_num=794 flags=0x1
+serial.log:469  CPU0 ts=63703232 F32H_COMPLETE_DONE token=794
+serial.log:470  CPU0 ts=63703232 F32H_COMPLETE_WAITER tid=10
+serial.log:471  CPU0 ts=63703232 F32H_ISR_UNBLOCK_CALL tid=10
+serial.log:472  CPU0 ts=63703232 F32H_ISR_BUF_PUSH tid=10
+serial.log:473  CPU0 ts=63703413 F32H_ISR_DRAIN_TID src_cpu<<24|tid=10
+serial.log:474  CPU0 ts=63703426 F32H_WAKE_IO_BEFORE state<<24|tid=100663306
+serial.log:475  CPU0 ts=63703430 F32H_WAKE_IO_AFTER target<<24|current<<16|tid=16711690
+```
+
+Decode:
+
+- `state<<24|tid=100663306` is `0x0600000a`: state 6 is BlockedOnIO, tid 10.
+- `target<<24|current<<16|tid=16711690` is `0x00ff000a`: target CPU 0,
+  current CPU sentinel 0xff, tid 10. The task was enqueued for CPU0 and was not
+  current on any CPU at that wake.
+- The ISR buffer push-to-drain latency for this token is
+  `63703413 - 63703232 = 181` trace timestamp ticks.
+
+The run also captured fast completions where the IRQ beat waiter installation.
+For token 797, AHCI command completion appears before the wait entry:
+
+```text
+serial.log:580  CPU0 ts=63709522 F32H_AHCI_CMD cmd_num=797 flags=0x1
+serial.log:581  CPU0 ts=63709522 F32H_AHCI_WAITER waiter_tid=0 flags=0x1
+serial.log:583  CPU0 ts=63709929 F32H_COMPLETE_DONE token=797
+serial.log:584  CPU0 ts=63709929 F32H_COMPLETE_WAITER tid=0
+serial.log:585  CPU0 ts=63710186 F32H_WAIT_ENTRY expected_token=797
+```
+
+That is a valid fast-path case, not the stall: the waiter is absent because the
+completion finished before the task committed to blocking.
+
+Ring snapshot at the first dump:
+
+```text
+serial.log:1957 CPU0 F32H_ISR_RING_DEPTH cpu<<16|depth=0
+serial.log:1958 CPU0 F32H_ISR_RING_DEPTH cpu<<16|depth=65536 flags=0x1
+serial.log:1959 CPU0 F32H_ISR_RING_DEPTH cpu<<16|depth=131072 flags=0x2
+serial.log:1960 CPU0 F32H_ISR_RING_DEPTH cpu<<16|depth=196608 flags=0x3
+serial.log:1961 CPU0 F32H_ISR_RING_DEPTH cpu<<16|depth=262144 flags=0x4
+serial.log:1962 CPU0 F32H_ISR_RING_DEPTH cpu<<16|depth=327680 flags=0x5
+serial.log:1963 CPU0 F32H_ISR_RING_DEPTH cpu<<16|depth=393216 flags=0x6
+serial.log:1964 CPU0 F32H_ISR_RING_DEPTH cpu<<16|depth=458752 flags=0x7
+```
+
+The payload is `(cpu << 16) | depth`; all depths are 0. The current structure is
+a per-CPU slot buffer rather than a head/tail ring, so "head/tail" maps to
+"pending slot count" for this implementation.
+
+## Run 4: Failure At telnetd Spawn
+
+Serial progression:
+
+- `serial.log:340`: `[spawn] path='/bin/bwm'`
+- `serial.log:349`: bwm process creation succeeds
+- `serial.log:360`: `[spawn] path='/sbin/telnetd'`
+- `serial.log:363`: soft lockup dump starts before telnetd process creation
+  finishes
+
+At the first dump:
+
+- Ready queue length is 0 (`serial.log:366`).
+- CPU0 is idle-current with init as previous: `CPU 0: current=0 previous=10`
+  (`serial.log:370`).
+- Init, tid 10, is `state=R` (`serial.log:389`).
+- Global ticks are stuck at 72 while aggregate timer IRQs continue:
+  `TIMER_TICK_TOTAL: 4272` then `82131`, while `Global ticks: 72` remains
+  unchanged (`serial.log:4001-4008`, `11318-11325`).
+
+Representative chain for command token 417:
+
+```text
+serial.log:439  CPU0 ts=57284348 F32H_WAIT_ENTRY expected_token=417
+serial.log:440  CPU0 ts=57284349 F32H_WAIT_WAITER_SET tid=10
+serial.log:441  CPU0 ts=57284381 F32H_WAIT_BLOCK tid=10
+serial.log:454  CPU0 ts=57284615 F32H_AHCI_IRQ_HBA_IS hba_is=2
+serial.log:455  CPU0 ts=57284743 F32H_AHCI_PORT_IS port_is=1 flags=0x1
+serial.log:456  CPU0 ts=57284743 F32H_AHCI_PORT_CI port_ci=0 flags=0x1
+serial.log:457  CPU0 ts=57284743 F32H_AHCI_ACTIVE active_mask=1 flags=0x1
+serial.log:458  CPU0 ts=57284837 F32H_AHCI_COMPLETED completed_slots=1 flags=0x1
+serial.log:459  CPU0 ts=57284837 F32H_AHCI_CMD cmd_num=417 flags=0x1
+serial.log:460  CPU0 ts=57284837 F32H_AHCI_WAITER waiter_tid=10 flags=0x1
+serial.log:461  CPU0 ts=57284897 F32H_AHCI_COMPLETE_CALL cmd_num=417 flags=0x1
+serial.log:462  CPU0 ts=57284897 F32H_COMPLETE_DONE token=417
+serial.log:463  CPU0 ts=57284897 F32H_COMPLETE_WAITER tid=10
+serial.log:464  CPU0 ts=57284897 F32H_ISR_UNBLOCK_CALL tid=10
+serial.log:465  CPU0 ts=57284897 F32H_ISR_BUF_PUSH tid=10
+serial.log:466  CPU0 ts=57285048 F32H_ISR_DRAIN_TID src_cpu<<24|tid=10
+serial.log:467  CPU0 ts=57285061 F32H_WAKE_IO_BEFORE state<<24|tid=100663306
+serial.log:468  CPU0 ts=57285062 F32H_WAKE_IO_AFTER target<<24|current<<16|tid=16711690
+```
+
+Decode:
+
+- `0x0600000a`: tid 10 was BlockedOnIO at wake.
+- `0x00ff000a`: tid 10 was enqueued for CPU0 and not current.
+- Push-to-drain latency is `57285048 - 57284897 = 151` trace timestamp ticks.
+
+Ring snapshot:
+
+```text
+serial.log:3673 CPU6 F32H_ISR_RING_DEPTH cpu<<16|depth=0
+serial.log:3674 CPU6 F32H_ISR_RING_DEPTH cpu<<16|depth=65536 flags=0x1
+serial.log:3675 CPU6 F32H_ISR_RING_DEPTH cpu<<16|depth=131072 flags=0x2
+serial.log:3676 CPU6 F32H_ISR_RING_DEPTH cpu<<16|depth=196608 flags=0x3
+serial.log:3677 CPU6 F32H_ISR_RING_DEPTH cpu<<16|depth=262144 flags=0x4
+serial.log:3678 CPU6 F32H_ISR_RING_DEPTH cpu<<16|depth=327680 flags=0x5
+serial.log:3679 CPU6 F32H_ISR_RING_DEPTH cpu<<16|depth=393216 flags=0x6
+serial.log:3680 CPU6 F32H_ISR_RING_DEPTH cpu<<16|depth=458752 flags=0x7
+```
+
+Again, all per-CPU pending depths decode to 0.
+
+## Direct Answers
+
+1. When `load_elf_from_ext2` blocks, the blocking thread is tid 10, the init
+   task. It blocks on an AHCI per-slot completion token, not a waitqueue. The
+   wake trace confirms the blocked state as BlockedOnIO (`state=6`) immediately
+   before the ISR wake transition.
+
+2. Yes. In run 3, token 794 blocks at ts 63702388 and the AHCI IRQ arrives at
+   ts 63702923 with `hba_is=2`, `port_is=1`, `port_ci=0`, `active_mask=1`, and
+   `completed_slots=1`. In run 4, token 417 blocks at ts 57284381 and the IRQ
+   arrives at ts 57284615 with the same PxIS/PxCI completion pattern.
+
+3. Yes. Run 3 token 794 records `F32H_AHCI_WAITER waiter_tid=10`,
+   `F32H_COMPLETE_WAITER tid=10`, and `F32H_ISR_UNBLOCK_CALL tid=10`. Run 4
+   token 417 records the same sequence for tid 10.
+
+4. Yes. Run 3 drains on CPU0 181 trace timestamp ticks after the push. Run 4
+   drains on CPU0 151 trace timestamp ticks after the push. Other later drains
+   also appear on CPUs 1, 2, 5, 6, and 7, which confirms cross-CPU drain is
+   active, but the representative failing-spawn chains above drain on CPU0.
+
+5. At the first trace dump in both trace-backed failures, all per-CPU pending
+   depths are 0. This implementation has fixed per-CPU slots rather than
+   head/tail indices.
+
+6. CPU0 is idle-current at the dumps (`current=0`) with init as its previous
+   thread (`previous=10`). In run 4, init is Ready at the dump. In run 3, the
+   first dump catches init BlockedOnTimer, and later dumps catch it Ready.
+
+7. The aggregate timer interrupt counter continues advancing on other CPUs, but
+   the global tick counter stops. Run 3 keeps `Global ticks: 147` while
+   `TIMER_TICK_TOTAL` rises from 7473 to 407140. Run 4 keeps `Global ticks: 72`
+   while `TIMER_TICK_TOTAL` rises from 4272 to 82131. This matches the F32c
+   signature class: CPU0/global tick progress stops while other CPUs still take
+   timer interrupts.
+
+## Break In Chain
+
+For both trace-backed failures, the chain does not break at:
+
+- AHCI IRQ delivery
+- PxIS/PxCI completion detection
+- completion waiter lookup
+- `isr_unblock_for_io(tid)`
+- ISR buffer push
+- ISR buffer drain
+- `BlockedOnIO -> Ready` transition
+
+The captured break is after the task is made runnable/enqueued, with CPU0/global
+tick progress stalled and ready queue state inconsistent with expected forward
+progress. F32i should therefore avoid assuming an unconsumed ISR ring entry
+unless a future capture catches non-zero pending slot depth or a missing drain.

--- a/docs/planning/f32h-ahci-wake/proposal.md
+++ b/docs/planning/f32h-ahci-wake/proposal.md
@@ -1,0 +1,200 @@
+# F32h Proposed ISR Wake Fix Design
+
+## Constraints
+
+This is design only. Do not implement in F32h.
+
+The design must preserve F32e/F32f:
+
+- Keep the Linux-style prepare-to-wait ordering.
+- Keep immediate task-context waitqueue wake.
+- Do not add serial output or logging to AHCI, syscall, interrupt, or scheduler
+  hot paths.
+- Do not call the global scheduler mutex from hard IRQ context.
+
+F32h evidence changes the starting assumption: the two trace-backed failures did
+not show a stuck pending ISR wake entry. The representative chains reached
+`BlockedOnIO -> Ready` and enqueued tid 10. Therefore the proposed fix should be
+framed as Linux-parity risk reduction for the ISR wake design, not as a proven
+fix for an observed non-draining ring in these captures.
+
+## Option A: IRQ-Safe Immediate Wake For I/O Completions
+
+Replace `isr_unblock_for_io(tid)`'s deferred-buffer publish with an IRQ-safe
+immediate wake operation that performs the state transition and runqueue enqueue
+inline from interrupt context.
+
+Linux cite:
+
+- `/tmp/linux-v6.8/kernel/sched/completion.c:16-25`: `complete_with_flags()`
+  uses `raw_spin_lock_irqsave()` and calls `swake_up_locked()`.
+- `/tmp/linux-v6.8/kernel/sched/swait.c:21-30`: `swake_up_locked()` calls
+  `try_to_wake_up(curr->task, TASK_NORMAL, wake_flags)` directly.
+- `/tmp/linux-v6.8/kernel/sched/core.c:4186-4222`: `try_to_wake_up()` is the
+  atomic state-to-runnable operation.
+
+Breenix shape:
+
+- Add a narrow IRQ-safe scheduler wake primitive, for example
+  `try_wake_io_from_irq(tid)`.
+- It must not take the global `SCHEDULER` mutex.
+- It should use only a scheduler-safe lock subset. The likely minimum is:
+  per-thread wake/state lock or atomic state transition; per-runqueue lock for
+  the selected target queue; per-CPU reschedule flag/IPI emission.
+- It should share the same state logic as `wake_io_thread_locked()`:
+  wake only BlockedOnIO or Ready+blocked_in_syscall; clear `wake_time_ns`; avoid
+  enqueue when the thread is still current or in deferred requeue; set
+  `need_resched`; send target reschedule IPI if enqueued on a remote or idle CPU.
+- The existing global-lock `wake_io_thread_locked()` remains the task-context
+  implementation until scheduler locking is split enough to share the lower
+  primitive.
+
+Safety analysis:
+
+- Safe only if the required state/runqueue data can be protected without the
+  global mutex. Linux uses `p->pi_lock` and rq locks; Breenix currently stores
+  thread state and per-CPU queues inside the global scheduler object. F32i would
+  need to split enough state out or introduce raw spinlocks around those
+  substructures.
+- The old `with_scheduler()` from IRQ is not acceptable. Commit `4caa2639`
+  showed that global scheduler lock contention with IRQs masked starves CPU0's
+  timer.
+- The primitive must handle the same deferred-requeue race F32e/F32f handle:
+  if the target is still current or in previous/deferred state, do not enqueue
+  it prematurely.
+
+Expected latency:
+
+- Best latency. The waiter becomes scheduler-visible during the AHCI IRQ itself,
+  matching Linux's completion wake semantics.
+- Removes the drain dependency and makes wake latency independent of the next
+  scheduler entry.
+
+Risk:
+
+- Highest implementation risk because it requires scheduler lock refactoring.
+- If implemented by taking the current global mutex, it regresses to the
+  pre-`4caa2639` CPU0 IRQ starvation failure.
+
+## Option B: Keep Deferred Buffer, Make Drain Bounded At IRQ Exit
+
+Keep `isr_unblock_for_io()` as a lock-free ISR publish, but guarantee that the
+publish is drained before returning to the interrupted context whenever the
+scheduler lock can be acquired without blocking.
+
+Linux cite:
+
+- Linux does not use this design for completions; it calls
+  `try_to_wake_up()` directly (`completion.c:16-25`, `swait.c:21-30`).
+- Linux does, however, avoid unbounded spinning in IRQ-disabled regions by using
+  raw spinlocks designed for this path. Option B is a transitional design for
+  Breenix because it does not yet have those locks.
+
+Breenix shape:
+
+- `isr_unblock_for_io(tid)` continues to push into the per-CPU slots.
+- At IRQ tail, attempt a non-blocking drain:
+  acquire scheduler state only with `try_lock`; if unavailable, leave the entry
+  pending and rely on the existing scheduler-entry drain.
+- If drain succeeds, run the existing `wake_io_thread_locked()` under the
+  scheduler lock and send target reschedule IPI.
+- Add permanent low-overhead counters, not serial logs:
+  pushed count, dropped/full count, drained count, max pending depth,
+  try-lock-miss count, max push-to-drain latency.
+
+Safety analysis:
+
+- Does not spin in hard IRQ context. A failed `try_lock` exits quickly.
+- Reuses the existing scheduler-locked wake logic, so it is lower risk than
+  splitting scheduler locks immediately.
+- Still not Linux parity: if the lock is busy, wake remains deferred. It reduces
+  average latency but not worst-case latency.
+
+Expected latency:
+
+- Lower than the current design when the scheduler lock is uncontended at IRQ
+  tail.
+- Still unbounded under sustained scheduler lock contention or if IRQ-tail
+  scheduling progress is the thing that has failed.
+
+Risk:
+
+- Medium. It touches interrupt-tail code and scheduler lock acquisition policy,
+  so it must avoid Tier 1 files unless explicitly approved in F32i.
+- It could hide the real scheduler/timer progress bug by making the common case
+  faster while leaving rare deferred failures.
+
+## Option C: Split Scheduler Wake State Into Linux-Like Locks, Then Remove Ring
+
+This is the clean Linux-parity endpoint. Introduce enough scheduler structure to
+make `try_to_wake_up` possible, then delete the deferred ISR buffer entirely.
+
+Linux cite:
+
+- `/tmp/linux-v6.8/kernel/sched/core.c:4202-4214`: `try_to_wake_up()` relies on
+  `p->pi_lock` and runqueue locks rather than one global scheduler lock.
+- `/tmp/linux-v6.8/kernel/sched/core.c:4253-4369`: the wake path serializes
+  state, on-rq/on-cpu, CPU selection, migration, and enqueue under that lock
+  protocol.
+- `/tmp/linux-v6.8/kernel/sched/swait.c:21-30`: completions reach that same
+  primitive directly.
+
+Breenix shape:
+
+- Introduce per-thread wake/state serialization separate from the global
+  scheduler mutex.
+- Introduce per-CPU runqueue locks or lock-free queue protocol sufficient for
+  IRQ-context enqueue.
+- Represent "current", "previous/deferred requeue", and "queued" with a protocol
+  equivalent to Linux `on_cpu`/`on_rq` ordering.
+- Route both completion ISR wake and task-context waitqueue wake through the
+  same lower-level wake primitive.
+- Remove `ISR_WAKEUP_BUFFERS` after parity tests pass.
+
+Safety analysis:
+
+- This avoids the global-lock-in-IRQ problem and removes the deferred
+  side-channel.
+- The hard part is preserving Breenix's AArch64 context-save/deferred-requeue
+  invariant. The wake primitive must never allow another CPU to run a thread
+  whose old CPU has not saved its context yet.
+- This option should be developed test-first with the F32e/F32f waitqueue tests,
+  an AHCI completion stress test, and Parallels boot captures.
+
+Expected latency:
+
+- Same class as Linux: wake becomes visible during completion, with IPI latency
+  as the dominant cross-CPU cost.
+- Removes buffer drain latency and removes scheduler-entry dependency.
+
+Risk:
+
+- Highest scope but best architectural result.
+- This is the right target if F32i is allowed to refactor scheduler locking
+  rather than patch the current mechanism.
+
+## Recommended F32i Direction
+
+Do not implement Option A by simply restoring the old
+`with_scheduler(|s| s.unblock_for_io(tid))` ISR call. That directly conflicts
+with the `4caa2639` evidence.
+
+The recommended path is:
+
+1. Add a permanent, low-overhead diagnostic counter set for ISR wake buffer
+   depth, push/drop/drain counts, and max push-to-drain latency. This preserves
+   the F32h evidence channel without serial breadcrumbs.
+2. In parallel, design Option C's minimal lock split for a Linux-like
+   `try_wake_io_from_irq()`.
+3. If F32i needs a narrow interim experiment, try Option B with strict
+   non-blocking `try_lock` only and compare traces. Treat it as transitional,
+   not final Linux parity.
+4. Implement Option C when the lock protocol is clear. The success criterion is
+   that AHCI completion wake uses one immediate scheduler wake primitive in IRQ
+   context, analogous to Linux `complete() -> swake_up_locked() ->
+   try_to_wake_up()`.
+
+F32h's captured failures point beyond the ISR ring drain itself: both runs show
+the ring drained and tid 10 made runnable. F32i should therefore validate not
+only wake latency but also CPU0/global tick progress, ready queue membership,
+and the IRQ-return scheduler path after the wake.

--- a/docs/planning/f32i-cpu0-wfi-wake/diagnosis.md
+++ b/docs/planning/f32i-cpu0-wfi-wake/diagnosis.md
@@ -1,0 +1,101 @@
+# F32i CPU0 WFI Wake Diagnosis
+
+Date: 2026-04-19
+
+Scope: diagnosis only. The temporary probes used for this document were reverted before committing this file. No Tier 1 files were modified for the final commit.
+
+## Instrumentation
+
+Temporary lock-free trace points were added around the aarch64 idle WFI path, reschedule IPI send/receive, and CPU0 runqueue enqueue. The probes emitted to the existing in-memory trace buffers and were dumped only after a CPU1 watchdog detected CPU0 timer progress had stopped. No serial breadcrumbs were added in the hot path.
+
+One deliberate exception: the probe did not read `ICC_IAR1_EL1` immediately before WFI. Reading IAR acknowledges the pending interrupt and would change the bug being measured. Instead, the real SGI receive path recorded IAR-derived interrupt IDs; no `F32I_IPI_RECV` events were present in either hang dump.
+
+Artifacts:
+
+- Run 4: `.factory-runs/f32i-cpu0-wfi-wake-20260419/parallels-run4/serial.log`
+- Run 5: `.factory-runs/f32i-cpu0-wfi-wake-20260419/parallels-run5/serial.log`
+
+## Reproduction Summary
+
+Two Parallels hangs reproduced the same CPU0 signature:
+
+| Run | Watchdog | CPU0 state | Runnable init | Timer state |
+| --- | --- | --- | --- | --- |
+| Run 4 | `CPU1 observed CPU0 timer stuck at 77 while CPU1 reached 2000` at line 392 | `CPU 0: current=0 previous=10` at line 402 | `tid=10 state=R user pid=1` at line 421 | global ticks stuck at 77 while total timer IRQ count reached 21350 |
+| Run 5 | `CPU1 observed CPU0 timer stuck at 137 while CPU1 reached 2000` at line 380 | `CPU 0: current=0 previous=10` at line 390 | `tid=10 state=R bis user pid=1` at line 409 | global ticks stuck at 137 while total timer IRQ count reached 19735 |
+
+## Evidence Answers
+
+1. Was an IPI sent to CPU0 after `wake_io_thread_locked` enqueued tid 10?
+
+Yes. Run 4 preserved the enqueue and send:
+
+- Line 2371: `F32I_RQ_ENQUEUE` from CPU1, payload `65546` = target CPU0, queue length 1, tid 10. Flags show the target CPU need bit was set.
+- Line 2372: `F32I_IPI_SEND` from CPU1, payload `16777216` = sender CPU1, target CPU0, SGI 0. Flags `0x11` mark the broadcast path and target need bit.
+
+Other CPUs later repeated the same pattern for target CPU0, also sending SGI 0.
+
+2. Did CPU0 receive the IPI?
+
+No receive was recorded. `grep F32I_IPI_RECV` over both run 4 and run 5 returned no events.
+
+The final CPU0 WFI snapshots instead show SGI0 pending in the redistributor while the CPU interface reports no highest-priority pending interrupt:
+
+- Run 4 line 444: `F32I_WFI_HPPIR_PEND` payload `67043329` = `ICC_HPPIR1_EL1 0x03ff` and `GICR_ISPENDR0 low16 0x0001`.
+- Run 5 line 431: same payload `67043329`.
+
+Decoded: `ICC_HPPIR1_EL1 == 1023` (spurious/no pending interrupt visible to the CPU interface), while `GICR_ISPENDR0 bit 0 == 1` (SGI0 pending for CPU0).
+
+3. If not received: is PMR too restrictive, is CPU0 already in a higher-priority interrupt, or is SGI routing wrong?
+
+The captured priority state does not support a PMR/RPR blocking explanation:
+
+- Run 4 line 443 and run 5 line 430: `F32I_WFI_PMR_RPR` payload `15728895` = `ICC_PMR_EL1 0xf0`, `ICC_RPR_EL1 0xff`.
+- `PMR=0xf0` should allow normal-priority interrupts configured at the default GIC priority. `RPR=0xff` means no active higher-priority interrupt was running.
+
+The suspicious state is SGI visibility/routing/group configuration: SGI0 is pending in CPU0's redistributor, but `HPPIR1` remains 1023 and no IAR-backed SGI receive event occurs.
+
+4. If received but CPU0 did not reschedule: was `need_resched` checked on WFI exit?
+
+The trace does not show receive. It does show that CPU0 kept cycling through the idle-loop WFI instrumentation:
+
+- Run 4 lines 445-450 are a WFI-exit snapshot for iteration 159900; line 451 is the next idle boundary; lines 452-457 are the next WFI-entry snapshot.
+- Run 5 lines 439-445 show the same exit-boundary-entry cycle.
+
+Run 5 proves CPU0 can re-enter WFI while the per-CPU need bit is set: line 432 has `F32I_IDLE_BOUNDARY` payload `71657` = CPU0, `need_resched=1`, iteration low bits `6121`. Run 4's final boundary payloads, such as line 451 payload `28829`, decode as `need_resched=0`.
+
+This means there are two related problems to design for:
+
+- The primary observed failure is no SGI receive despite SGI0 pending.
+- The idle loop also lacks Linux's explicit "do not enter WFI when `need_resched()` is already true" structure. Run 5 captured that condition.
+
+5. Is CPU0 actually in WFI or a different idle state?
+
+CPU0 is executing the idle-loop WFI path. The WFI point flags alternate between site 1 entry (`flags=0x1`) and site 1 exit (`flags=0x11`) in both runs. `DISR_EL1` and `ISR_EL1` were both zero at the sampled entries/exits:
+
+- Run 4 line 447 and line 460: `F32I_WFI_ISR_DISR ... =0`.
+- Run 5 line 441 and line 454: `F32I_WFI_ISR_DISR ... =0`.
+
+So CPU0 is not in a different idle state. It is in the Breenix idle-loop WFI cycle, but interrupts that should drive scheduling are not being acknowledged.
+
+6. Does CPU0's timer show armed/pending state?
+
+Yes for the virtual timer:
+
+- Run 4 line 442 and run 5 line 429: `F32I_WFI_CNT_CTL` payload `262149` = `0x0004_0005`.
+- Decoded: `CNTP_CTL_EL0=0x4`, `CNTV_CTL_EL0=0x5`.
+
+`CNTV_CTL_EL0=0x5` means the virtual timer is enabled (`ENABLE=1`), not masked (`IMASK=0`), and its status bit is set (`ISTATUS=1`). The physical timer has status set but is not enabled.
+
+## Diagnosis
+
+The AHCI waitqueue wake path is no longer the break point. The runqueue enqueue and reschedule SGI send happen. The hang point is CPU0 interrupt admission while idle:
+
+- tid 10 is Ready and associated with CPU0 after the IO wake.
+- CPU0 remains the idle thread with previous thread 10.
+- SGI0 is pending in CPU0's redistributor.
+- CPU0's priority mask and running priority do not explain blocking.
+- CPU0's CPU interface reports no highest-priority pending interrupt and never records an IAR-backed SGI receive.
+- The idle loop can re-enter WFI with `need_resched` already true.
+
+This is a Breenix bug until proven otherwise. The Linux probe validation in `linux-probe-validation.md` shows Linux on the same Parallels ARM64 hypervisor wakes CPU0 from idle reliably.

--- a/docs/planning/f32i-cpu0-wfi-wake/linux-audit.md
+++ b/docs/planning/f32i-cpu0-wfi-wake/linux-audit.md
@@ -1,0 +1,93 @@
+# F32i Linux WFI / Idle / IPI Audit
+
+Date: 2026-04-19
+
+Linux tree: `/tmp/linux-v6.8`, commit `e8f897f4a`.
+
+## Source Map
+
+ARM64 idle:
+
+- `/tmp/linux-v6.8/arch/arm64/kernel/idle.c:19-21` warns that if priority masking blocks the wake signal in the interrupt controller, the core will not wake.
+- `/tmp/linux-v6.8/arch/arm64/kernel/idle.c:23-32` implements `cpu_do_idle()`: save cpuidle IRQ context, `dsb(sy)`, `wfi()`, restore context.
+- `/tmp/linux-v6.8/arch/arm64/kernel/idle.c:38-44` implements `arch_cpu_idle()` by calling `cpu_do_idle()`.
+- `/tmp/linux-v6.8/arch/arm64/kernel/process.c:72-75` only contains `arch_cpu_idle_dead()` in this tree. `arch_cpu_idle()` is not in `process.c` for Linux v6.8.
+
+ARM64 barriers:
+
+- `/tmp/linux-v6.8/arch/arm64/include/asm/barrier.h:23` defines `wfi()` as inline assembly with a memory clobber.
+- `/tmp/linux-v6.8/arch/arm64/include/asm/barrier.h:29` defines `dsb(opt)`.
+- `/tmp/linux-v6.8/arch/arm64/include/asm/barrier.h:56` maps `__mb()` to `dsb(sy)`.
+- `/tmp/linux-v6.8/arch/arm64/include/asm/barrier.h:119-121` map SMP barriers to inner-shareable `dmb`.
+
+Generic idle loop:
+
+- `/tmp/linux-v6.8/kernel/sched/idle.c:255-256` sets the idle polling bit and enters tick-nohz idle.
+- `/tmp/linux-v6.8/kernel/sched/idle.c:258-259` loops while `!need_resched()` and executes `rmb()` after the check.
+- `/tmp/linux-v6.8/kernel/sched/idle.c:261-289` documents the lost-wake/timer race: interrupts must not be re-enabled between the decision to sleep and the sleeping instruction.
+- `/tmp/linux-v6.8/kernel/sched/idle.c:291-314` disables local IRQs, enters arch idle, and calls the cpuidle idle path.
+- `/tmp/linux-v6.8/kernel/sched/idle.c:317-333` handles the `need_resched()` exit path, including `preempt_set_need_resched()` and `smp_mb__after_atomic()` after clearing polling.
+- `/tmp/linux-v6.8/kernel/sched/idle.c:339-340` drains SMP call wake work and calls `schedule_idle()`.
+
+ARM64 IPI path:
+
+- `/tmp/linux-v6.8/arch/arm64/kernel/smp.c:70-77` defines IPI numbers: `IPI_RESCHEDULE` is enum value 0 and `IPI_CALL_FUNC` is enum value 1.
+- `/tmp/linux-v6.8/arch/arm64/kernel/smp.c:887-945` dispatches IPIs. `IPI_RESCHEDULE` calls `scheduler_ipi()`; `IPI_CALL_FUNC` calls `generic_smp_call_function_interrupt()`.
+- `/tmp/linux-v6.8/arch/arm64/kernel/smp.c:948-957` maps an IRQ to an IPI number and sends it through `__ipi_send_mask`.
+- `/tmp/linux-v6.8/arch/arm64/kernel/smp.c:1044-1047` implements `arch_smp_send_reschedule()` as `smp_cross_call(..., IPI_RESCHEDULE)`.
+- `/tmp/linux-v6.8/arch/arm64/kernel/smp.c:1050-1057` uses the scheduler IPI as the CPU wake IPI for the parking protocol path.
+
+GICv3 SGI send:
+
+- `/tmp/linux-v6.8/drivers/irqchip/irq-gic-v3.c:1350-1363` builds `ICC_SGI1R_EL1` and writes the SGI.
+- `/tmp/linux-v6.8/drivers/irqchip/irq-gic-v3.c:1365-1376` rejects non-SGI hwirqs and executes `dsb(ishst)` so normal-memory stores are visible before the IPI.
+- `/tmp/linux-v6.8/drivers/irqchip/irq-gic-v3.c:1378-1387` computes target lists, sends SGIs, then executes `isb()` so the ICC_SGI1R writes are executed.
+
+Scheduler wake and resched:
+
+- `/tmp/linux-v6.8/kernel/sched/core.c:900-910` atomically sets `TIF_NEED_RESCHED` and tests `TIF_POLLING_NRFLAG`, avoiding the polling-idle IPI race.
+- `/tmp/linux-v6.8/kernel/sched/core.c:912-930` documents the polling-idle promise: if the idle task is polling, it will call `sched_ttwu_pending()` and reschedule soon.
+- `/tmp/linux-v6.8/kernel/sched/core.c:1041-1062` implements `resched_curr()`: same-CPU wake sets need locally; remote wake sets need and sends `smp_send_reschedule(cpu)` only if the target is not polling.
+- `/tmp/linux-v6.8/kernel/sched/core.c:1135-1159` applies the same non-polling idle check for remote timer enqueue.
+- `/tmp/linux-v6.8/kernel/sched/core.c:3930-3944` implements the remote wake-list path: set `rq->ttwu_pending`, queue the task on the target CPU's wake list, and wake the CPU via `__smp_call_single_queue`.
+- `/tmp/linux-v6.8/kernel/sched/core.c:4018-4044` chooses that wake-list path when `TTWU_QUEUE` is enabled and the wake condition qualifies.
+- `/tmp/linux-v6.8/kernel/sched/core.c:6848-6862` notes a remote wake can arrive before its IPI and handles scheduling from user return in that case.
+- `/tmp/linux-v6.8/kernel/sched/core.c:6871-6875` implements `schedule_preempt_disabled()`.
+
+## Answers
+
+A. What exact memory barrier is between "check need_resched" and "enter WFI"?
+
+It is not a single standalone `smp_mb()` immediately between the check and WFI. Linux uses a structured idle protocol:
+
+- `while (!need_resched())` is the sleep gate (`kernel/sched/idle.c:258`).
+- `rmb()` follows the check (`kernel/sched/idle.c:259`).
+- Linux then disables local IRQs before entering the idle operation (`kernel/sched/idle.c:291`).
+- ARM64 `cpu_do_idle()` executes `dsb(sy); wfi()` (`arch/arm64/kernel/idle.c:29-30`).
+- The idle polling state is ordered with atomic operations and `smp_mb__after_atomic()` when polling is cleared (`kernel/sched/idle.c:317-333`).
+
+The important race-prevention property is documented in `kernel/sched/idle.c:261-289`: after Linux decides it may sleep, it must not re-enable interrupts before reaching the sleeping instruction. WFI is acceptable because it can be entered with interrupts disabled and still wakes on a pending interrupt.
+
+B. What IPI does Linux send from `try_to_wake_up` to wake an idle CPU?
+
+There are two relevant paths:
+
+- A pure reschedule request uses `IPI_RESCHEDULE` (ARM64 enum value 0). `resched_curr()` calls `smp_send_reschedule(cpu)` when the remote CPU is non-polling (`kernel/sched/core.c:1041-1062`), and ARM64 maps that to `smp_cross_call(..., IPI_RESCHEDULE)` (`arch/arm64/kernel/smp.c:1044-1047`).
+- A remote task wake commonly uses the TTWU wake-list path. Linux sets `rq->ttwu_pending`, queues the task on the target CPU's wake list, and calls `__smp_call_single_queue()` (`kernel/sched/core.c:3930-3944`). On ARM64 this is observed as `IPI_CALL_FUNC` (enum value 1), handled by `generic_smp_call_function_interrupt()` (`arch/arm64/kernel/smp.c:70-77`, `887-901`).
+
+Both are backed by GIC SGIs. The GICv3 driver sends hwirq values below 16 through `ICC_SGI1R_EL1` (`drivers/irqchip/irq-gic-v3.c:1350-1387`). The audited send path does not assign a special scheduler priority at send time; priority comes from the interrupt controller configuration.
+
+C. Does Linux rely on WFI exiting on any unmasked interrupt, or on SEV?
+
+Linux relies on WFI and interrupt delivery, not SEV, for scheduler idle wake. ARM64 `cpu_do_idle()` is `dsb(sy); wfi()` (`arch/arm64/kernel/idle.c:29-30`). The generic idle comment explicitly names WFI as a sleep-until-pending-interrupt instruction that can be entered with interrupts disabled (`kernel/sched/idle.c:270-272`). `sev()` exists in `barrier.h:19`, but it is not part of this scheduler idle wake path.
+
+D. How does Linux handle `need_resched` set without an IPI?
+
+Linux has an explicit polling-idle contract:
+
+- Idle sets its polling bit before entering the loop (`kernel/sched/idle.c:255`).
+- Remote setters atomically set `TIF_NEED_RESCHED` and test the polling flag (`kernel/sched/core.c:900-910`).
+- If the target is polling, Linux can skip the IPI because the idle task promises to call `sched_ttwu_pending()` and reschedule soon (`kernel/sched/core.c:912-930`).
+- When `need_resched()` becomes true, the idle loop leaves the WFI loop, propagates preempt need, clears polling with ordering, flushes SMP call function work, and calls `schedule_idle()` (`kernel/sched/idle.c:317-340`).
+
+So Linux does not rely only on an interrupt as the no-IPI path. It also has a polling-idle state machine that makes the no-IPI case safe.

--- a/docs/planning/f32i-cpu0-wfi-wake/linux-probe-validation.md
+++ b/docs/planning/f32i-cpu0-wfi-wake/linux-probe-validation.md
@@ -1,0 +1,102 @@
+# F32i Linux Probe Validation
+
+Date: 2026-04-19
+
+Probe VM: `linux-probe` at `10.211.55.3`, started with `prlctl start linux-probe`.
+
+Kernel:
+
+```text
+Linux probe 6.8.0-107-generic #107-Ubuntu SMP PREEMPT_DYNAMIC Fri Mar 13 19:42:33 UTC 2026 aarch64 aarch64 aarch64 GNU/Linux
+```
+
+Artifacts:
+
+- Raw trace: `.factory-runs/f32i-cpu0-wfi-wake-20260419/linux-probe-validation/f32i_probe/trace.txt`
+- Target PIDs: `.factory-runs/f32i-cpu0-wfi-wake-20260419/linux-probe-validation/f32i_probe/targets.txt`
+- Latency CSV: `.factory-runs/f32i-cpu0-wfi-wake-20260419/linux-probe-validation/latency.csv`
+- Interrupt snapshots: `.factory-runs/f32i-cpu0-wfi-wake-20260419/linux-probe-validation/f32i_probe/interrupts.before` and `.factory-runs/f32i-cpu0-wfi-wake-20260419/linux-probe-validation/f32i_probe/interrupts.after`
+
+## Test
+
+The test enabled ftrace events:
+
+- `sched:sched_waking`
+- `sched:sched_wakeup`
+- `sched:sched_switch`
+- `sched:sched_migrate_task`
+- `power:cpu_idle`
+- `ipi:ipi_raise`
+- `ipi:ipi_send_cpu`
+- `ipi:ipi_send_cpumask`
+- `ipi:ipi_entry`
+- `ipi:ipi_exit`
+
+For each of 20 iterations:
+
+1. Start a Python process pinned through `taskset -c 0`.
+2. Install a `SIGUSR1` handler and block in `signal.pause()`.
+3. From CPU1, send `SIGUSR1` with `taskset -c 1 kill -USR1 <pid>`.
+4. Capture the CPU0 idle exit, IPI entry, scheduler wakeup, and switch to the target task.
+
+## Representative Trace
+
+Iteration 20 targeted pid 5877. Relevant raw trace lines:
+
+- `trace.txt:15166`: CPU1 `sched_waking` for `python3 pid=5877 target_cpu=000` at `161.576165`.
+- `trace.txt:15167`: CPU1 sends IPI to CPU0 from `ttwu_queue_wakelist+0x19c/0x248`.
+- `trace.txt:15168`: CPU1 raises `target_mask=...0001 (Function call interrupts)`.
+- `trace.txt:15169`: CPU0 exits idle (`cpu_idle: state=4294967295 cpu_id=0`) at `161.576191`.
+- `trace.txt:15170`: CPU0 enters the IPI handler for `Function call interrupts`.
+- `trace.txt:15171`: CPU0 performs `sched_wakeup` for pid 5877.
+- `trace.txt:15172`: CPU0 exits the IPI handler.
+- `trace.txt:15173`: CPU0 switches from `swapper/0` to `python3 pid=5877`.
+
+For that iteration, wake-to-switch latency was 54 us.
+
+## Latency Distribution
+
+All 20 trials woke CPU0 and scheduled the target task.
+
+From `latency.csv`:
+
+- Count: 20
+- Min wake-to-switch: 14 us
+- Median wake-to-switch: 31 us
+- p95 wake-to-switch: 43 us
+- Max wake-to-switch: 54 us
+
+Wake-to-IPI-send was 0-2 us. Wake-to-CPU0-idle-exit was 6-26 us.
+
+## IPI Type
+
+The signal wake path used Linux's TTWU wake-list machinery, not a bare reschedule IPI:
+
+```text
+ipi_send_cpu: cpu=0 callsite=ttwu_queue_wakelist+0x19c/0x248 callback=generic_smp_call_function_single_interrupt+0x0/0x48
+ipi_raise: target_mask=00000000,00000001 (Function call interrupts)
+```
+
+That matches the Linux source audit:
+
+- `kernel/sched/core.c:3930-3944` queues the remote wake on the target CPU and calls `__smp_call_single_queue()`.
+- `arch/arm64/kernel/smp.c:70-77` defines `IPI_CALL_FUNC` as enum value 1.
+- `arch/arm64/kernel/smp.c:887-901` handles `IPI_CALL_FUNC` by running `generic_smp_call_function_interrupt()`.
+- `drivers/irqchip/irq-gic-v3.c:1350-1387` delivers ARM64 IPIs as GIC SGIs.
+
+The interrupt snapshot also moved in the expected direction. During the 20-iteration test, CPU0's function-call interrupt count rose from 4324 to 4421, and its reschedule interrupt count rose from 1690 to 1714.
+
+## Validation Result
+
+Linux wakes CPU0 from idle reliably on the same Parallels ARM64 hypervisor. The measured behavior is:
+
+1. Cross-CPU wake queues target work.
+2. Linux sends a GIC-backed SGI to CPU0.
+3. CPU0 exits idle/WFI.
+4. CPU0 enters the IPI handler.
+5. The wakeup is completed on CPU0.
+6. CPU0 switches from `swapper/0` to the target task.
+
+This rules out an unvalidated "Parallels cannot wake CPU0 from WFI" hypothesis. The current F32i evidence should be treated as a Breenix structural bug.
+
+The structural difference observed in the equivalent Linux path is that Linux's remote task wake uses a target-CPU wake list plus function-call IPI, so the target CPU drains and activates the task inside the IPI path. Breenix currently enqueues directly to CPU0's runqueue and sends SGI0 as a reschedule signal; the F32i trace then shows SGI0 pending in CPU0's redistributor but never acknowledged by CPU0.

--- a/docs/planning/f32i-cpu0-wfi-wake/proposal.md
+++ b/docs/planning/f32i-cpu0-wfi-wake/proposal.md
@@ -1,0 +1,142 @@
+# F32i Fix Proposal
+
+Date: 2026-04-19
+
+Scope: design only. Do not implement in F32i. F32j should choose and implement the option supported by review.
+
+## Evidence Summary
+
+F32i reproduced the CPU0 hang twice with lock-free tracing:
+
+- `wake_io_thread_locked` enqueued tid 10 on CPU0 and set the target need bit.
+- Breenix sent SGI0 to CPU0.
+- CPU0 never recorded an IAR-backed SGI receive.
+- CPU0's `GICR_ISPENDR0` showed SGI0 pending, while `ICC_HPPIR1_EL1` returned 1023 and `ICC_RPR_EL1=0xff`.
+- `ICC_PMR_EL1=0xf0`, so the evidence does not point to PMR masking as the immediate blocker.
+- Run 5 also showed CPU0 re-entering WFI with `need_resched=1`.
+
+Linux on the same Parallels ARM64 hypervisor woke CPU0 from idle in 20/20 trials, with 14-54 us wake-to-switch latency. The equivalent Linux task wake used a target wake list and `IPI_CALL_FUNC`, not a bare scheduler IPI.
+
+## Option 1: Make Breenix Idle Loop Follow Linux's Sleep Gate
+
+Design:
+
+- Give `idle_loop_arm64` a real Linux-style sleep gate:
+  - check `need_resched` and CPU0's runqueue before WFI;
+  - do not enter WFI if work is already visible;
+  - keep the check-to-WFI sequence ordered so there is no re-enable gap;
+  - after WFI/interrupt return, re-check and schedule rather than blindly looping.
+- Preserve the existing `dsb sy; wfi` sequence in the actual idle instruction path.
+- If Breenix keeps a polling-idle fast path, add a Linux-style polling contract so remote wake can safely skip IPIs only when the idle CPU promises to reschedule.
+
+Linux basis:
+
+- `kernel/sched/idle.c:258-259`: idle loops only while `!need_resched()`, followed by `rmb()`.
+- `kernel/sched/idle.c:261-289`: Linux documents the lost-wake rule: no interrupt re-enable gap between deciding to sleep and the sleeping instruction.
+- `kernel/sched/idle.c:291-314`: Linux disables local IRQs before arch idle.
+- `arch/arm64/kernel/idle.c:23-32`: ARM64 idle is `dsb(sy); wfi()`.
+- `kernel/sched/idle.c:317-340`: Linux exits idle, orders polling clear, flushes pending SMP wake work, and schedules.
+
+Safety:
+
+- This touches idle behavior, not syscall or timer hot paths.
+- It directly addresses run 5, where CPU0 re-entered WFI with `need_resched=1`.
+- It does not by itself explain why SGI0 is pending but not acknowledged, so it should be paired with Option 2 or Option 3 unless review finds the idle-loop race sufficient.
+
+Expected impact:
+
+- Prevents CPU0 from sleeping when work is already visible.
+- Reduces dependency on the next timer interrupt when the need bit is already set.
+- Moves Breenix closer to Linux's idle semantics without adding arbitrary timers or fallbacks.
+
+## Option 2: Adopt Linux-Style Remote Wake List + Function-Call IPI
+
+Design:
+
+- For cross-CPU task wake, stop treating the remote target runqueue enqueue as complete work that only needs a reschedule SGI.
+- Queue the wake on a per-target CPU wake list, set a target `ttwu_pending` equivalent, and send a function-call IPI to the target CPU.
+- In the target CPU's IPI handler, drain the wake list, activate the tasks locally, set target `need_resched`, and schedule on interrupt exit.
+- Keep the SGI send ordering Linux uses: stores visible before SGI, then force the SGI system-register write to execute.
+
+Linux basis:
+
+- `kernel/sched/core.c:3930-3944`: Linux queues the remote wake on the target CPU's wake list and wakes that CPU via IPI.
+- `kernel/sched/core.c:4018-4044`: TTWU chooses the wake-list path and returns without direct activation when it applies.
+- `arch/arm64/kernel/smp.c:70-77`: `IPI_CALL_FUNC` is ARM64 IPI enum value 1.
+- `arch/arm64/kernel/smp.c:887-901`: `IPI_CALL_FUNC` runs `generic_smp_call_function_interrupt()`.
+- `drivers/irqchip/irq-gic-v3.c:1365-1387`: Linux executes `dsb(ishst)` before SGI send and `isb()` after writing `ICC_SGI1R_EL1`.
+- Linux probe trace lines `15166-15173`: the same Parallels VM wakes CPU0 through `ttwu_queue_wakelist` + function-call IPI and switches to the target task.
+
+Safety:
+
+- This is the closest structural match to Linux's remote wake path.
+- It avoids remote CPUs mutating CPU0's runnable state without CPU0 participating in the activation.
+- It gives the IPI handler concrete work to drain, instead of relying on a pending reschedule SGI whose receive is currently missing.
+- It requires careful ownership of per-CPU wake lists and should be implemented with lock-free or interrupt-safe primitives only.
+
+Expected impact:
+
+- Makes cross-CPU wake completion target-CPU-local, matching Linux's TTWU architecture.
+- Provides a natural trace point and invariant: if wake-list pending is set, the function-call IPI must be received and drained.
+
+## Option 3: Audit and Repair CPU0 GIC SGI Admission
+
+Design:
+
+- Investigate why CPU0 has `GICR_ISPENDR0.SGI0=1` while `ICC_HPPIR1_EL1=1023` and no IAR receive occurs.
+- Specifically audit:
+  - SGI0 group configuration on CPU0's redistributor;
+  - SGI0 enable state on CPU0;
+  - SGI0 priority relative to `ICC_PMR_EL1=0xf0`;
+  - `ICC_IGRPEN1_EL1` / group enable state per CPU;
+  - CPU0 redistributor routing and affinity used in `ICC_SGI1R_EL1`;
+  - whether EOImode split priority-drop/deactivate state can strand SGIs;
+  - whether SGI0 and the virtual timer are configured in the same group expected by the CPU interface.
+- Keep `gic.rs` changes highly scoped and avoid logging in interrupt paths.
+
+Linux basis:
+
+- `arch/arm64/kernel/idle.c:19-21`: Linux explicitly warns that PMR/controller masking can prevent the core from waking.
+- `drivers/irqchip/irq-gic-v3.c:1350-1387`: Linux sends SGIs through `ICC_SGI1R_EL1` with pre-send `dsb(ishst)` and post-send `isb()`.
+- `arch/arm64/kernel/smp.c:948-957`: Linux maps GIC IRQs back to IPI numbers by subtracting `ipi_irq_base`, then dispatches through `do_handle_IPI()`.
+
+Safety:
+
+- This option addresses the strongest F32i anomaly: pending SGI0 in the redistributor but no CPU-interface delivery.
+- `kernel/src/arch_impl/aarch64/gic.rs` was listed as read-only in the F32i prompt, but not Tier 1 in AGENTS. Any F32j change should still be treated as high scrutiny because it can break all interrupt delivery.
+- Use GDB and in-memory tracing for validation; do not add serial output to interrupt paths.
+
+Expected impact:
+
+- If the root cause is group/enable/priority/routing mismatch, this is the fix that makes both SGI0 reschedule and any future IPI design reliable.
+- It should also clarify whether the virtual timer's pending-but-stalled behavior shares the same CPU-interface admission problem.
+
+## Option 4: Add `dsb sy` to `halt_with_interrupts()` Only After Proving That Path Is Active
+
+Design:
+
+- `Aarch64Cpu::halt_with_interrupts()` currently does `msr daifclr, #3; wfi` without the `dsb sy` used by Linux and by `idle_loop_arm64`.
+- If F32j proves this helper is an active WFI path for the hang, align it with Linux's `dsb(sy); wfi()` pattern.
+
+Linux basis:
+
+- `arch/arm64/kernel/idle.c:29-30`: `dsb(sy); wfi()`.
+- `arch/arm64/include/asm/barrier.h:29` defines `dsb(opt)`.
+
+Safety:
+
+- This is low risk if the path is active, but F32i evidence points at `idle_loop_arm64`, which already has `dsb sy`.
+- Do not treat this as the primary fix without proving the helper participates in the failure.
+
+Expected impact:
+
+- Aligns the secondary WFI helper with Linux and avoids a known class of ordering bugs.
+- It will not fix a GIC admission problem by itself.
+
+## Recommended F32j Direction
+
+Start with Option 3's GIC admission audit because the decisive F32i artifact is `GICR_ISPENDR0.SGI0=1` with `ICC_HPPIR1_EL1=1023` and no IAR receive. In parallel, implement Option 1's idle sleep gate because run 5 captured CPU0 entering WFI with `need_resched=1` and Linux never permits that through the generic idle loop.
+
+Option 2 is the architectural target if review agrees Breenix should converge on Linux TTWU semantics rather than direct remote runqueue enqueue. It is larger than Option 1 but gives the cleanest parity with the Linux probe trace.
+
+Do not introduce arbitrary timer fallbacks, SEV/WFE substitutions, or hypervisor-specific quirks. Linux validated that Parallels ARM64 wakes CPU0 correctly through GIC SGIs.

--- a/kernel/src/syscall/graphics.rs
+++ b/kernel/src/syscall/graphics.rs
@@ -51,6 +51,18 @@ static COMPOSITOR_FRAME_WQ: crate::task::waitqueue::WaitQueueHead =
 static CLIENT_FRAME_WQ: crate::task::waitqueue::WaitQueueHead =
     crate::task::waitqueue::WaitQueueHead::new();
 
+/// Dedicated F32c waitqueue race reproducer. These test-only FBDRAW ops let a
+/// userspace harness drive wait/wake races without involving BWM state.
+#[cfg(target_arch = "aarch64")]
+static WAIT_STRESS_WQ: crate::task::waitqueue::WaitQueueHead =
+    crate::task::waitqueue::WaitQueueHead::new();
+#[cfg(target_arch = "aarch64")]
+static WAIT_STRESS_ENTERED: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+#[cfg(target_arch = "aarch64")]
+static WAIT_STRESS_RETURNED: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+#[cfg(target_arch = "aarch64")]
+static WAIT_STRESS_WAKES: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
 /// Registry generation counter — bumped when windows are registered/unregistered.
 /// compositor_wait (op=23) compares this against its saved value to detect changes.
 #[cfg(target_arch = "aarch64")]
@@ -169,6 +181,73 @@ fn compositor_ready_bits(last_registry_gen: u64, prev_mouse: u64) -> (u64, u64, 
     }
 
     (ready, cur_reg_gen, mouse_packed)
+}
+
+#[cfg(target_arch = "aarch64")]
+fn handle_wait_stress_reset() -> SyscallResult {
+    use core::sync::atomic::Ordering;
+
+    WAIT_STRESS_WQ.wake_up();
+    WAIT_STRESS_ENTERED.store(0, Ordering::SeqCst);
+    WAIT_STRESS_RETURNED.store(0, Ordering::SeqCst);
+    WAIT_STRESS_WAKES.store(0, Ordering::SeqCst);
+    SyscallResult::Ok(0)
+}
+
+#[cfg(target_arch = "aarch64")]
+fn handle_wait_stress_wait() -> SyscallResult {
+    use core::sync::atomic::Ordering;
+
+    let entered = WAIT_STRESS_ENTERED.fetch_add(1, Ordering::SeqCst) + 1;
+    if WAIT_STRESS_WQ
+        .prepare_to_wait(crate::task::thread::ThreadState::BlockedOnIO)
+        .is_none()
+    {
+        return SyscallResult::Err(super::ErrorCode::InvalidArgument as u64);
+    }
+
+    crate::task::waitqueue::schedule_current_wait();
+    WAIT_STRESS_WQ.finish_wait();
+    ensure_current_address_space();
+
+    WAIT_STRESS_RETURNED.fetch_add(1, Ordering::SeqCst);
+    SyscallResult::Ok(entered)
+}
+
+#[cfg(target_arch = "aarch64")]
+fn handle_wait_stress_wake() -> SyscallResult {
+    use core::sync::atomic::Ordering;
+
+    let wakes = WAIT_STRESS_WAKES.fetch_add(1, Ordering::SeqCst) + 1;
+    WAIT_STRESS_WQ.wake_up();
+    SyscallResult::Ok(wakes)
+}
+
+#[cfg(target_arch = "aarch64")]
+fn handle_wait_stress_stats(cmd: &FbDrawCmd) -> SyscallResult {
+    use core::sync::atomic::Ordering;
+
+    let out_ptr = (cmd.p1 as u32 as u64) | ((cmd.p2 as u32 as u64) << 32);
+    let out_len = cmd.p3 as u32;
+    if out_ptr == 0 || out_ptr >= USER_SPACE_MAX || out_len < 4 {
+        return SyscallResult::Err(super::ErrorCode::InvalidArgument as u64);
+    }
+
+    let out_end = out_ptr + 4 * core::mem::size_of::<u64>() as u64;
+    if out_end > USER_SPACE_MAX {
+        return SyscallResult::Err(super::ErrorCode::Fault as u64);
+    }
+
+    let waiters = if WAIT_STRESS_WQ.has_waiters() { 1 } else { 0 };
+    unsafe {
+        let dst = out_ptr as *mut u64;
+        core::ptr::write(dst.add(0), WAIT_STRESS_ENTERED.load(Ordering::SeqCst));
+        core::ptr::write(dst.add(1), WAIT_STRESS_RETURNED.load(Ordering::SeqCst));
+        core::ptr::write(dst.add(2), WAIT_STRESS_WAKES.load(Ordering::SeqCst));
+        core::ptr::write(dst.add(3), waiters);
+    }
+
+    SyscallResult::Ok(0)
 }
 
 // =============================================================================
@@ -1220,6 +1299,24 @@ fn handle_virgl_op(cmd: &FbDrawCmd) -> SyscallResult {
             // Bits: 0=Shift, 1=Ctrl, 2=Alt, 3=Super
             let state = crate::drivers::usb::hid::poll_modifier_state();
             SyscallResult::Ok(state as u64)
+        }
+        27 => {
+            // F32c waitqueue stress reset.
+            handle_wait_stress_reset()
+        }
+        28 => {
+            // F32c waitqueue stress wait. Intentionally has no persistent
+            // condition; a wake after prepare_to_wait must make schedule a
+            // no-op, matching the Linux waitqueue race-closure invariant.
+            handle_wait_stress_wait()
+        }
+        29 => {
+            // F32c waitqueue stress wake.
+            handle_wait_stress_wake()
+        }
+        30 => {
+            // F32c waitqueue stress stats.
+            handle_wait_stress_stats(cmd)
         }
         _ => {
             crate::serial_println!("[virgl-op] UNKNOWN op={}", cmd.op);

--- a/kernel/src/syscall/graphics.rs
+++ b/kernel/src/syscall/graphics.rs
@@ -41,12 +41,15 @@ use crate::graphics::primitives::{
 #[cfg(target_arch = "aarch64")]
 pub static FB_FLUSH_COUNT: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
-/// Thread ID of the compositor when it's waiting for a dirty window.
-/// Set by op=16 when nothing is dirty; cleared when the compositor wakes.
-/// op=15 (mark_window_dirty) reads this to wake the compositor immediately.
+/// Waitqueue for BWM's compositor_wait syscall (op=23).
 #[cfg(target_arch = "aarch64")]
-static COMPOSITOR_WAITING_THREAD: core::sync::atomic::AtomicU64 =
-    core::sync::atomic::AtomicU64::new(0);
+static COMPOSITOR_FRAME_WQ: crate::task::waitqueue::WaitQueueHead =
+    crate::task::waitqueue::WaitQueueHead::new();
+
+/// Waitqueue for client frame pacing after mark_window_dirty (op=15).
+#[cfg(target_arch = "aarch64")]
+static CLIENT_FRAME_WQ: crate::task::waitqueue::WaitQueueHead =
+    crate::task::waitqueue::WaitQueueHead::new();
 
 /// Registry generation counter — bumped when windows are registered/unregistered.
 /// compositor_wait (op=23) compares this against its saved value to detect changes.
@@ -64,30 +67,12 @@ static COMPOSITOR_LAST_MOUSE: core::sync::atomic::AtomicU64 = core::sync::atomic
 static COMPOSITOR_DIRTY_WAKE: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
-/// Timestamp (ns) of the last compositor_wait return.
-/// Used to enforce a minimum inter-frame interval so the compositor doesn't
-/// saturate the CPU when GPU wake is fast (e.g., MSI-X interrupt-driven).
-#[cfg(target_arch = "aarch64")]
-static COMPOSITOR_LAST_WAKE_NS: core::sync::atomic::AtomicU64 =
-    core::sync::atomic::AtomicU64::new(0);
-
-/// Minimum nanoseconds between compositor_wait returns.
-/// 5ms = 200 FPS cap — smooth enough for all use cases while preventing
-/// the compositor from running flat-out when events arrive continuously.
-#[cfg(target_arch = "aarch64")]
-const MIN_FRAME_INTERVAL_NS: u64 = 5_000_000;
-
 /// Wake the compositor thread if it's blocked in compositor_wait (op=23).
 /// Called from input interrupt handlers (mouse, keyboard) to provide low-latency
 /// input response without polling.
 #[cfg(target_arch = "aarch64")]
 pub fn wake_compositor_if_waiting() {
-    let tid = COMPOSITOR_WAITING_THREAD.load(core::sync::atomic::Ordering::Acquire);
-    if tid != 0 {
-        crate::task::scheduler::with_scheduler(|sched| {
-            sched.unblock(tid);
-        });
-    }
+    COMPOSITOR_FRAME_WQ.wake_up();
 }
 
 /// Clean up all window buffers owned by a terminated process.
@@ -129,6 +114,61 @@ fn ensure_current_address_space() {
             }
         }
     }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn window_frame_pending(buffer_id: u32, thread_id: u64) -> bool {
+    let reg = WINDOW_REGISTRY.lock();
+    reg.find(buffer_id)
+        .map(|buf| buf.waiting_thread_id == Some(thread_id))
+        .unwrap_or(false)
+}
+
+#[cfg(target_arch = "aarch64")]
+fn wake_presented_client_frames() {
+    let mut has_presented_waiters = false;
+    {
+        let mut reg = WINDOW_REGISTRY.lock();
+        for slot in reg.buffers.iter_mut() {
+            let Some(buf) = slot.as_mut() else {
+                continue;
+            };
+
+            if buf.waiting_thread_id.is_some() && buf.last_read_gen == buf.generation {
+                buf.waiting_thread_id.take();
+                has_presented_waiters = true;
+            }
+        }
+    }
+
+    if has_presented_waiters {
+        CLIENT_FRAME_WQ.wake_up();
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn compositor_ready_bits(last_registry_gen: u64, prev_mouse: u64) -> (u64, u64, u64) {
+    use core::sync::atomic::Ordering;
+
+    let (mx, my, mb) = crate::drivers::usb::hid::mouse_state();
+    let mouse_packed = ((mx as u64) << 32) | ((my as u64) << 16) | (mb as u64);
+    let cur_reg_gen = REGISTRY_GENERATION.load(Ordering::Relaxed);
+
+    let mut ready = 0u64;
+    if COMPOSITOR_DIRTY_WAKE.swap(false, Ordering::Relaxed) {
+        ready |= 1;
+    }
+    if mouse_packed != prev_mouse
+        || crate::drivers::usb::hid::has_pending_press()
+        || crate::drivers::usb::hid::has_pending_scroll()
+    {
+        ready |= 2;
+    }
+    if cur_reg_gen != last_registry_gen {
+        ready |= 4;
+    }
+
+    (ready, cur_reg_gen, mouse_packed)
 }
 
 // =============================================================================
@@ -662,7 +702,10 @@ fn handle_virgl_op(cmd: &FbDrawCmd) -> SyscallResult {
                         return match crate::drivers::virtio::gpu_pci::virgl_composite_frame(
                             pixels, width, height,
                         ) {
-                            Ok(()) => SyscallResult::Ok(0),
+                            Ok(()) => {
+                                wake_presented_client_frames();
+                                SyscallResult::Ok(0)
+                            }
                             Err(e) => {
                                 crate::serial_println!(
                                     "[composite] VirGL direct composite_frame FAILED: {}",
@@ -756,13 +799,7 @@ fn handle_virgl_op(cmd: &FbDrawCmd) -> SyscallResult {
                 #[cfg(target_arch = "aarch64")]
                 {
                     REGISTRY_GENERATION.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-                    let compositor_tid =
-                        COMPOSITOR_WAITING_THREAD.load(core::sync::atomic::Ordering::Acquire);
-                    if compositor_tid != 0 {
-                        crate::task::scheduler::with_scheduler(|sched| {
-                            sched.unblock(compositor_tid);
-                        });
-                    }
+                    COMPOSITOR_FRAME_WQ.wake_up();
                 }
                 SyscallResult::Ok(0)
             } else {
@@ -844,8 +881,8 @@ fn handle_virgl_op(cmd: &FbDrawCmd) -> SyscallResult {
             // This provides Wayland-style back-pressure / frame pacing — the client
             // renders at exactly the compositor's display rate.
             //
-            // Uses BlockedOnTimer with a 50ms timeout as fallback. The compositor
-            // calls unblock() to wake the client early when it uploads the frame.
+            // Uses CLIENT_FRAME_WQ; the compositor wakes clients when it uploads
+            // the frame. There is intentionally no timer fallback here.
             // p1=buffer_id
             let buffer_id = cmd.p1 as u32;
 
@@ -867,68 +904,32 @@ fn handle_virgl_op(cmd: &FbDrawCmd) -> SyscallResult {
                 }
             }
 
-            // Calculate timeout from now. This is only a fallback if the
-            // compositor wake is missed; use the same 5ms frame interval as
-            // compositor_wait pacing so a missed wake degrades to ~200Hz, not
-            // the old 20Hz/50ms behavior.
-            let (cur_secs, cur_nanos) = crate::time::get_monotonic_time_ns();
-            let now_ns = cur_secs as u64 * 1_000_000_000 + cur_nanos as u64;
-            let timeout_ns = now_ns.saturating_add(MIN_FRAME_INTERVAL_NS);
-
-            // Block the thread using the scheduler's timer infrastructure.
-            // The compositor will call unblock() when it consumes our frame,
-            // or wake_expired_timers() will wake us after the fallback interval.
-            crate::task::scheduler::with_scheduler(|sched| {
-                sched.block_current_for_compositor(timeout_ns);
-            });
-
-            // Wake compositor after the client is marked blocked. Waking before
-            // this point lets bwm consume the frame and "unblock" a still-running
-            // client, after which the client blocks and waits for the 50ms fallback.
+            // Wake BWM after publishing the dirty frame. If BWM consumes the
+            // frame before this thread reaches prepare_to_wait(), the condition
+            // re-check below observes that waiting_thread_id was cleared and
+            // returns without sleeping.
             #[cfg(target_arch = "aarch64")]
             {
                 COMPOSITOR_DIRTY_WAKE.store(true, core::sync::atomic::Ordering::Relaxed);
-                let compositor_tid =
-                    COMPOSITOR_WAITING_THREAD.load(core::sync::atomic::Ordering::Acquire);
-                if compositor_tid != 0 {
-                    crate::task::scheduler::with_scheduler(|sched| {
-                        sched.unblock(compositor_tid);
-                    });
-                }
+                COMPOSITOR_FRAME_WQ.wake_up();
             }
 
-            // Enable preemption so timer interrupts can context-switch us out
-            #[cfg(target_arch = "aarch64")]
-            crate::per_cpu_aarch64::preempt_enable();
+            while window_frame_pending(buffer_id, thread_id) {
+                if CLIENT_FRAME_WQ
+                    .prepare_to_wait(crate::task::thread::ThreadState::BlockedOnIO)
+                    .is_none()
+                {
+                    return SyscallResult::Err(super::ErrorCode::InvalidArgument as u64);
+                }
 
-            // WFI loop: sleep until the compositor wakes us or timeout expires.
-            // Each WFI suspends the CPU until the next interrupt (timer at 1000Hz).
-            loop {
-                let still_blocked = crate::task::scheduler::with_scheduler(|sched| {
-                    sched.wake_expired_timers();
-                    sched
-                        .current_thread_mut()
-                        .map(|t| t.state == crate::task::thread::ThreadState::BlockedOnTimer)
-                        .unwrap_or(false)
-                });
-
-                if !still_blocked.unwrap_or(false) {
+                if !window_frame_pending(buffer_id, thread_id) {
+                    CLIENT_FRAME_WQ.finish_wait();
                     break;
                 }
 
-                crate::task::scheduler::yield_current();
-                crate::arch_halt_with_interrupts();
+                crate::task::waitqueue::schedule_current_wait();
+                CLIENT_FRAME_WQ.finish_wait();
             }
-
-            // Clear blocked_in_syscall and re-disable preemption before returning
-            crate::task::scheduler::with_scheduler(|sched| {
-                if let Some(thread) = sched.current_thread_mut() {
-                    thread.blocked_in_syscall = false;
-                }
-            });
-
-            #[cfg(target_arch = "aarch64")]
-            crate::per_cpu_aarch64::preempt_disable();
 
             // Restore TTBR0 to this process's page tables after blocking
             #[cfg(target_arch = "aarch64")]
@@ -1175,7 +1176,7 @@ fn handle_virgl_op(cmd: &FbDrawCmd) -> SyscallResult {
         }
         23 => {
             // CompositorWait: block until something needs compositing.
-            // p1=timeout_ms, p2=last_registry_gen (lo32)
+            // p1=ignored (formerly timeout_ms), p2=last_registry_gen (lo32)
             // Returns bitmask: bit0=windows_dirty, bit1=mouse_changed, bit2=registry_changed
             // Replaces BWM's poll+sleep loop with a single blocking syscall.
             #[cfg(target_arch = "aarch64")]
@@ -1233,177 +1234,55 @@ fn handle_virgl_op(cmd: &FbDrawCmd) -> SyscallResult {
 ///   bits 0-7: ready bitmask (bit0=dirty, bit1=mouse, bit2=registry)
 ///   bits 8-31: current registry generation (for next call's last_registry_gen)
 ///
-/// If nothing is ready, blocks the compositor thread with the given timeout.
+/// If nothing is ready, blocks the compositor thread on `COMPOSITOR_FRAME_WQ`.
 /// Woken by: mark_window_dirty (op=15), mouse interrupt handler, registry changes.
 #[cfg(target_arch = "aarch64")]
 fn handle_compositor_wait(cmd: &FbDrawCmd) -> SyscallResult {
     use core::sync::atomic::Ordering;
 
-    let timeout_ms = cmd.p1 as u32;
     let last_registry_gen = cmd.p2 as u32 as u64;
 
-    // Frame pacing: enforce minimum inter-frame interval.
-    // Without this, MSI-X interrupt-driven GPU wake causes the compositor to
-    // run flat-out (~200+ FPS), saturating the CPU. By sleeping until the
-    // minimum interval has elapsed, we cap effective FPS while keeping
-    // latency low for input events (mouse/keyboard still wake immediately).
-    //
-    // IMPORTANT: This uses a plain timer block, NOT block_current_for_compositor.
-    // We must NOT set COMPOSITOR_WAITING_THREAD here because mark_window_dirty
-    // would wake us early and consume the dirty signal, causing the main
-    // blocking section to re-block and wait for the full 16ms timeout.
-    let (s, n) = crate::time::get_monotonic_time_ns();
-    let now_ns = (s as u64) * 1_000_000_000 + (n as u64);
-    let last_wake = COMPOSITOR_LAST_WAKE_NS.load(Ordering::Relaxed);
-    if last_wake != 0 {
-        let earliest_return = last_wake + MIN_FRAME_INTERVAL_NS;
-        if now_ns < earliest_return {
-            crate::task::scheduler::with_scheduler(|sched| {
-                sched.block_current_for_timer(earliest_return);
-            });
-
-            #[cfg(target_arch = "aarch64")]
-            crate::per_cpu_aarch64::preempt_enable();
-
-            loop {
-                let still_blocked = crate::task::scheduler::with_scheduler(|sched| {
-                    sched.wake_expired_timers();
-                    sched
-                        .current_thread_mut()
-                        .map(|t| t.state == crate::task::thread::ThreadState::BlockedOnTimer)
-                        .unwrap_or(false)
-                });
-                if !still_blocked.unwrap_or(false) {
-                    break;
-                }
-                crate::task::scheduler::yield_current();
-                crate::arch_halt_with_interrupts();
-            }
-
-            crate::task::scheduler::with_scheduler(|sched| {
-                if let Some(thread) = sched.current_thread_mut() {
-                    thread.blocked_in_syscall = false;
-                }
-            });
-
-            #[cfg(target_arch = "aarch64")]
-            crate::per_cpu_aarch64::preempt_disable();
-            #[cfg(target_arch = "aarch64")]
-            ensure_current_address_space();
-        }
-    }
-
-    // Pack current mouse state for comparison
-    let (mx, my, mb) = crate::drivers::usb::hid::mouse_state();
-    let mouse_packed = ((mx as u64) << 32) | ((my as u64) << 16) | (mb as u64);
+    // Compare against the last mouse state returned to BWM. This stays stable
+    // across the wait so movement while blocked becomes a readiness bit.
     let prev_mouse = COMPOSITOR_LAST_MOUSE.load(Ordering::Relaxed);
 
-    // Check non-dirty conditions first (mouse + registry are always non-blocking)
-    let mut ready: u64 = 0;
-
-    // Bit 1: mouse changed (position, buttons, pending latched press, or scroll wheel)?
-    if mouse_packed != prev_mouse
-        || crate::drivers::usb::hid::has_pending_press()
-        || crate::drivers::usb::hid::has_pending_scroll()
-    {
-        ready |= 2;
-    }
-
-    // Bit 2: registry changed?
-    let cur_reg_gen = REGISTRY_GENERATION.load(Ordering::Relaxed);
-    if cur_reg_gen != last_registry_gen {
-        ready |= 4;
-    }
-
-    // Bit 0: dirty window signal pending (may have arrived during frame pacing sleep)
-    if COMPOSITOR_DIRTY_WAKE.swap(false, Ordering::Relaxed) {
-        ready |= 1;
-    }
-
-    // If anything is ready, return immediately.
-    if ready != 0 {
-        COMPOSITOR_LAST_MOUSE.store(mouse_packed, Ordering::Relaxed);
-        let (ws, wn) = crate::time::get_monotonic_time_ns();
-        COMPOSITOR_LAST_WAKE_NS.store((ws as u64) * 1_000_000_000 + (wn as u64), Ordering::Relaxed);
-        return SyscallResult::Ok(ready | ((cur_reg_gen & 0x00FF_FFFF) << 8));
-    }
-
-    // Nothing urgent — block until woken by mark_window_dirty, mouse, or registry change.
-    // mark_window_dirty (op=15) wakes us immediately via COMPOSITOR_WAITING_THREAD.
-    let compositor_tid = match crate::task::scheduler::current_thread_id() {
-        Some(id) => id,
-        None => return SyscallResult::Ok(0),
-    };
-    COMPOSITOR_WAITING_THREAD.store(compositor_tid, Ordering::Release);
-
-    let (s, n) = crate::time::get_monotonic_time_ns();
-    let now_ns = (s as u64) * 1_000_000_000 + (n as u64);
-    let timeout_ns = now_ns.saturating_add((timeout_ms as u64) * 1_000_000);
-
-    crate::task::scheduler::with_scheduler(|sched| {
-        sched.block_current_for_compositor(timeout_ns);
-    });
-
-    #[cfg(target_arch = "aarch64")]
-    crate::per_cpu_aarch64::preempt_enable();
-
     loop {
-        let still_blocked = crate::task::scheduler::with_scheduler(|sched| {
-            sched.wake_expired_timers();
-            sched
-                .current_thread_mut()
-                .map(|t| t.state == crate::task::thread::ThreadState::BlockedOnTimer)
-                .unwrap_or(false)
-        });
-        if !still_blocked.unwrap_or(false) {
-            break;
+        let (ready, cur_reg_gen, mouse_packed) =
+            compositor_ready_bits(last_registry_gen, prev_mouse);
+        if ready != 0 {
+            COMPOSITOR_LAST_MOUSE.store(mouse_packed, Ordering::Relaxed);
+            return SyscallResult::Ok(ready | ((cur_reg_gen & 0x00FF_FFFF) << 8));
         }
-        crate::task::scheduler::yield_current();
-        crate::arch_halt_with_interrupts();
-    }
 
-    crate::task::scheduler::with_scheduler(|sched| {
-        if let Some(thread) = sched.current_thread_mut() {
-            thread.blocked_in_syscall = false;
+        if COMPOSITOR_FRAME_WQ
+            .prepare_to_wait(crate::task::thread::ThreadState::BlockedOnIO)
+            .is_none()
+        {
+            return SyscallResult::Ok(0);
         }
-    });
 
-    #[cfg(target_arch = "aarch64")]
-    crate::per_cpu_aarch64::preempt_disable();
-    #[cfg(target_arch = "aarch64")]
-    ensure_current_address_space();
+        // Race closure: a producer may wake after the first condition check but
+        // before prepare_to_wait completes. Re-check after the thread is queued
+        // and marked BlockedOnIO; if ready, finish_wait restores runnable state
+        // without entering the scheduler.
+        let (ready_after_prepare, cur_reg_after_prepare, mouse_after_prepare) =
+            compositor_ready_bits(last_registry_gen, prev_mouse);
+        if ready_after_prepare != 0 {
+            COMPOSITOR_FRAME_WQ.finish_wait();
+            COMPOSITOR_LAST_MOUSE.store(mouse_after_prepare, Ordering::Relaxed);
+            return SyscallResult::Ok(
+                ready_after_prepare | ((cur_reg_after_prepare & 0x00FF_FFFF) << 8),
+            );
+        }
 
-    COMPOSITOR_WAITING_THREAD.store(0, Ordering::Release);
+        crate::task::waitqueue::schedule_current_wait();
+        COMPOSITOR_FRAME_WQ.finish_wait();
 
-    // Re-check conditions after waking — return bitmask of what woke us.
-    let mut ready_after: u64 = 0;
+        #[cfg(target_arch = "aarch64")]
+        ensure_current_address_space();
 
-    // Bit 0: check if mark_window_dirty woke us
-    if COMPOSITOR_DIRTY_WAKE.swap(false, Ordering::Relaxed) {
-        ready_after |= 1;
+        // If the wake was unrelated or coalesced, loop and re-check.
     }
-
-    let (mx2, my2, mb2) = crate::drivers::usb::hid::mouse_state();
-    let mouse_packed2 = ((mx2 as u64) << 32) | ((my2 as u64) << 16) | (mb2 as u64);
-
-    if mouse_packed2 != prev_mouse || crate::drivers::usb::hid::has_pending_press() {
-        ready_after |= 2;
-    }
-
-    let cur_reg_gen2 = REGISTRY_GENERATION.load(Ordering::Relaxed);
-    if cur_reg_gen2 != last_registry_gen {
-        ready_after |= 4;
-    }
-
-    COMPOSITOR_LAST_MOUSE.store(mouse_packed2, Ordering::Relaxed);
-
-    let (ws2, wn2) = crate::time::get_monotonic_time_ns();
-    COMPOSITOR_LAST_WAKE_NS.store(
-        (ws2 as u64) * 1_000_000_000 + (wn2 as u64),
-        Ordering::Relaxed,
-    );
-
-    SyscallResult::Ok(ready_after | ((cur_reg_gen2 & 0x00FF_FFFF) << 8))
 }
 
 /// Descriptor for multi-window GPU compositing (passed from userspace).
@@ -1642,12 +1521,9 @@ fn handle_composite_windows(desc_ptr: u64) -> SyscallResult {
     };
 
     // Wake blocked clients after GPU work completes (frame pacing back-pressure).
-    // This must happen OUTSIDE the WINDOW_REGISTRY lock to avoid deadlock with
-    // the scheduler lock.
-    for tid in threads_to_wake.iter().flatten() {
-        crate::task::scheduler::with_scheduler(|sched| {
-            sched.unblock(*tid);
-        });
+    // This must happen OUTSIDE the WINDOW_REGISTRY lock.
+    if threads_to_wake.iter().any(|tid| tid.is_some()) {
+        CLIENT_FRAME_WQ.wake_up();
     }
 
     result

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -10,6 +10,7 @@ use core::{
 pub mod completion;
 pub mod executor;
 pub mod thread;
+pub mod waitqueue;
 
 // Architecture-specific context switching
 // Note: context.rs contains x86_64 assembly - ARM64 uses separate implementation

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -167,6 +167,18 @@ static CPU_IS_IDLE: [AtomicBool; MAX_CPUS] = [
 /// 3. AtomicU64 ensures visibility across threads without additional locking
 static UNBLOCK_CALL_COUNT: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
+#[derive(Clone, Copy, Default)]
+struct IoWakeResult {
+    enqueued_target: Option<usize>,
+    current_cpu: Option<usize>,
+}
+
+impl IoWakeResult {
+    fn resched_target(self) -> Option<usize> {
+        self.enqueued_target.or(self.current_cpu)
+    }
+}
+
 /// Get the current unblock() call count (for testing)
 ///
 /// This function is used by the test framework to verify that pipe wake
@@ -1331,6 +1343,24 @@ impl Scheduler {
         }
     }
 
+    /// Send a reschedule IPI to the CPU that received a newly runnable task.
+    #[cfg(target_arch = "aarch64")]
+    fn send_resched_ipi_to_cpu(&self, target_cpu: usize) {
+        use crate::arch_impl::aarch64::smp;
+
+        if target_cpu == Self::current_cpu_id() {
+            return;
+        }
+        if target_cpu >= MAX_CPUS || target_cpu >= smp::cpus_online() as usize {
+            return;
+        }
+
+        crate::arch_impl::aarch64::gic::send_sgi(
+            crate::arch_impl::aarch64::constants::SGI_RESCHEDULE as u8,
+            target_cpu as u8,
+        );
+    }
+
     /// Block current thread until a signal is delivered
     /// Used by the pause() syscall
     ///
@@ -1673,6 +1703,30 @@ impl Scheduler {
     /// with_scheduler() disables interrupts before acquiring the lock, and
     /// the ISR runs with interrupts already masked by hardware.
     pub fn unblock_for_io(&mut self, tid: u64) {
+        let wake = self.wake_io_thread_locked(tid);
+        if wake.enqueued_target.is_some() {
+            #[cfg(target_arch = "aarch64")]
+            self.send_resched_ipi();
+        }
+    }
+
+    /// Immediate task-context waitqueue wake.
+    ///
+    /// Mirrors Linux's waitqueue -> try_to_wake_up nesting: the waitqueue lock
+    /// is held by the caller, and this helper performs the scheduler state
+    /// transition before the waitqueue wake returns.
+    pub fn wake_waitqueue_thread(&mut self, tid: u64) {
+        let wake = self.wake_io_thread_locked(tid);
+        #[cfg(target_arch = "aarch64")]
+        if let Some(target) = wake.resched_target() {
+            self.send_resched_ipi_to_cpu(target);
+        }
+        #[cfg(not(target_arch = "aarch64"))]
+        let _ = wake.resched_target();
+    }
+
+    fn wake_io_thread_locked(&mut self, tid: u64) -> IoWakeResult {
+        let mut wake = IoWakeResult::default();
         if let Some(thread) = self.get_thread_mut(tid) {
             let should_queue = if thread.state == ThreadState::BlockedOnIO {
                 thread.set_ready();
@@ -1695,27 +1749,27 @@ impl Scheduler {
                 // against the old CPU's context save; that CPU will publish
                 // the saved context and requeue the Ready thread after the
                 // save point completes.
-                let is_current_on_any_cpu =
-                    (0..MAX_CPUS).any(|cpu| self.cpu_state[cpu].current_thread == Some(tid));
+                wake.current_cpu =
+                    (0..MAX_CPUS).find(|&cpu| self.cpu_state[cpu].current_thread == Some(tid));
 
                 #[cfg(target_arch = "aarch64")]
                 let is_in_deferred = self.is_in_deferred_requeue(tid);
                 #[cfg(not(target_arch = "aarch64"))]
                 let is_in_deferred = false;
 
-                if !is_current_on_any_cpu
+                if wake.current_cpu.is_none()
                     && !is_in_deferred
                     && tid != self.cpu_state[Self::current_cpu_id()].idle_thread
                     && !self.per_cpu_queues.iter().any(|q| q.contains(&tid))
                 {
                     let target = self.find_target_cpu_for_wakeup(tid);
                     self.per_cpu_queues[target].push_back(tid);
-                    #[cfg(target_arch = "aarch64")]
-                    self.send_resched_ipi();
+                    wake.enqueued_target = Some(target);
                 }
                 set_need_resched();
             }
         }
+        wake
     }
 
     /// Block current thread for compositor frame pacing (mark_window_dirty syscall).
@@ -2408,6 +2462,14 @@ where
             .as_mut()
             .and_then(|sched| sched.get_thread_mut(thread_id).map(f))
     })
+}
+
+/// Wake a waitqueue waiter immediately from task context.
+///
+/// The caller must not be in interrupt context; hard IRQ paths must use
+/// `isr_unblock_for_io` so they never spin on the scheduler lock.
+pub fn wake_waitqueue_thread(tid: u64) {
+    with_scheduler(|sched| sched.wake_waitqueue_thread(tid));
 }
 
 /// Get per-process accumulated CPU ticks from all threads in the scheduler.

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -1597,6 +1597,41 @@ impl Scheduler {
         }
     }
 
+    fn publish_current_io_wait_state_inner(&mut self, wake_time_ns: Option<u64>) -> Option<u64> {
+        if let Some(current_id) = self.cpu_state[Self::current_cpu_id()].current_thread {
+            if let Some(thread) = self.get_thread_mut(current_id) {
+                // Charge elapsed CPU ticks before blocking
+                let now = crate::time::get_ticks();
+                thread.cpu_ticks_total += now.wrapping_sub(thread.run_start_ticks);
+                thread.run_start_ticks = now;
+
+                thread.state = ThreadState::BlockedOnIO;
+                thread.wake_time_ns = wake_time_ns;
+                // Mark blocked_in_syscall so the context switch path resumes
+                // inside the syscall (wait_timeout loop) rather than restoring
+                // stale userspace context.
+                thread.blocked_in_syscall = true;
+
+                // Linux set_current_state() is smp_store_mb(): publish the sleep
+                // state before later condition checks or schedule entry observe
+                // wakeups. On AArch64 Rust lowers SeqCst fence to a full DMB.
+                core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+                return Some(current_id);
+            }
+        }
+
+        None
+    }
+
+    /// Publish that the current thread intends to sleep for device I/O.
+    ///
+    /// This is the waitqueue equivalent of Linux `set_current_state()`: callers
+    /// hold the waitqueue lock across enqueue and this state publication, then
+    /// release that lock before entering the scheduler.
+    pub fn publish_current_io_wait_state(&mut self) -> bool {
+        self.publish_current_io_wait_state_inner(None).is_some()
+    }
+
     /// Block the current thread for device I/O.
     ///
     /// Sets state to BlockedOnIO and blocked_in_syscall. The thread will be
@@ -1615,20 +1650,7 @@ impl Scheduler {
     /// unblock_for_io(), while the timer path wakes it by observing
     /// wake_time_ns without clearing blocked_in_syscall prematurely.
     pub fn block_current_for_io_with_timeout(&mut self, wake_time_ns: Option<u64>) {
-        if let Some(current_id) = self.cpu_state[Self::current_cpu_id()].current_thread {
-            if let Some(thread) = self.get_thread_mut(current_id) {
-                // Charge elapsed CPU ticks before blocking
-                let now = crate::time::get_ticks();
-                thread.cpu_ticks_total += now.wrapping_sub(thread.run_start_ticks);
-                thread.run_start_ticks = now;
-
-                thread.state = ThreadState::BlockedOnIO;
-                thread.wake_time_ns = wake_time_ns;
-                // Mark blocked_in_syscall so the context switch path resumes
-                // inside the syscall (wait_timeout loop) rather than restoring
-                // stale userspace context.
-                thread.blocked_in_syscall = true;
-            }
+        if let Some(current_id) = self.publish_current_io_wait_state_inner(wake_time_ns) {
             // Insert into timer heap if a timeout was specified
             if let Some(wt) = wake_time_ns {
                 self.timer_heap.push(Reverse((wt, current_id)));

--- a/kernel/src/task/waitqueue.rs
+++ b/kernel/src/task/waitqueue.rs
@@ -1,0 +1,230 @@
+//! Scheduler-integrated wait queues.
+//!
+//! This is Breenix's equivalent of Linux waitqueues: callers enqueue the
+//! current thread, mark it blocked in the scheduler, re-check their condition,
+//! then schedule if the condition is still false. Wakers remove queued TIDs and
+//! deliver wakeups through F16's lock-free `isr_unblock_for_io` path.
+
+use alloc::collections::VecDeque;
+
+use super::thread::ThreadState;
+
+/// A single waiter recorded by thread ID.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Waiter {
+    tid: u64,
+}
+
+impl Waiter {
+    pub const fn new(tid: u64) -> Self {
+        Self { tid }
+    }
+
+    pub const fn tid(&self) -> u64 {
+        self.tid
+    }
+}
+
+/// Wait queue head for event-driven scheduler waits.
+///
+/// Linux stores caller-owned intrusive wait entries. Breenix's scheduler wake
+/// API is TID-based, so the first implementation stores duplicate-free TIDs
+/// behind a small spin mutex. The public semantics match Linux's core pattern:
+/// prepare, check condition, schedule, finish.
+pub struct WaitQueueHead {
+    waiters: spin::Mutex<VecDeque<Waiter>>,
+}
+
+impl WaitQueueHead {
+    /// Create an empty waitqueue.
+    pub const fn new() -> Self {
+        Self {
+            waiters: spin::Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Enqueue the current thread and set its scheduler state.
+    ///
+    /// F32 initially supports `BlockedOnIO` because that is the state wired to
+    /// `scheduler::isr_unblock_for_io`. Unsupported states return `None` rather
+    /// than duplicating scheduler policy.
+    pub fn prepare_to_wait(&self, state: ThreadState) -> Option<u64> {
+        if state != ThreadState::BlockedOnIO {
+            return None;
+        }
+
+        let tid = crate::task::scheduler::current_thread_id()?;
+
+        self.with_waiters(|waiters| {
+            if !waiters.iter().any(|waiter| waiter.tid == tid) {
+                waiters.push_back(Waiter::new(tid));
+            }
+        });
+
+        crate::task::scheduler::with_scheduler(|sched| {
+            sched.block_current_for_io();
+        });
+
+        Some(tid)
+    }
+
+    /// Remove the current thread from the waitqueue and normalize syscall state.
+    ///
+    /// This mirrors Linux `finish_wait`: a thread that was prepared but never
+    /// actually slept must become runnable before returning from the syscall.
+    pub fn finish_wait(&self) {
+        let Some(tid) = crate::task::scheduler::current_thread_id() else {
+            return;
+        };
+
+        self.remove_waiter(tid);
+
+        crate::task::scheduler::with_scheduler(|sched| {
+            if let Some(thread) = sched.current_thread_mut() {
+                if thread.state == ThreadState::BlockedOnIO {
+                    thread.set_ready();
+                    thread.wake_time_ns = None;
+                }
+                thread.blocked_in_syscall = false;
+            }
+        });
+    }
+
+    /// Wake all waiters.
+    pub fn wake_up(&self) {
+        for waiter in self.drain_waiters() {
+            crate::task::scheduler::isr_unblock_for_io(waiter.tid);
+        }
+    }
+
+    /// Wake the first waiter, if any.
+    pub fn wake_up_one(&self) {
+        if let Some(waiter) = self.pop_one_waiter() {
+            crate::task::scheduler::isr_unblock_for_io(waiter.tid);
+        }
+    }
+
+    /// Return whether the queue currently has waiters.
+    #[allow(dead_code)]
+    pub fn has_waiters(&self) -> bool {
+        self.with_waiters(|waiters| !waiters.is_empty())
+    }
+
+    fn remove_waiter(&self, tid: u64) {
+        self.with_waiters(|waiters| {
+            waiters.retain(|waiter| waiter.tid != tid);
+        });
+    }
+
+    fn drain_waiters(&self) -> VecDeque<Waiter> {
+        self.with_waiters(|waiters| waiters.drain(..).collect::<VecDeque<_>>())
+    }
+
+    fn pop_one_waiter(&self) -> Option<Waiter> {
+        self.with_waiters(|waiters| waiters.pop_front())
+    }
+
+    fn with_waiters<R>(&self, f: impl FnOnce(&mut VecDeque<Waiter>) -> R) -> R {
+        crate::arch_without_interrupts(|| {
+            let mut waiters = self.waiters.lock();
+            f(&mut waiters)
+        })
+    }
+
+    #[cfg(test)]
+    fn push_waiter_for_test(&self, tid: u64) {
+        self.with_waiters(|waiters| {
+            if !waiters.iter().any(|waiter| waiter.tid == tid) {
+                waiters.push_back(Waiter::new(tid));
+            }
+        });
+    }
+
+    #[cfg(test)]
+    fn waiter_count_for_test(&self) -> usize {
+        self.with_waiters(|waiters| waiters.len())
+    }
+
+    #[cfg(test)]
+    fn contains_waiter_for_test(&self, tid: u64) -> bool {
+        self.with_waiters(|waiters| waiters.iter().any(|waiter| waiter.tid == tid))
+    }
+}
+
+/// Sleep the current prepared waiter until the scheduler wake path makes it
+/// runnable again.
+///
+/// Syscall handlers enter with preemption disabled. Waiting must enable
+/// preemption before scheduling and restore the syscall entry invariant before
+/// returning to the caller.
+pub fn schedule_current_wait() {
+    #[cfg(target_arch = "aarch64")]
+    crate::per_cpu_aarch64::preempt_enable();
+    #[cfg(not(target_arch = "aarch64"))]
+    crate::per_cpu::preempt_enable();
+
+    loop {
+        let still_waiting = crate::task::scheduler::with_scheduler(|sched| {
+            sched
+                .current_thread_mut()
+                .map(|thread| thread.state == ThreadState::BlockedOnIO)
+                .unwrap_or(false)
+        })
+        .unwrap_or(false);
+
+        if !still_waiting {
+            break;
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        crate::arch_impl::aarch64::context_switch::schedule_from_kernel();
+        #[cfg(not(target_arch = "aarch64"))]
+        crate::arch_halt_with_interrupts();
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    crate::per_cpu_aarch64::preempt_disable();
+    #[cfg(not(target_arch = "aarch64"))]
+    crate::per_cpu::preempt_disable();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WaitQueueHead;
+
+    #[test]
+    fn duplicate_waiters_are_ignored() {
+        let waitq = WaitQueueHead::new();
+
+        waitq.push_waiter_for_test(42);
+        waitq.push_waiter_for_test(42);
+
+        assert_eq!(waitq.waiter_count_for_test(), 1);
+    }
+
+    #[test]
+    fn wake_up_one_removes_single_waiter() {
+        let waitq = WaitQueueHead::new();
+
+        waitq.push_waiter_for_test(1);
+        waitq.push_waiter_for_test(2);
+        let waiter = waitq.pop_one_waiter();
+
+        assert_eq!(waiter.map(|waiter| waiter.tid()), Some(1));
+        assert_eq!(waitq.waiter_count_for_test(), 1);
+        assert!(!waitq.contains_waiter_for_test(1));
+        assert!(waitq.contains_waiter_for_test(2));
+    }
+
+    #[test]
+    fn wake_up_drains_waiters() {
+        let waitq = WaitQueueHead::new();
+
+        waitq.push_waiter_for_test(1);
+        waitq.push_waiter_for_test(2);
+        let waiters = waitq.drain_waiters();
+
+        assert_eq!(waiters.len(), 2);
+        assert_eq!(waitq.waiter_count_for_test(), 0);
+    }
+}

--- a/kernel/src/task/waitqueue.rs
+++ b/kernel/src/task/waitqueue.rs
@@ -43,7 +43,7 @@ impl WaitQueueHead {
         }
     }
 
-    /// Enqueue the current thread and set its scheduler state.
+    /// Enqueue the current thread and publish its scheduler wait state.
     ///
     /// F32 initially supports `BlockedOnIO` because that is the state wired to
     /// `scheduler::isr_unblock_for_io`. Unsupported states return `None` rather
@@ -55,23 +55,28 @@ impl WaitQueueHead {
 
         let tid = crate::task::scheduler::current_thread_id()?;
 
-        self.with_waiters(|waiters| {
+        let published = self.with_waiters(|waiters| {
             if !waiters.iter().any(|waiter| waiter.tid == tid) {
                 waiters.push_back(Waiter::new(tid));
             }
 
-            crate::task::scheduler::with_scheduler(|sched| {
-                sched.block_current_for_io();
-            });
+            let published = crate::task::scheduler::with_scheduler(|sched| {
+                sched.publish_current_io_wait_state()
+            })
+            .unwrap_or(false);
 
-            // Linux prepare_to_wait() holds wq_head->lock across list insertion
-            // and set_current_state(), whose smp_store_mb() publishes the blocked
-            // state before the lock is released. Keep the same ordering so a wake
-            // that drains this TID cannot run before BlockedOnIO is visible.
-            core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+            if !published {
+                waiters.retain(|waiter| waiter.tid != tid);
+            }
+
+            published
         });
 
-        Some(tid)
+        if published {
+            Some(tid)
+        } else {
+            None
+        }
     }
 
     /// Remove the current thread from the waitqueue and normalize syscall state.
@@ -98,16 +103,20 @@ impl WaitQueueHead {
 
     /// Wake all waiters.
     pub fn wake_up(&self) {
-        for waiter in self.drain_waiters() {
-            crate::task::scheduler::isr_unblock_for_io(waiter.tid);
-        }
+        self.with_waiters(|waiters| {
+            while let Some(waiter) = waiters.pop_front() {
+                crate::task::scheduler::isr_unblock_for_io(waiter.tid);
+            }
+        });
     }
 
     /// Wake the first waiter, if any.
     pub fn wake_up_one(&self) {
-        if let Some(waiter) = self.pop_one_waiter() {
-            crate::task::scheduler::isr_unblock_for_io(waiter.tid);
-        }
+        self.with_waiters(|waiters| {
+            if let Some(waiter) = waiters.pop_front() {
+                crate::task::scheduler::isr_unblock_for_io(waiter.tid);
+            }
+        });
     }
 
     /// Return whether the queue currently has waiters.
@@ -122,10 +131,12 @@ impl WaitQueueHead {
         });
     }
 
+    #[cfg(test)]
     fn drain_waiters(&self) -> VecDeque<Waiter> {
         self.with_waiters(|waiters| waiters.drain(..).collect::<VecDeque<_>>())
     }
 
+    #[cfg(test)]
     fn pop_one_waiter(&self) -> Option<Waiter> {
         self.with_waiters(|waiters| waiters.pop_front())
     }

--- a/kernel/src/task/waitqueue.rs
+++ b/kernel/src/task/waitqueue.rs
@@ -2,8 +2,9 @@
 //!
 //! This is Breenix's equivalent of Linux waitqueues: callers enqueue the
 //! current thread, mark it blocked in the scheduler, re-check their condition,
-//! then schedule if the condition is still false. Wakers remove queued TIDs and
-//! deliver wakeups through F16's lock-free `isr_unblock_for_io` path.
+//! then schedule if the condition is still false. Task-context wakers remove
+//! queued TIDs and wake them inline; interrupt-context wakers use F16's
+//! lock-free `isr_unblock_for_io` path.
 
 use alloc::collections::VecDeque;
 
@@ -105,7 +106,7 @@ impl WaitQueueHead {
     pub fn wake_up(&self) {
         self.with_waiters(|waiters| {
             while let Some(waiter) = waiters.pop_front() {
-                crate::task::scheduler::isr_unblock_for_io(waiter.tid);
+                wake_waiter(waiter);
             }
         });
     }
@@ -114,7 +115,7 @@ impl WaitQueueHead {
     pub fn wake_up_one(&self) {
         self.with_waiters(|waiters| {
             if let Some(waiter) = waiters.pop_front() {
-                crate::task::scheduler::isr_unblock_for_io(waiter.tid);
+                wake_waiter(waiter);
             }
         });
     }
@@ -165,6 +166,25 @@ impl WaitQueueHead {
     #[cfg(test)]
     fn contains_waiter_for_test(&self, tid: u64) -> bool {
         self.with_waiters(|waiters| waiters.iter().any(|waiter| waiter.tid == tid))
+    }
+}
+
+fn wake_waiter(waiter: Waiter) {
+    if in_interrupt_context() {
+        crate::task::scheduler::isr_unblock_for_io(waiter.tid);
+    } else {
+        crate::task::scheduler::wake_waitqueue_thread(waiter.tid);
+    }
+}
+
+fn in_interrupt_context() -> bool {
+    #[cfg(target_arch = "aarch64")]
+    {
+        crate::per_cpu_aarch64::in_interrupt()
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        crate::per_cpu::in_interrupt()
     }
 }
 

--- a/kernel/src/task/waitqueue.rs
+++ b/kernel/src/task/waitqueue.rs
@@ -59,10 +59,16 @@ impl WaitQueueHead {
             if !waiters.iter().any(|waiter| waiter.tid == tid) {
                 waiters.push_back(Waiter::new(tid));
             }
-        });
 
-        crate::task::scheduler::with_scheduler(|sched| {
-            sched.block_current_for_io();
+            crate::task::scheduler::with_scheduler(|sched| {
+                sched.block_current_for_io();
+            });
+
+            // Linux prepare_to_wait() holds wq_head->lock across list insertion
+            // and set_current_state(), whose smp_store_mb() publishes the blocked
+            // state before the lock is released. Keep the same ordering so a wake
+            // that drains this TID cannot run before BlockedOnIO is visible.
+            core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
         });
 
         Some(tid)

--- a/libs/libbreenix/src/graphics.rs
+++ b/libs/libbreenix/src/graphics.rs
@@ -144,6 +144,14 @@ pub mod draw_op {
     pub const SET_CURSOR_SHAPE: u32 = 25;
     /// Poll modifier key state (returns bitmask: bit0=Shift, bit1=Ctrl, bit2=Alt, bit3=Super)
     pub const POLL_MODIFIER_STATE: u32 = 26;
+    /// F32c waitqueue stress reset.
+    pub const WAIT_STRESS_RESET: u32 = 27;
+    /// F32c waitqueue stress wait.
+    pub const WAIT_STRESS_WAIT: u32 = 28;
+    /// F32c waitqueue stress wake.
+    pub const WAIT_STRESS_WAKE: u32 = 29;
+    /// F32c waitqueue stress stats.
+    pub const WAIT_STRESS_STATS: u32 = 30;
 }
 
 /// Ball descriptor for VirGL GPU rendering.
@@ -187,6 +195,61 @@ pub fn fb_clear(color: u32) -> Result<(), Error> {
         p3: 0,
         p4: 0,
         color,
+    };
+    fbdraw(&cmd)
+}
+
+/// Reset the F32c waitqueue stress counters and wake any stale waiter.
+pub fn wait_stress_reset() -> Result<(), Error> {
+    let cmd = FbDrawCmd {
+        op: draw_op::WAIT_STRESS_RESET,
+        p1: 0,
+        p2: 0,
+        p3: 0,
+        p4: 0,
+        color: 0,
+    };
+    fbdraw(&cmd)
+}
+
+/// Block once on the F32c waitqueue stress queue.
+pub fn wait_stress_wait() -> Result<u64, Error> {
+    let cmd = FbDrawCmd {
+        op: draw_op::WAIT_STRESS_WAIT,
+        p1: 0,
+        p2: 0,
+        p3: 0,
+        p4: 0,
+        color: 0,
+    };
+    let ret = unsafe { raw::syscall1(nr::FBDRAW, &cmd as *const FbDrawCmd as u64) as i64 };
+    Error::from_syscall(ret).map(|value| value as u64)
+}
+
+/// Wake the F32c waitqueue stress queue once.
+pub fn wait_stress_wake() -> Result<u64, Error> {
+    let cmd = FbDrawCmd {
+        op: draw_op::WAIT_STRESS_WAKE,
+        p1: 0,
+        p2: 0,
+        p3: 0,
+        p4: 0,
+        color: 0,
+    };
+    let ret = unsafe { raw::syscall1(nr::FBDRAW, &cmd as *const FbDrawCmd as u64) as i64 };
+    Error::from_syscall(ret).map(|value| value as u64)
+}
+
+/// Read F32c waitqueue stress counters: entered, returned, wakes, has_waiters.
+pub fn wait_stress_stats(out: &mut [u64; 4]) -> Result<(), Error> {
+    let ptr = out.as_mut_ptr() as u64;
+    let cmd = FbDrawCmd {
+        op: draw_op::WAIT_STRESS_STATS,
+        p1: ptr as u32 as i32,
+        p2: (ptr >> 32) as u32 as i32,
+        p3: out.len() as i32,
+        p4: 0,
+        color: 0,
     };
     fbdraw(&cmd)
 }

--- a/scripts/create_ext2_disk.sh
+++ b/scripts/create_ext2_disk.sh
@@ -87,6 +87,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
         -v "$USERSPACE_DIR:/binaries:ro" \
         -v "$PROJECT_ROOT/fonts:/fonts:ro" \
         -e "OUTPUT_FILENAME=$OUTPUT_FILENAME" \
+        -e "BREENIX_WAIT_STRESS=${BREENIX_WAIT_STRESS:-0}" \
         alpine:latest \
         sh -c '
             set -e
@@ -206,6 +207,11 @@ BSHRC
 
             # Create /tmp for filesystem write tests
             mkdir -p /mnt/ext2/tmp
+
+            if [ "${BREENIX_WAIT_STRESS:-0}" = "1" ]; then
+                touch /mnt/ext2/etc/wait_stress.enabled
+                echo "  Enabled wait_stress init gate"
+            fi
 
             # Create /home for user data (Gus Kit saves, etc.)
             mkdir -p /mnt/ext2/home
@@ -468,6 +474,11 @@ BSHRC
 
     # Create /tmp for filesystem write tests
     mkdir -p "$MOUNT_DIR/tmp"
+
+    if [ "${BREENIX_WAIT_STRESS:-0}" = "1" ]; then
+        touch "$MOUNT_DIR/etc/wait_stress.enabled"
+        echo "  Enabled wait_stress init gate"
+    fi
 
     # Create /home for user data (Gus Kit saves, etc.)
     mkdir -p "$MOUNT_DIR/home"

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -280,6 +280,10 @@ name = "concurrent_recv_stress"
 path = "src/concurrent_recv_stress.rs"
 
 [[bin]]
+name = "wait_stress"
+path = "src/wait_stress.rs"
+
+[[bin]]
 name = "counter"
 path = "src/counter.rs"
 

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -189,6 +189,7 @@ STD_BINARIES=(
     "nonblock_eagain_test"
     "blocking_recv_test"
     "tcp_client_test"
+    "wait_stress"
     "simple_exit"
     "counter"
     "spinner"

--- a/userspace/programs/src/bwm.rs
+++ b/userspace/programs/src/bwm.rs
@@ -1214,6 +1214,8 @@ fn blit_window_contents(vram: &mut [u32], screen_w: usize, screen_h: usize, wind
         let copy_h = src_h.min(screen_h - dst_y);
         let src = unsafe { core::slice::from_raw_parts(ptr, win.mapped_width * win.mapped_height) };
 
+        let _ = graphics::check_window_dirty(win.window_id);
+
         for row in 0..copy_h {
             let src_start = row * win.mapped_width;
             let dst_start = (dst_y + row) * screen_w + dst_x;

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -3,14 +3,18 @@
 //! PID 1 - runs bsh (no arguments), then starts background services and reaps zombies.
 //! bsh detects it's the init shell (PID 2) and loads /etc/init.js.
 
+#[cfg(target_arch = "aarch64")]
+use libbreenix::fs;
 use libbreenix::process::{getpid, spawn, waitpid};
 #[cfg(target_arch = "aarch64")]
-use libbreenix::process::yield_now;
+use libbreenix::process::{spawnv, yield_now};
 
 fn main() {
     let pid = getpid().map(|p| p.raw()).unwrap_or(0);
     print!("[init] Breenix init starting (PID {})\n", pid);
 
+    #[cfg(target_arch = "aarch64")]
+    run_wait_stress_if_enabled();
     run_boot_script();
     start_bsshd();
     #[cfg(target_arch = "aarch64")]
@@ -36,6 +40,35 @@ fn main() {
                 };
                 let _ = libbreenix::time::nanosleep(&ts);
             }
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn run_wait_stress_if_enabled() {
+    if fs::access("/etc/wait_stress.enabled", fs::F_OK).is_err() {
+        return;
+    }
+
+    print!("[init] wait_stress enabled; starting 60s waitqueue stress\n");
+    let path = b"/bin/wait_stress\0";
+    let arg0 = b"wait_stress\0";
+    let arg1 = b"60\0";
+    let argv = [arg0.as_ptr(), arg1.as_ptr(), core::ptr::null()];
+
+    match spawnv(path, argv.as_ptr()) {
+        Ok(child_pid) => {
+            let mut status = 0i32;
+            let _ = waitpid(child_pid.raw() as i32, &mut status as *mut i32, 0);
+            let exit_code = (status >> 8) & 0xFF;
+            print!(
+                "[init] wait_stress exited pid={} code={}\n",
+                child_pid.raw(),
+                exit_code
+            );
+        }
+        Err(e) => {
+            print!("[init] Warning: failed to start wait_stress: {}\n", e);
         }
     }
 }

--- a/userspace/programs/src/wait_stress.rs
+++ b/userspace/programs/src/wait_stress.rs
@@ -1,0 +1,181 @@
+//! F32c waitqueue race reproducer.
+//!
+//! This program intentionally stresses a waitqueue with no persistent condition:
+//! a wake that lands after queue enrollment must still prevent the waiter from
+//! sleeping. Linux closes that race by setting task state under the waitqueue
+//! lock and making schedule a no-op for TASK_RUNNING tasks.
+
+use libbreenix::graphics;
+use libbreenix::process::{self, ForkResult, WNOHANG};
+use libbreenix::signal::{kill, SIGKILL};
+use libbreenix::time;
+use libbreenix::types::Timespec;
+use std::process as std_process;
+
+const DEFAULT_DURATION_SECS: u64 = 60;
+const SAMPLE_MS: u64 = 100;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Stats {
+    entered: u64,
+    returned: u64,
+    wakes: u64,
+    has_waiters: u64,
+}
+
+fn read_stats() -> Stats {
+    let mut raw = [0u64; 4];
+    if let Err(err) = graphics::wait_stress_stats(&mut raw) {
+        println!("WAIT_STRESS_ERROR stats failed: {:?}", err);
+        std_process::exit(2);
+    }
+    Stats {
+        entered: raw[0],
+        returned: raw[1],
+        wakes: raw[2],
+        has_waiters: raw[3],
+    }
+}
+
+fn sleep_ms(ms: u64) {
+    let ts = Timespec {
+        tv_sec: (ms / 1000) as i64,
+        tv_nsec: ((ms % 1000) * 1_000_000) as i64,
+    };
+    let _ = time::nanosleep(&ts);
+}
+
+fn parse_duration_secs() -> u64 {
+    std::env::args()
+        .nth(1)
+        .and_then(|arg| arg.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(DEFAULT_DURATION_SECS)
+}
+
+fn waiter() -> ! {
+    loop {
+        if let Err(err) = graphics::wait_stress_wait() {
+            println!("WAIT_STRESS_ERROR waiter failed: {:?}", err);
+            std_process::exit(10);
+        }
+    }
+}
+
+fn waker() -> ! {
+    let mut wakes = 0u64;
+    loop {
+        if let Err(err) = graphics::wait_stress_wake() {
+            println!("WAIT_STRESS_ERROR waker failed: {:?}", err);
+            std_process::exit(11);
+        }
+        wakes += 1;
+        if wakes & 0x3f == 0 {
+            let _ = process::yield_now();
+        }
+    }
+}
+
+fn fork_child(role: &str, f: fn() -> !) -> u64 {
+    match process::fork() {
+        Ok(ForkResult::Child) => f(),
+        Ok(ForkResult::Parent(pid)) => {
+            println!("WAIT_STRESS: forked {} pid={}", role, pid.raw());
+            pid.raw()
+        }
+        Err(err) => {
+            println!("WAIT_STRESS_ERROR fork {} failed: {:?}", role, err);
+            std_process::exit(3);
+        }
+    }
+}
+
+fn cleanup(waiter_pid: u64, waker_pid: u64) {
+    let _ = kill(waiter_pid as i32, SIGKILL);
+    let _ = kill(waker_pid as i32, SIGKILL);
+
+    let mut status = 0i32;
+    let mut waiter_reaped = false;
+    let mut waker_reaped = false;
+    for _ in 0..20 {
+        if !waiter_reaped
+            && process::waitpid(waiter_pid as i32, &mut status, WNOHANG)
+                .map(|pid| pid.raw() != 0)
+                .unwrap_or(false)
+        {
+            waiter_reaped = true;
+        }
+        if !waker_reaped
+            && process::waitpid(waker_pid as i32, &mut status, WNOHANG)
+                .map(|pid| pid.raw() != 0)
+                .unwrap_or(false)
+        {
+            waker_reaped = true;
+        }
+        if waiter_reaped && waker_reaped {
+            break;
+        }
+        sleep_ms(10);
+    }
+}
+
+fn main() {
+    let duration_secs = parse_duration_secs();
+    println!(
+        "WAIT_STRESS_START duration={}s sample={}ms",
+        duration_secs, SAMPLE_MS
+    );
+
+    if let Err(err) = graphics::wait_stress_reset() {
+        println!("WAIT_STRESS_ERROR reset failed: {:?}", err);
+        std_process::exit(1);
+    }
+
+    let waiter_pid = fork_child("waiter", waiter);
+    let waker_pid = fork_child("waker", waker);
+
+    let samples = (duration_secs * 1000).div_ceil(SAMPLE_MS);
+    let mut last = read_stats();
+
+    for sample in 0..samples {
+        sleep_ms(SAMPLE_MS);
+        let stats = read_stats();
+
+        if stats.entered > stats.returned
+            && stats.returned == last.returned
+            && stats.wakes > last.wakes
+        {
+            println!(
+                "WAIT_STRESS_STALL sample={} entered={} returned={} wakes={} waiters={}",
+                sample + 1,
+                stats.entered,
+                stats.returned,
+                stats.wakes,
+                stats.has_waiters
+            );
+            cleanup(waiter_pid, waker_pid);
+            std_process::exit(4);
+        }
+
+        if (sample + 1) % 10 == 0 {
+            println!(
+                "WAIT_STRESS_PROGRESS sample={} entered={} returned={} wakes={} waiters={}",
+                sample + 1,
+                stats.entered,
+                stats.returned,
+                stats.wakes,
+                stats.has_waiters
+            );
+        }
+
+        last = stats;
+    }
+
+    let final_stats = read_stats();
+    cleanup(waiter_pid, waker_pid);
+    println!(
+        "WAIT_STRESS_PASS entered={} returned={} wakes={} waiters={}",
+        final_stats.entered, final_stats.returned, final_stats.wakes, final_stats.has_waiters
+    );
+    std_process::exit(0);
+}


### PR DESCRIPTION
## Summary
- Captures F32i CPU0 WFI wake diagnosis from two Parallels hang reproductions
- Audits Linux v6.8 ARM64 idle, WFI, GIC SGI, reschedule, and TTWU wake-list paths with file:line cites
- Validates Linux probe CPU0 idle wake behavior on Parallels ARM64 with ftrace evidence
- Proposes design-only F32j fix options; no implementation changes

## Validation
- cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64
- cargo build --release --features testing,external_test_bins --bin qemu-uefi
- bd dolt push
- QEMU cleanup completed