### PR TITLE
F32n-fix: store xHCI MSI irq into XhciState so GIC SPI activates

### DIFF
--- a/kernel/src/drivers/usb/xhci.rs
+++ b/kernel/src/drivers/usb/xhci.rs
@@ -5027,7 +5027,7 @@ pub fn init(pci_dev: &crate::drivers::pci::Device) -> Result<(), &'static str> {
         max_slots: slots_en,
         max_ports,
         context_size,
-        irq: 0,
+        irq: early_irq,
         kbd_slot: 0,
         kbd_endpoint: 0,
         kbd_nkro_endpoint: 0,


### PR DESCRIPTION
## One-line fix — input regression

**Root cause** (from F32n diagnosis, evidence on branch \`f32n-event-driven-input\` at \`docs/planning/f32n-input/diagnosis.md\`):

MSI allocation produces \`early_irq=55\` correctly. \`XHCI_IRQ.store(early_irq)\` publishes the global. But \`XhciState\` construction at \`kernel/src/drivers/usb/xhci.rs:5030\` hard-codes \`irq: 0\`. The deferred SPI activation path guards on \`state.irq != 0\` before calling \`gic::enable_spi()\`, so the xHCI SPI is never enabled → xHCI IRQ never fires → event ring never drained → no HID reports → \`mouse_pos\`/\`modifier_state\` globals never updated → no cursor movement, no hotkeys.

The code even comments \"Create state with IRQ already set\" — the field was plumbed but never wired up.

## Fix

\`irq: 0\` → \`irq: early_irq\` at line 5030. That's it.

## Validation

- Clean aarch64 kernel build
- Final input smoke test requires your manual verification on Parallels:
  - Mouse moves → cursor moves
  - Double-tap Super → blauncher opens
  - Super+Return → bterm opens

Do not auto-merge — please verify input works, then merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)