### PR TITLE
F32r: per-CPU resched audit + design + primitive (no consumers)

### DIFF
--- a/docs/planning/f32r-percpu-resched/audit.md
+++ b/docs/planning/f32r-percpu-resched/audit.md
@@ -1,0 +1,156 @@
+# F32r Per-CPU Reschedule Audit
+
+Date: 2026-04-20
+
+## Scope
+
+This audit inventories every call site in the current tree that directly sets
+the global `NEED_RESCHED` flag, directly sets an x86_64/aarch64 per-CPU
+`need_resched` flag, or calls `scheduler::set_need_resched()` and therefore
+sets both the global flag and the current CPU's per-CPU flag.
+
+The Linux comparison point is not a global boolean. Linux marks a specific
+runqueue's current task through `resched_curr(rq)` and, for remote CPUs, sends
+a targeted reschedule IPI (`/tmp/linux-v6.8/kernel/sched/core.c:1041-1063`).
+The explicit helper `resched_cpu(int cpu)` locks `cpu_rq(cpu)` and delegates
+to `resched_curr()` (`/tmp/linux-v6.8/kernel/sched/core.c:1065-1073`).
+On arm64 the flag is per-thread/per-task state: `TIF_NEED_RESCHED` and
+`_TIF_NEED_RESCHED` live in `thread_info.flags`
+(`/tmp/linux-v6.8/arch/arm64/include/asm/thread_info.h:24-46`,
+`:60-86`). Linux wakeups determine a target CPU in `try_to_wake_up()` and
+queue the task to that CPU (`/tmp/linux-v6.8/kernel/sched/core.c:4222-4370`).
+
+## Breenix Primitives Today
+
+| Site | Purpose | Target CPU known at call? | How | Linux equivalent |
+| --- | --- | --- | --- | --- |
+| `kernel/src/task/scheduler.rs:133-134` | Declares global `NEED_RESCHED`. | No. | Single global bit has no CPU ownership. | No equivalent global bit; Linux uses `TIF_NEED_RESCHED` on the target task/current task (`thread_info.h:60-86`). |
+| `kernel/src/task/scheduler.rs:2563-2570` | Public `set_need_resched()` sets global + current CPU per-CPU bit. | Current CPU only. | Uses current CPU's per-CPU storage, but global bit lets any CPU observe it. | Same-CPU branch of `resched_curr()` sets current's need-resched (`core.c:1051-1056`); remote case is targeted IPI (`core.c:1059-1060`). |
+| `kernel/src/task/scheduler.rs:2572-2596` | `check_and_clear_need_resched()` reads/clears per-CPU and swaps global. | N/A read path. | Any CPU can consume and clear the global bit, which loses target ownership. | Linux clears the previous task's flag during schedule (`core.c:6691-6693`). |
+| `kernel/src/task/scheduler.rs:2599-2610` | `is_need_resched()` reads per-CPU OR global. | N/A read path. | Idle gate sees global as local work. | Linux `need_resched()` is per current task/thread, not a machine-global flag. |
+| `kernel/src/task/scheduler.rs:2018-2023` | `set_need_resched_inner()` sets global + aarch64 current CPU per-CPU bit while scheduler lock is held. | Current CPU only. | Called from aarch64 context-switch redirect paths. | Same-CPU `resched_curr()` behavior (`core.c:1051-1056`). |
+| `kernel/src/arch_impl/aarch64/exception.rs:1243-1248` | SGI reschedule handler sets target CPU's per-CPU bit. | Yes: receiving CPU. | The GIC delivered `SGI_RESCHEDULE` to this CPU. | Remote branch of `resched_curr()` sends `smp_send_reschedule(cpu)` (`core.c:1059-1060`). |
+| `kernel/src/per_cpu.rs:429-435` | x86_64 per-CPU setter. | Current CPU only. | Writes x86 per-CPU storage. | Same-CPU need-resched flag set. |
+| `kernel/src/per_cpu_aarch64.rs:221-228` | aarch64 per-CPU setter. | Current CPU only. | Writes aarch64 per-CPU storage. | Same-CPU need-resched flag set. |
+
+## Scheduler Wake And Spawn Sites
+
+| Site | Purpose | Target CPU known at call? | How | Linux equivalent |
+| --- | --- | --- | --- | --- |
+| `kernel/src/task/scheduler.rs:565-587` | `add_thread_inner()` queues a new thread. | Yes internally. | `least_loaded_cpu()` is stored in local `target` (`:581-587`) but `add_thread()`/`add_thread_front()` discard it. | `try_to_wake_up()` selects a CPU (`core.c:4354-4364`) before `ttwu_queue()` (`core.c:4369`). |
+| `kernel/src/task/scheduler.rs:2212-2230` | `spawn()` adds a new thread, sets global/current per-CPU, and broadcasts SGI to idle CPUs. | Yes, but not exposed. | `add_thread_inner()` computed target; public `add_thread()` currently returns `()`. | Wake path should enqueue to selected CPU and resched that runqueue (`core.c:4369`, `core.c:1041-1063`). |
+| `kernel/src/task/scheduler.rs:2237-2255` | `spawn_front()` adds fork child to front, sets global/current per-CPU, and broadcasts SGI to idle CPUs. | Yes, but not exposed. | `add_thread_inner()` computed target; public `add_thread_front()` currently returns `()`. | Same as child wake/enqueue to selected CPU; no global flag (`core.c:4354-4370`). |
+| `kernel/src/task/scheduler.rs:1244-1303` | `unblock()` makes blocked thread ready and queues it. | Yes when queued; yes when current. | Queued target is `find_target_cpu_for_wakeup(thread_id)` (`:1290-1291`); if still current, target is `cpu_state[cpu].current_thread`. Current callers often add a later global set. | `try_to_wake_up()` handles current task specially (`core.c:4227-4244`) or chooses `task_cpu/select_task_rq` (`core.c:4339-4369`). |
+| `kernel/src/task/scheduler.rs:1437-1509` | `unblock_for_signal()` wakes a signal waiter; sets global via `set_need_resched()`. | Yes after lookup. | Queued target is `find_target_cpu_for_wakeup()` (`:1486-1487`); if current, target is owning `cpu_state` (`:1471-1474`). | `wake_up_state()`/`try_to_wake_up()` (`core.c:4505-4507`, `core.c:4222-4370`). |
+| `kernel/src/task/scheduler.rs:1561-1604` | `unblock_for_child_exit()` wakes waitpid waiter; sets global via `set_need_resched()`. | Yes after lookup. | Queued target is `find_target_cpu_for_wakeup()` (`:1587-1588`); if current, target is owning `cpu_state`. | `try_to_wake_up()` target CPU selection (`core.c:4354-4369`). |
+| `kernel/src/task/scheduler.rs:1705-1710` | `unblock_for_io()` wakes I/O waiter and broadcasts SGI to idle CPUs when enqueued. | Yes. | `wake_io_thread_locked()` returns `enqueued_target`; this call ignores the specific CPU and broadcasts through `send_resched_ipi()`. | Targeted `resched_curr(rq)`/`smp_send_reschedule(cpu)` (`core.c:1041-1063`). |
+| `kernel/src/task/scheduler.rs:1713-1725` | `wake_waitqueue_thread()` wakes waitqueue waiter and sends targeted SGI. | Yes. | `IoWakeResult::resched_target()` returns queued target or current owner (`:170-179`, `:1721-1722`). | Closest current Breenix parity to `try_to_wake_up()` + target runqueue (`core.c:4222-4370`). |
+| `kernel/src/task/scheduler.rs:1728-1770` | `wake_io_thread_locked()` core I/O wake; sets global via `set_need_resched()`. | Yes. | Captures current CPU owner (`:1752-1753`) or enqueued target (`:1765-1767`). | `try_to_wake_up()` observes `on_cpu`/`task_cpu` and queues target (`core.c:4339-4369`). |
+| `kernel/src/task/scheduler.rs:1840-1897` | `wake_expired_timers()` queues expired timer/I/O sleepers. | Yes when queued. | Uses `find_target_cpu_for_wakeup(tid)` (`:1894-1896`), but does not itself resched the target. | Timer wake should be normal target wake (`core.c:4222-4370`). |
+| `kernel/src/task/scheduler.rs:1944-1958` | `find_target_cpu_for_wakeup()` target lookup helper. | Yes. | Prefer current owner CPU, else least-loaded runqueue. | Simplified analogue of `task_cpu(p)`/`select_task_rq()` (`core.c:4339-4364`). |
+| `kernel/src/task/scheduler.rs:2040-2126` | `rescue_stuck_ready_threads()` queues stuck Ready threads and broadcasts SGI. | Yes. | Target from `find_target_cpu_for_wakeup(tid)` (`:2123-2125`), but broadcast IPI is used. | Targeted `resched_cpu(cpu)` (`core.c:1065-1073`). |
+| `kernel/src/task/scheduler.rs:2535-2544` | `yield_current()` asks current CPU to reschedule. | Yes. | Current CPU only; not a wake. | Same-CPU branch of `resched_curr()` (`core.c:1051-1056`). |
+| `kernel/src/task/scheduler.rs:2636-2645` | `isr_unblock_for_io()` pushes tid into current CPU ISR wake buffer and sets global/current per-CPU. | Yes: current CPU buffer. | `current_cpu_id_raw()` selects the buffer drained on that CPU. | Deferred remote wake endpoint resembles Linux `ttwu_queue_wakelist()` but current design intentionally drains locally (`core.c:3930-4049`). |
+| `kernel/src/task/scheduler.rs:846-852` | Schedule fallback switches current CPU to idle and sets per-CPU bit for follow-up scheduling. | Yes. | Current CPU is executing the schedule path. | Same-CPU `resched_curr()` branch (`core.c:1051-1056`). |
+| `kernel/src/task/scheduler.rs:1127-1134` | aarch64 deferred schedule fallback switches current CPU to idle and sets per-CPU bit. | Yes. | Current CPU is executing the schedule path. | Same-CPU `resched_curr()` branch (`core.c:1051-1056`). |
+
+## External Wake Callers Using Global `set_need_resched()`
+
+These sites currently wake one or more known threads and then call the global
+helper. The target CPU is derivable per waiter by having the scheduler wake
+primitive return `IoWakeResult`/target CPU, or by moving the resched call inside
+the scheduler method that already computes the target.
+
+| Site | Purpose | Target CPU known at call? | How | Linux equivalent |
+| --- | --- | --- | --- | --- |
+| `kernel/src/ipc/stdin.rs:146-153` | Wake stdin readers after interrupt-context input. | Yes per reader after scheduler lookup. | Iterates concrete thread IDs; `sched.unblock(thread_id)` can return target. | `wake_up_process()`/`try_to_wake_up()` (`core.c:4499-4501`, `core.c:4222-4370`). |
+| `kernel/src/ipc/stdin.rs:171-179` | ARM64 try-lock stdin reader wake. | Yes per reader after scheduler lookup. | Same concrete thread ID loop. | Same as above. |
+| `kernel/src/ipc/stdin.rs:237-246` | Wake stdin readers on buffered input path. | Yes per reader after scheduler lookup. | Same concrete thread ID loop. | Same as above. |
+| `kernel/src/ipc/stdin.rs:264-272` | ARM64 lock-taking stdin reader wake. | Yes per reader after scheduler lookup. | Same concrete thread ID loop. | Same as above. |
+| `kernel/src/tty/driver.rs:675-683` | Wake TTY readers. | Yes per reader after scheduler lookup. | Iterates concrete waiter TIDs. | Waitqueue wake -> `try_to_wake_up()` (`core.c:4222-4370`). |
+| `kernel/src/tty/pty/pair.rs:155-168` | Wake PTY master waiters. | Yes per waiter after scheduler lookup. | Iterates concrete waiter TIDs. | Waitqueue wake -> `try_to_wake_up()` (`core.c:4222-4370`). |
+| `kernel/src/tty/pty/pair.rs:186-198` | Wake PTY slave waiters. | Yes per waiter after scheduler lookup. | Iterates concrete waiter TIDs. | Waitqueue wake -> `try_to_wake_up()` (`core.c:4222-4370`). |
+| `kernel/src/tty/pty/pair.rs:382-389` | PTY hangup wakes signal/child-exit waiters. | Yes after scheduler lookup. | Has a concrete `thread_id`; scheduler methods can return targets. | Signal wake follows `wake_up_state()`/`try_to_wake_up()` (`core.c:4505-4507`). |
+| `kernel/src/socket/udp.rs:132-139` | Wake UDP recv waiters. | Yes per waiter after scheduler lookup. | Iterates concrete waiter TIDs. | Socket waitqueue wake -> `try_to_wake_up()` (`core.c:4222-4370`). |
+| `kernel/src/net/tcp.rs:1558-1570` | Wake TCP accept waiters. | Yes per waiter after scheduler lookup. | Iterates concrete waiter TIDs. | Socket waitqueue wake -> `try_to_wake_up()` (`core.c:4222-4370`). |
+| `kernel/src/net/tcp.rs:1575-1588` | Wake TCP connection waiters. | Yes per waiter after scheduler lookup. | Iterates concrete waiter TIDs. | Socket waitqueue wake -> `try_to_wake_up()` (`core.c:4222-4370`). |
+| `kernel/src/drivers/virtio/gpu_pci.rs:1488-1494` | Wake compositor waiting for GPU command completion. | Yes after scheduler lookup. | `GPU_WAITING_THREAD` holds concrete TID; `sched.unblock()` can return target. | Device completion wake -> `try_to_wake_up()` target CPU (`core.c:4222-4370`). |
+| `kernel/src/socket/udp.rs:139`, `kernel/src/net/tcp.rs:1570`, `kernel/src/net/tcp.rs:1588` | Network waiter global resched calls. | Yes per waiter after scheduler lookup. | Duplicate direct global helper rows called out because these are likely high traffic. | Same as socket waitqueue wake above. |
+| `kernel/src/task/kthread.rs:183-192` | `kthread_unpark()` wakes parked kernel thread. | Yes after scheduler lookup. | Handle stores concrete TID. | `wake_up_process()` (`core.c:4499-4501`). |
+| `kernel/src/task/kthread.rs:216-242` | `kthread_exit()` terminates current kthread and asks current CPU to reschedule. | Yes. | Current CPU must stop running terminated current thread. | Same-CPU `resched_curr()` (`core.c:1051-1056`). |
+
+## Syscall, Signal, Fault, And Timer Sites
+
+These sites are mostly "current CPU must stop running this thread" rather than
+cross-CPU wakeups. They should become `resched_cpu(current_cpu)` or a current
+CPU helper, not a global broadcast.
+
+| Site | Purpose | Target CPU known at call? | How | Linux equivalent |
+| --- | --- | --- | --- | --- |
+| `kernel/src/interrupts/timer.rs:62-66` | x86_64 quantum expiry. | Yes. | Timer interrupt is running on the target CPU. | Timer tick calls scheduler on local runqueue; local need-resched flag. |
+| `kernel/src/arch_impl/aarch64/timer_interrupt.rs:716-720` | aarch64 quantum expiry. | Yes. | Timer interrupt's `cpu_id` indexes the current CPU. | Local tick marks current runqueue/task for resched. |
+| `kernel/src/arch_impl/aarch64/timer_interrupt.rs:723-730` | aarch64 idle CPU fast path sets need-resched every tick. | Yes but this is the CPU burn source. | Uses `cpu_id`; should eventually be unnecessary once wakeups target idle CPUs. | Linux idle exits on local `need_resched()`; no global polling bit. |
+| `kernel/src/syscall/handlers.rs:213-215` | `sys_exit` terminates current thread. | Yes. | Current syscall CPU. | Current task exits and schedules locally. |
+| `kernel/src/syscall/handler.rs:683-689` | x86_64 signal termination after syscall delivery. | Yes. | Current syscall CPU. | Current task needs local resched. |
+| `kernel/src/arch_impl/aarch64/syscall_entry.rs:276-282` | aarch64 signal termination after syscall delivery. | Yes. | Current syscall CPU. | Current task needs local resched. |
+| `kernel/src/syscall/signal.rs:158-168` | `SIGKILL` process termination. | Partly. | Process state known, but target thread/CPU is not resolved at this call; should wake/mark affected threads explicitly. | Linux signal wake paths resolve target tasks and call `try_to_wake_up()` as needed. |
+| `kernel/src/syscall/signal.rs:178-185` | `SIGCONT` readies blocked process. | Partly. | Process is known; target thread/CPU must be derived from process threads. | Targeted signal wake through `wake_up_state()`/`try_to_wake_up()` (`core.c:4505-4507`). |
+| `kernel/src/syscall/signal.rs:203-206` | Ordinary signal readies blocked process. | Partly. | Process is known; target thread/CPU must be derived from process threads. | Targeted signal wake through `wake_up_state()`/`try_to_wake_up()`. |
+| `kernel/src/arch_impl/aarch64/exception.rs:461-468` | Data abort terminates current user thread and redirects to idle. | Yes. | Faulting CPU is current CPU. | Current task termination schedules locally. |
+| `kernel/src/arch_impl/aarch64/exception.rs:482-494` | Kernel-mode data abort cleanup redirect. | Yes. | Faulting CPU is current CPU. | Current task termination schedules locally. |
+| `kernel/src/arch_impl/aarch64/exception.rs:810-813` | Instruction abort terminates current user thread and redirects to idle. | Yes. | Faulting CPU is current CPU. | Current task termination schedules locally. |
+| `kernel/src/arch_impl/aarch64/exception.rs:824-836` | Kernel-mode instruction abort cleanup redirect. | Yes. | Faulting CPU is current CPU. | Current task termination schedules locally. |
+| `kernel/src/arch_impl/aarch64/context_switch.rs:3460-3463` | Signal delivery terminated current process on aarch64 IRQ/syscall return path. | Yes. | Current CPU. | Current task termination schedules locally. |
+| `kernel/src/arch_impl/aarch64/context_switch.rs:3468-3471` | Delivered signal caused current process termination. | Yes. | Current CPU. | Current task termination schedules locally. |
+| `kernel/src/interrupts.rs:1419-1430` | x86_64 page-fault/current process termination. | Yes. | Faulting CPU is current CPU. | Current task termination schedules locally. |
+| `kernel/src/interrupts.rs:1728-1736` | x86_64 general-protection/current process termination. | Yes. | Faulting CPU is current CPU. | Current task termination schedules locally. |
+| `kernel/src/interrupts/context_switch.rs:151-159` | x86_64 context switch abort because process manager lock is busy. | Yes. | Current CPU should retry later. | Same-CPU `resched_curr()` retry behavior. |
+| `kernel/src/interrupts/context_switch.rs:286-288` | x86_64 context save failure retry. | Yes. | Current CPU. | Same-CPU `resched_curr()` retry behavior. |
+| `kernel/src/interrupts/context_switch.rs:828-835` | x86_64 context restore failure retry. | Yes. | Current CPU. | Same-CPU `resched_curr()` retry behavior. |
+| `kernel/src/interrupts/context_switch.rs:1016-1025` | x86_64 bad userspace context terminates thread. | Yes. | Current CPU. | Current task termination schedules locally. |
+| `kernel/src/interrupts/context_switch.rs:1107-1123` | x86_64 signal delivery terminates current process. | Yes. | Current CPU. | Current task termination schedules locally. |
+| `kernel/src/interrupts/context_switch.rs:1338-1349` | x86_64 signal delivery terminates current process, second path. | Yes. | Current CPU. | Current task termination schedules locally. |
+| `kernel/src/preempt_count_test.rs:176-192` | Test-only direct x86 per-CPU need-resched set. | Yes. | Current CPU under test. | Unit-style local flag testing; not production wake path. |
+
+## Broadcast Or Targeted SGI Sources
+
+These sites do not directly set the local flag, but they cause
+`exception.rs:1247` to set a remote CPU's per-CPU bit. They matter because the
+new `resched_cpu(target)` primitive should replace both the flag set and the
+IPI send.
+
+| Site | Purpose | Target CPU known at call? | How | Linux equivalent |
+| --- | --- | --- | --- | --- |
+| `kernel/src/task/scheduler.rs:1308-1344` | `send_resched_ipi()` broadcasts SGI to all idle CPUs except current. | No single target. | Scans `cpu_state` for idle current threads. This was useful as a wake-all fallback but is not Linux-like. | Linux targets one runqueue via `resched_curr(rq)`; `wake_up_if_idle(cpu)` still takes a specific CPU (`core.c:3946-3955`). |
+| `kernel/src/task/scheduler.rs:1346-1362` | `send_resched_ipi_to_cpu(target_cpu)` sends SGI to one CPU. | Yes. | Explicit argument. It currently returns without setting local per-CPU state for same-CPU targets. | Remote branch of `resched_curr()` (`core.c:1059-1060`). |
+| `kernel/src/task/scheduler.rs:1222-1227` | `requeue_thread_after_save()` queues current CPU's deferred thread and broadcasts SGI. | Yes. | Queues to `Self::current_cpu_id()` (`:1224-1225`) but wakes all idle CPUs. | Targeted `resched_cpu(cpu)` (`core.c:1065-1073`). |
+| `kernel/src/task/scheduler.rs:1290-1302` | `unblock()` queues to target CPU and broadcasts SGI. | Yes. | Target local variable from `find_target_cpu_for_wakeup()`. | Targeted wake CPU in `try_to_wake_up()` (`core.c:4354-4369`). |
+| `kernel/src/task/scheduler.rs:1486-1497` | `unblock_for_signal()` queues to target CPU and broadcasts SGI. | Yes. | Target local variable. | Targeted wake CPU in `try_to_wake_up()`. |
+| `kernel/src/task/scheduler.rs:1587-1599` | `unblock_for_child_exit()` queues to target CPU and broadcasts SGI. | Yes. | Target local variable. | Targeted wake CPU in `try_to_wake_up()`. |
+| `kernel/src/task/scheduler.rs:1705-1709` | `unblock_for_io()` ignores returned target and broadcasts. | Yes. | `wake.enqueued_target` is available. | Targeted `resched_curr(rq)`. |
+| `kernel/src/task/scheduler.rs:1721-1722` | `wake_waitqueue_thread()` sends targeted SGI. | Yes. | Uses `IoWakeResult::resched_target()`. | Targeted `resched_curr(rq)`. |
+| `kernel/src/task/scheduler.rs:2123-2125` | Rescue path queues stuck thread to target and broadcasts. | Yes. | Target local variable. | Targeted `resched_cpu(cpu)`. |
+| `kernel/src/task/scheduler.rs:2226-2229` | `spawn()` broadcasts after adding new thread. | Yes internally but dropped. | `add_thread_inner()` target should be returned. | Targeted wake CPU in `try_to_wake_up()`. |
+| `kernel/src/task/scheduler.rs:2249-2254` | `spawn_front()` broadcasts after adding fork child. | Yes internally but dropped. | `add_thread_inner()` target should be returned. | Targeted wake CPU in `try_to_wake_up()`. |
+| `kernel/src/arch_impl/aarch64/context_switch.rs:2095-2105` | CPU0 user dispatch guard requeues a thread and sends SGI to CPU0. | Yes. | Explicit self target CPU0 to drain deferred requeue. | Explicit `resched_cpu(cpu)` helper (`core.c:1065-1073`). |
+
+## Findings
+
+1. The high-traffic idle-gate bug is structurally explained by
+   `is_need_resched()` mixing local per-CPU state with global `NEED_RESCHED`.
+   Any wake on any CPU can make every idle CPU believe it has local scheduling
+   work.
+2. Most wake sites already have enough information to target a CPU. The target
+   is either a local variable (`find_target_cpu_for_wakeup()` result), a known
+   current owner from `cpu_state`, the current CPU in timer/fault/yield paths,
+   or an explicit SGI target.
+3. Spawn and spawn_front compute the target but discard it. Converting
+   `add_thread()`/`add_thread_front()` to return the selected CPU is the minimal
+   API change needed before targeting those wakeups.
+4. The remaining "partly known" process-signal sites operate at process level,
+   not thread/runqueue level. They should be converted by resolving affected
+   thread IDs and applying the same per-thread wake target loop, not by keeping
+   a global fallback.
+5. Broadcast SGI helpers are separate from the global atomic, but they are the
+   same architectural smell: a wake site should mark and notify the target CPU
+   selected by the enqueue operation, matching Linux `resched_curr(rq)`.

--- a/docs/planning/f32r-percpu-resched/design.md
+++ b/docs/planning/f32r-percpu-resched/design.md
@@ -1,0 +1,310 @@
+# F32r Per-CPU Reschedule Design
+
+Date: 2026-04-20
+
+## Goal
+
+Retire the global `NEED_RESCHED` scheduling signal and replace it with a
+targeted `resched_cpu(target)` primitive. A wake site must mark the CPU that
+owns or receives the runnable work. Idle and interrupt-return paths must only
+consume their own CPU's reschedule state.
+
+This matches Linux's scheduler shape:
+
+- `resched_curr(rq)` is the sole primitive that marks a runqueue's current task
+  for reschedule (`/tmp/linux-v6.8/kernel/sched/core.c:1035-1063`).
+- `resched_cpu(int cpu)` is the explicit CPU-targeted helper
+  (`/tmp/linux-v6.8/kernel/sched/core.c:1065-1073`).
+- arm64 need-resched state is per task/thread-info, not global
+  (`/tmp/linux-v6.8/arch/arm64/include/asm/thread_info.h:24-46`,
+  `:60-86`).
+- `try_to_wake_up()` determines a target CPU before queuing the wake
+  (`/tmp/linux-v6.8/kernel/sched/core.c:4222-4370`).
+
+## Target Architecture
+
+### 1. Add `resched_cpu(target: u8)`
+
+Add a scheduler-owned primitive in `kernel/src/task/scheduler.rs`:
+
+```rust
+#[cfg(target_arch = "aarch64")]
+pub fn resched_cpu(target: u8) {
+    // validate target is online and < MAX_CPUS
+    // set target CPU's per-CPU need_resched flag
+    // if target != current CPU, send SGI_RESCHEDULE to target
+}
+```
+
+Required behavior:
+
+- The target CPU's per-CPU `need_resched` bit is set before the IPI is sent.
+- If `target == current_cpu`, only the local per-CPU bit is set.
+- If `target != current_cpu`, the target bit is set and `SGI_RESCHEDULE` is
+  sent to that CPU.
+- No global boolean is set, read, or cleared by this primitive.
+
+Linux parity:
+
+- Linux's same-CPU branch sets the current task's need-resched bit and returns
+  without an IPI (`core.c:1051-1056`).
+- Linux's remote branch sets the target task's need-resched bit and sends a
+  reschedule IPI (`core.c:1059-1060`).
+- Linux's exported CPU helper takes an explicit `cpu` argument and calls
+  `resched_curr()` for that CPU's runqueue (`core.c:1065-1073`).
+
+Implementation detail:
+
+Current aarch64 per-CPU storage stores `need_resched` as a plain `u8` inside
+`ALL_CPU_DATA` (`kernel/src/per_cpu_aarch64.rs:16-32`, `:93-104`), and the
+public setter only writes the current CPU through `TPIDR_EL1`
+(`kernel/src/per_cpu_aarch64.rs:221-228`). F32r should add a small aarch64
+helper for remote target writes, for example
+`per_cpu_aarch64::set_need_resched_for_cpu(cpu, true)`, with release ordering
+or an atomic byte. That helper must be the only remote writer. It should be
+documented as scheduler-owned so random subsystems do not mutate remote
+per-CPU state directly.
+
+The receiving SGI handler at `kernel/src/arch_impl/aarch64/exception.rs:1243-1248`
+can keep setting the local bit during the migration as an idempotent backstop,
+but the correctness contract should be that the waker marks the target before
+IPI, just like Linux's `set_nr_and_not_polling()` happens before
+`smp_send_reschedule(cpu)` (`core.c:900-910`, `:1059-1060`).
+
+### 2. Convert Wake Sites To Return Or Carry Target CPU
+
+Every wake path must call `resched_cpu(target)` with the CPU selected by the
+enqueue/state transition, while still holding the scheduler lock when the
+target is derived.
+
+Rules:
+
+- If a thread is enqueued onto `per_cpu_queues[target]`, call
+  `resched_cpu(target)`.
+- If the thread is still current on a CPU and must observe its state change on
+  interrupt/syscall return, call `resched_cpu(owner_cpu)`.
+- If a wake drains multiple waiter TIDs, loop per waiter and target each one.
+- If a wake is process-level, resolve the affected thread IDs first and then
+  use the same per-thread target path.
+- If a thread is not yet assigned, spawning must choose a CPU before publishing
+  the runnable state.
+
+Linux parity:
+
+- Linux handles the "waking current" special case without a runqueue lock when
+  the target is current (`core.c:4227-4244`).
+- Linux waits for `on_cpu` and uses `task_cpu(p)` or `select_task_rq()` before
+  queueing (`core.c:4339-4364`).
+- Linux calls `ttwu_queue(p, cpu, wake_flags)` only after a CPU is known
+  (`core.c:4369`).
+- Linux's remote wake-list path is per target CPU, not a broadcast
+  (`core.c:3930-4049`).
+
+Concrete Breenix API changes:
+
+- Change `Scheduler::add_thread()` and `Scheduler::add_thread_front()` to
+  return the selected CPU from `add_thread_inner()`; the target is already
+  computed at `kernel/src/task/scheduler.rs:581-587`.
+- Change `Scheduler::unblock()`, `unblock_for_signal()`,
+  `unblock_for_child_exit()`, and `unblock_for_io()` to return a wake result
+  that includes either `enqueued_target` or `current_cpu`. `wake_io_thread_locked()`
+  already has this shape through `IoWakeResult` (`scheduler.rs:170-179`,
+  `:1728-1770`).
+- Replace `send_resched_ipi()` broadcasts with `resched_cpu(target)` at sites
+  that already have a target local variable.
+- Keep `send_resched_ipi_to_cpu()` only as a lower-level architecture helper
+  or fold it into `resched_cpu()`.
+
+### 3. Idle Gate Reads Per-CPU Only
+
+After every wake/spawn path targets a CPU, change the aarch64 idle gate to read
+only local per-CPU state:
+
+- `idle_gate_state()` in `kernel/src/arch_impl/aarch64/context_switch.rs:3233-3242`
+  should not call `scheduler::is_need_resched()` while that helper still ORs in
+  the global bit.
+- The final shape should be a local read equivalent to
+  `per_cpu_aarch64::need_resched()` plus the existing ISR wake-buffer depth
+  check.
+
+Linux parity:
+
+- Linux's idle loop checks `need_resched()` for the current task/CPU, not a
+  machine-global pending bit.
+- The F32i Linux audit records the generic idle loop's `!need_resched()` sleep
+  gate and ordering requirements in `docs/planning/f32i-cpu0-wfi-wake/linux-audit.md`.
+
+This step must happen only after wake sites have target coverage. F32q proved
+that switching the idle gate first loses cross-CPU wake signals because the
+global flag was still carrying wake information.
+
+### 4. Retire Global `NEED_RESCHED`
+
+Migration stages:
+
+1. Add targeted API and keep all current behavior.
+2. Convert call sites to target per-CPU resched while temporarily leaving the
+   global `NEED_RESCHED.store(true)` in place as a migration cross-check.
+3. Switch the idle gate to local per-CPU reads after targeted coverage exists.
+4. Remove the redundant global stores from converted sites.
+5. Delete the global atomic and update helpers so `set_need_resched()` is
+   either removed or becomes a current-CPU-only wrapper.
+
+The temporary global must not be used as a fallback after Phase 3c. If retained
+for diagnostics, it should become a counter or assertion-only instrument that
+is never consulted by idle or interrupt-return scheduling decisions.
+
+Linux parity:
+
+- There is no Linux global `need_resched`; the flag is part of the current
+  task/thread-info (`thread_info.h:24-46`, `:60-86`).
+- Linux clears need-resched as part of scheduling the previous task
+  (`core.c:6691-6693`), which corresponds to clearing the local target's flag
+  when that CPU reaches the scheduler.
+
+## Conversion Order
+
+F32o's diagnosis is not present in this checkout at the prompt path
+`docs/planning/f32o-perf/diagnosis.md`, so the ordering below uses the prompt's
+reported symptom (idle gate bypassing WFI 13.6M times/120s) and the audit's
+call-site traffic expectations.
+
+1. `resched_cpu(target)` API, no consumers.
+2. Highest-risk/highest-traffic scheduler internals:
+   - `wake_io_thread_locked()` / `unblock_for_io()`
+     (`kernel/src/task/scheduler.rs:1705-1770`)
+   - `spawn()` / `spawn_front()` (`scheduler.rs:2212-2255`)
+   - timer wake enqueue in `wake_expired_timers()` (`scheduler.rs:1840-1897`)
+3. Device and UI wake sites:
+   - GPU completion (`kernel/src/drivers/virtio/gpu_pci.rs:1488-1494`)
+   - TTY/PTY/stdin waiters (`kernel/src/ipc/stdin.rs`, `kernel/src/tty/*`)
+4. Network waiters:
+   - UDP/TCP waiter loops (`kernel/src/socket/udp.rs:132-139`,
+     `kernel/src/net/tcp.rs:1558-1588`)
+5. Current-CPU-only paths:
+   - yield, exit, signal termination, fault termination, context-switch retry,
+     and timer quantum expiry.
+6. Process-level signal paths:
+   - `kernel/src/syscall/signal.rs:158-206` must resolve concrete thread IDs
+     instead of relying on a process-level global resched.
+7. Idle gate local-read switch.
+8. Global store removal and final global deletion.
+
+## Validation Plan
+
+Every implementation sub-phase must pass:
+
+- x86_64 clean build:
+  `cargo build --release --features testing,external_test_bins --bin qemu-uefi`
+- aarch64 clean build:
+  `cargo build --release --features testing,external_test_bins --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64`
+- `wait_stress` for 60 seconds with zero stalls.
+- Short Parallels boot after each wake-site batch.
+
+Final validation:
+
+- `wait_stress` 60s: 0 stalls.
+- 5 consecutive 120s Parallels boots: bsshd, bounce, frames, strict render,
+  no AHCI timeout.
+- Host CPU drops meaningfully from the 800% baseline, with target below 300%
+  on idle boot running bsshd + bounce + BWM and no user input.
+- Rendering remains intact.
+- Bounce FPS is at least 160.
+
+Before and after CPU measurements should be recorded in the final `exit.md`
+with the exact command, duration, and observed values.
+
+## Risks And Required Invariants
+
+### Stale Wake Target
+
+Risk: a thread can move between CPUs after a wake site computes a target.
+
+Invariant: target derivation, state transition, and enqueue must happen under
+the scheduler lock. If the thread is enqueued to `per_cpu_queues[target]`, then
+`resched_cpu(target)` is correct even if a later load-balancing operation moves
+it; the mover becomes responsible for rescheduling the new target.
+
+Linux parity: `try_to_wake_up()` serializes state and CPU selection with
+`p->pi_lock`, `on_cpu` ordering, and `set_task_cpu()` before `ttwu_queue()`
+(`core.c:4253-4369`).
+
+### Current-On-CPU Wake
+
+Risk: a thread blocked in a syscall may still be the current thread on a CPU,
+so enqueuing it elsewhere double-schedules the same kernel stack.
+
+Invariant: if `cpu_state[cpu].current_thread == tid`, do not enqueue it; mark
+that owning CPU with `resched_cpu(cpu)` so it observes the state change.
+
+Linux parity: `try_to_wake_up()` treats waking current specially and reasons
+about `on_cpu` before queueing (`core.c:4227-4244`, `:4339-4352`).
+
+### Multi-Waiter Broadcast Replacement
+
+Risk: stdin, PTY, TCP, UDP, and signal wait queues can wake multiple threads
+that belong to different CPUs.
+
+Invariant: replace broadcast with a targeted per-waiter loop. The loop may
+send multiple IPIs, one per distinct target, or coalesce targets into a CPU
+mask, but it must never set a global fallback bit.
+
+Linux parity: waitqueue wake eventually calls `try_to_wake_up()` per task; the
+target CPU is task-specific (`core.c:4222-4370`).
+
+### Remote Per-CPU Storage Safety
+
+Risk: a plain `u8` remote write can become a data race or lack ordering.
+
+Invariant: remote target marking must use an atomic representation or a small
+unsafe helper with explicit release/acquire semantics and no aliasing through
+ordinary mutable references. The local read/clear path must pair with that
+ordering.
+
+Linux parity: Linux atomically ORs `_TIF_NEED_RESCHED` into the target
+thread-info flags before deciding whether to send an IPI (`core.c:900-910`).
+
+### CPU0 / Parallels SGI Behavior
+
+Risk: prior work observed CPU0-specific SGI admission problems. A pure
+reschedule SGI may not be enough if the target CPU never acknowledges it.
+
+Invariant: this migration must preserve F32c-F32k behavior and keep the F32i
+larger endpoint in view: per-target wake-list delivery may still be required
+for CPU0 parity. F32r should not reintroduce broadcast fallback to hide a
+missed targeted wake.
+
+Linux parity: the larger endpoint is Linux's `ttwu_queue_wakelist()` path,
+which queues remote wake work to the target CPU and wakes it through an IPI
+(`core.c:3930-4049`).
+
+### Hot Path Cleanliness
+
+Risk: debugging this migration by adding serial breadcrumbs to interrupt,
+syscall, or idle paths would change timing and repeat earlier failures.
+
+Invariant: no logging or formatting in Tier 1 paths, IRQ paths, syscall entry,
+or idle loops. Use existing trace framework, post-mortem logs, GDB, and QEMU
+interrupt tracing.
+
+## Phase Commit Map
+
+| Phase | Commit intent | Behavior change? | Validation |
+| --- | --- | --- | --- |
+| 1 | `docs(kernel): F32r per-CPU resched audit` | No | x86_64 + aarch64 clean builds |
+| 2 | `docs(kernel): F32r per-CPU resched design` | No | x86_64 + aarch64 clean builds |
+| 3a | Add `resched_cpu(target)` and remote per-CPU setter, no consumers | No intended behavior change | x86_64 + aarch64 clean builds |
+| 3b | Convert wake sites one batch at a time, keep global cross-check | Yes, target per-CPU signals added | wait_stress + short Parallels boot per batch |
+| 3c | Idle gate reads local per-CPU only | Yes, removes global idle wake source | wait_stress + short Parallels boot |
+| 3d | Remove redundant global stores from converted sites | Yes, global fallback no longer present | wait_stress + Parallels boot after each safe batch |
+| 3e | Delete global atomic/helper fallback | Yes, final architecture | full final gate |
+
+## Stop Conditions
+
+Stop and write `exit.md` instead of continuing if:
+
+- A wake site cannot derive a target CPU from thread/runqueue state.
+- A targeted conversion loses a wake, stalls rendering, or regresses
+  `wait_stress`.
+- The only apparent fix is to keep or reintroduce global resched state.
+- Validation requires Tier 1 edits or logging in IRQ/syscall/idle paths.

--- a/docs/planning/f32r-percpu-resched/exit.md
+++ b/docs/planning/f32r-percpu-resched/exit.md
@@ -1,0 +1,130 @@
+# F32r Exit Report
+
+Date: 2026-04-20
+
+## What I Built
+
+| File | Purpose |
+| --- | --- |
+| `docs/planning/f32r-percpu-resched/audit.md` | Phase 1 inventory of global `NEED_RESCHED`, per-CPU `need_resched`, indirect `scheduler::set_need_resched()` callers, and SGI reschedule sources, with Linux parity cites. |
+| `docs/planning/f32r-percpu-resched/design.md` | Phase 2 target architecture for `resched_cpu(target)`, wake-site conversion rules, idle-gate migration, global retirement, validation plan, and risks. |
+| `kernel/src/per_cpu_aarch64.rs` | Phase 3a made the aarch64 `need_resched` field atomically addressable and added scheduler-owned `set_need_resched_for_cpu()`. |
+| `kernel/src/arch_impl/aarch64/percpu.rs` | Phase 3a changed local aarch64 need-resched reads/writes to atomic load/store through TPIDR-relative access. |
+| `kernel/src/task/scheduler.rs` | Phase 3a added `resched_cpu(target)` with no consumers. |
+
+## Original Ask
+
+F32r was intended to move Breenix away from a global `NEED_RESCHED` flag toward
+Linux-style targeted rescheduling: audit every setter, design the per-CPU
+architecture, add `resched_cpu(target)`, convert wake sites in validated stages,
+switch the idle gate to local-only reads, delete the global flag, validate
+wait_stress and Parallels boots, then PR and merge only if all gates passed.
+
+## Deliverable Status
+
+| Deliverable | Status | Evidence |
+| --- | --- | --- |
+| Phase 1 audit | Implemented | `docs/planning/f32r-percpu-resched/audit.md`; commit `2cb62b0d docs(kernel): F32r per-CPU resched audit`. |
+| Phase 2 design | Implemented | `docs/planning/f32r-percpu-resched/design.md`; commit `3a2c4ce6 docs(kernel): F32r per-CPU resched design`. |
+| Phase 3a no-consumer API | Implemented | `a4380b7b kernel: add targeted resched CPU primitive`. |
+| Phase 3b wake-site conversions | Not implemented in committed tree | First attempted batch (`spawn`, `spawn_front`, central I/O wake) built clean but failed wait_stress validation, so it was not committed. |
+| Phase 3c idle gate local-only | Not implemented | Blocked by Phase 3b failure. |
+| Phase 3d remove global stores | Not implemented | Blocked by Phase 3b failure. |
+| Phase 3e delete global atomic/helpers | Not implemented | Blocked by Phase 3b failure. |
+| Phase 4 final gate | Not run | Stop rule triggered during Phase 3b first-batch validation. |
+| Phase 5 PR + merge | Not done | Gates did not pass. |
+
+## Audit Table Summary
+
+| Area | Result |
+| --- | --- |
+| Global primitive | `NEED_RESCHED` is declared in `kernel/src/task/scheduler.rs:133-134` and is still present after this run. |
+| Public global setter | `scheduler::set_need_resched()` still sets global + current per-CPU flags. |
+| Spawn targets | `add_thread_inner()` already computes a target CPU, but committed Phase 3a does not yet expose that target to consumers. |
+| Wake targets | Most wake sites can derive a target from `find_target_cpu_for_wakeup()`, `IoWakeResult`, current CPU ownership, or explicit SGI target. |
+| Hard cases | Process-level signal paths must resolve affected thread IDs before targeted resched; no global fallback is justified. |
+| Linux parity | Audit cites Linux `resched_curr`, `resched_cpu`, `try_to_wake_up`, `ttwu_queue_wakelist`, and arm64 `TIF_NEED_RESCHED`. |
+
+## Design Rationale
+
+Linux does not have a machine-global need-resched bit. It marks a specific
+runqueue current task in `resched_curr(rq)` and sends a targeted reschedule IPI
+for remote CPUs. The F32r design therefore makes every Breenix wake site carry
+or recover the target CPU selected by thread/runqueue state, then call
+`resched_cpu(target)`.
+
+The design deliberately does not switch the idle gate first. F32q already proved
+that per-CPU-only idle reads lose wakes while wake sites still rely on the global
+flag. The safe order is targeted wake coverage first, idle gate local-only
+second, and global deletion last.
+
+## Sub-Phase Commit Map
+
+| Phase | Commit | Validation |
+| --- | --- | --- |
+| Phase 1 | `2cb62b0d docs(kernel): F32r per-CPU resched audit` | x86_64 clean build; aarch64 clean build. |
+| Phase 2 | `3a2c4ce6 docs(kernel): F32r per-CPU resched design` | x86_64 clean build; aarch64 clean build. |
+| Phase 3a | `a4380b7b kernel: add targeted resched CPU primitive` | x86_64 clean build; aarch64 clean build. |
+| Phase 3b first attempted batch | Not committed | x86_64/aarch64 builds passed after fixing warnings; wait_stress failed, so the batch was reverted before exit. |
+
+## Validation Sweep
+
+| Check | Command | Result |
+| --- | --- | --- |
+| Phase 1 x86_64 build | `cargo build --release --features testing,external_test_bins --bin qemu-uefi` | Pass, no warning/error lines. |
+| Phase 1 aarch64 build | `cargo build --release --features testing,external_test_bins --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` | Pass, no warning/error lines. |
+| Phase 2 x86_64 build | same as above | Pass, no warning/error lines. |
+| Phase 2 aarch64 build | same as above | Pass, no warning/error lines. |
+| Phase 3a x86_64 build | same as above | Pass, no warning/error lines. |
+| Phase 3a aarch64 build | same as above | Pass, no warning/error lines. |
+| Phase 3b attempted x86_64 build | same as above | Initially failed with two unused `target` warnings; fixed; final pass. |
+| Phase 3b attempted aarch64 build | same as above | Pass, no warning/error lines. |
+| Phase 3b attempted wait_stress | `BREENIX_WAIT_STRESS=1 ./run.sh --parallels --test 150` | Fail: wrapper exited 0, but serial never reached `WAIT_STRESS_PASS`; log ended at `WAIT_STRESS_PROGRESS sample=250 entered=65978 returned=65978 wakes=430337 waiters=0`. |
+| Phase 3b attempted render verdict | `./scripts/f23-render-verdict.sh /tmp/breenix-screenshot.png` | Fail: `distinct=1`, solid blue baseline, `VERDICT=FAIL`. |
+| Phase 3b short Parallels boot | Not run | Stop rule triggered after wait_stress failure. |
+
+Ignored evidence artifacts:
+
+- `.factory-runs/f32r-percpu-resched/phase3b-failed-scheduler.diff`
+- `.factory-runs/f32r-percpu-resched/phase3b-wait-stress-fail.serial.log`
+- `.factory-runs/f32r-percpu-resched/phase3b-wait-stress-fail.png`
+- `.factory-runs/f32r-percpu-resched/phase3b-wait-stress-fail.verdict.txt`
+
+## Before/After CPU Measurement
+
+Not measured. The run stopped before the idle gate was changed and before global
+stores were removed, so a host CPU reduction was not expected or validated.
+
+## What I Did Not Build
+
+- No committed wake-site consumer conversions.
+- No idle-gate local-only change.
+- No global `NEED_RESCHED` removal.
+- No 5x 120s Parallels sweep.
+- No PR or merge.
+
+## Known Risks And Gaps
+
+- The first attempted Phase 3b batch caused or exposed a wait_stress/render
+  stall by about 25 seconds of guest stress progress. The attempted batch added
+  targeted `resched_cpu()` calls to `spawn`, `spawn_front`, and
+  `wake_io_thread_locked()` while retaining global/broadcast signaling.
+- The failure did not print panic, data abort, instruction abort, AHCI timeout,
+  or soft-lockup markers in the captured serial tail. It manifested as serial
+  progress stopping before `WAIT_STRESS_PASS` and a solid-blue screenshot.
+- `cargo fmt` for the whole workspace is currently blocked by pre-existing
+  trailing whitespace in `tests/shared_qemu.rs`; edited files were formatted
+  directly with `rustfmt`.
+
+## Recommended Next Step
+
+Start F32s from commit `a4380b7b`. Re-apply the saved Phase 3b diff one smaller
+piece at a time:
+
+1. Convert only spawn/spawn_front, validate wait_stress.
+2. Convert only central I/O wake, validate wait_stress.
+3. If one fails, debug with GDB or existing trace framework before touching the
+   idle gate or removing global stores.
+
+Do not switch the idle gate or remove any global stores until the targeted wake
+consumer batch passes wait_stress and short Parallels boot validation.

--- a/kernel/src/arch_impl/aarch64/percpu.rs
+++ b/kernel/src/arch_impl/aarch64/percpu.rs
@@ -18,7 +18,7 @@ use crate::arch_impl::aarch64::constants::{
     PERCPU_TSS_OFFSET, PERCPU_USER_RSP_SCRATCH_OFFSET, PREEMPT_ACTIVE, SOFTIRQ_MASK, SOFTIRQ_SHIFT,
 };
 use crate::arch_impl::traits::PerCpuOps;
-use core::sync::atomic::{compiler_fence, AtomicU32, Ordering};
+use core::sync::atomic::{compiler_fence, AtomicBool, AtomicU32, Ordering};
 
 pub struct Aarch64PerCpu;
 
@@ -77,6 +77,16 @@ fn percpu_atomic_u32(offset: usize) -> Option<&'static AtomicU32> {
         return None;
     }
     unsafe { Some(&*((base as *const u8).add(offset) as *const AtomicU32)) }
+}
+
+/// Get atomic reference to a bool field in per-CPU data
+#[inline(always)]
+fn percpu_atomic_bool(offset: usize) -> Option<&'static AtomicBool> {
+    let base = read_tpidr_el1();
+    if base == 0 {
+        return None;
+    }
+    unsafe { Some(&*((base as *const u8).add(offset) as *const AtomicBool)) }
 }
 
 impl PerCpuOps for Aarch64PerCpu {
@@ -221,13 +231,17 @@ impl Aarch64PerCpu {
     /// Get the need_resched flag.
     #[inline(always)]
     pub fn need_resched() -> bool {
-        percpu_read_u8(PERCPU_NEED_RESCHED_OFFSET) != 0
+        percpu_atomic_bool(PERCPU_NEED_RESCHED_OFFSET)
+            .map(|flag| flag.load(Ordering::Acquire))
+            .unwrap_or(false)
     }
 
     /// Set the need_resched flag.
     #[inline(always)]
     pub unsafe fn set_need_resched(need: bool) {
-        percpu_write_u8(PERCPU_NEED_RESCHED_OFFSET, if need { 1 } else { 0 });
+        if let Some(flag) = percpu_atomic_bool(PERCPU_NEED_RESCHED_OFFSET) {
+            flag.store(need, Ordering::Release);
+        }
     }
 
     /// Get the next TTBR0 value (for context switching).

--- a/kernel/src/per_cpu_aarch64.rs
+++ b/kernel/src/per_cpu_aarch64.rs
@@ -29,7 +29,7 @@ pub struct PerCpuData {
     /// Preempt count (offset 32)
     pub preempt_count: u32,
     /// Need resched flag (offset 36)
-    pub need_resched: u8,
+    pub need_resched: AtomicBool,
     /// Padding
     _pad: [u8; 3],
     /// User SP scratch space (offset 40)
@@ -73,7 +73,7 @@ impl PerCpuData {
             kernel_stack_top: 0,
             idle_thread: core::ptr::null_mut(),
             preempt_count: 0,
-            need_resched: 0,
+            need_resched: AtomicBool::new(false),
             _pad: [0; 3],
             user_sp_scratch: 0,
             tss: core::ptr::null_mut(),
@@ -225,6 +225,26 @@ pub fn set_need_resched(need: bool) {
             hal_percpu::Aarch64PerCpu::set_need_resched(need);
         }
     }
+}
+
+/// Set another CPU's reschedule-needed flag.
+///
+/// This is scheduler-owned plumbing for targeted wakeups. Most code should use
+/// scheduler::resched_cpu() instead of touching remote per-CPU state directly.
+pub fn set_need_resched_for_cpu(cpu: usize, need: bool) -> bool {
+    if !PER_CPU_INITIALIZED.load(Ordering::Acquire)
+        || cpu >= crate::arch_impl::aarch64::constants::MAX_CPUS
+    {
+        return false;
+    }
+
+    unsafe {
+        let all_cpu_data = core::ptr::addr_of!(ALL_CPU_DATA) as *const PerCpuData;
+        (*all_cpu_data.add(cpu))
+            .need_resched
+            .store(need, Ordering::Release);
+    }
+    true
 }
 
 /// Check if we're in any interrupt context

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -2569,6 +2569,36 @@ pub fn set_need_resched() {
     crate::per_cpu_aarch64::set_need_resched(true);
 }
 
+/// Mark one CPU for reschedule.
+///
+/// Mirrors Linux's resched_cpu()/resched_curr() split: mark the target CPU's
+/// reschedule flag, then send a reschedule IPI only when the target is remote.
+#[cfg(target_arch = "aarch64")]
+pub fn resched_cpu(target: u8) -> bool {
+    let target = target as usize;
+    let current_cpu = Scheduler::current_cpu_id();
+    if target >= MAX_CPUS {
+        return false;
+    }
+
+    let online = crate::arch_impl::aarch64::smp::cpus_online() as usize;
+    if target >= online && target != current_cpu {
+        return false;
+    }
+
+    if !crate::per_cpu_aarch64::set_need_resched_for_cpu(target, true) {
+        return false;
+    }
+
+    if target != current_cpu {
+        crate::arch_impl::aarch64::gic::send_sgi(
+            crate::arch_impl::aarch64::constants::SGI_RESCHEDULE as u8,
+            target as u8,
+        );
+    }
+    true
+}
+
 /// Check and clear the need_resched flag (called from interrupt return path)
 pub fn check_and_clear_need_resched() -> bool {
     #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
## Summary

Foundational work for retiring the global \`NEED_RESCHED\` flag that causes the 800% host-CPU idle-gate bypass (diagnosed in F32o).

This PR lands only the docs + the no-consumer primitive. Zero behavior change. The actual wake-site conversion is F32s (follow-up factory).

## What's in here

- **audit.md** — every \`need_resched\` setter with Linux file:line equivalents
- **design.md** — \`resched_cpu(target: u8)\` API design citing \`resched_curr\`/\`resched_cpu\`/\`TIF_NEED_RESCHED\`
- **Primitive (no consumers)** — \`scheduler::resched_cpu(target)\`, aarch64 remote per-CPU need-resched setter, atomic local need-resched access

## Why no fix yet

F32r attempted a 3-site batch conversion (spawn + spawn_front + central I/O wake) in Phase 3b. Built clean, but wait_stress stalled and render verdict FAILed. Factory correctly reverted per contract. Cross-site interactions need to be untangled one at a time.

## Validation

- Clean aarch64 + x86_64 builds
- No runtime behavior change — primitive has no callers

## Follow-up

F32s: one-site-at-a-time conversion with validation between each. F32t: xHCI MSI programming order fix to eliminate HID polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)