### PR TITLE
fix(arm64): remove CPU0 user-guard causing infinite dispatch-redirect loop

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -2063,48 +2063,21 @@ fn dispatch_thread_locked(
             }
         }
         //
-        // CPU 0 GUARD: On Parallels/HVF, ERET to EL0 kills CPU 0's vtimer
-        // PPI 27 delivery. Without the timer, CPU 0 cannot preempt and any
-        // thread dispatched here monopolises the CPU. Redirect to idle and
-        // requeue the thread on CPUs 1-7 where the timer works.
-        if cpu_id == 0 && crate::arch_impl::aarch64::smp::cpus_online() > 1 {
-            if let Some(thread) = sched.get_thread(thread_id) {
-                let candidate_elr = thread.context.elr_el1;
-                let candidate_spsr = if thread.has_started {
-                    dispatch_spsr(thread.context.spsr_el1)
-                } else {
-                    0
-                };
-                trace_cpu0_user_dispatch(
-                    TRACE_CPU0_USER_DISPATCH_GUARD_REDIRECT,
-                    thread_id,
-                    candidate_elr,
-                    candidate_spsr,
-                    thread.cached_ttbr0,
-                );
-            }
-            trace_dispatch_redirect(thread_id, TRACE_REDIRECT_CPU0_USER_GUARD);
-            if let Some(thread) = sched.get_thread_mut(thread_id) {
-                thread.state = ThreadState::Ready;
-            }
-            setup_idle_return_locked(sched, frame, cpu_id);
-            let idle_id = sched.cpu_state[cpu_id].idle_thread;
-            sched.cpu_state[cpu_id].current_thread = Some(idle_id);
-            // Requeue the thread being dispatched to a non-CPU0 queue.
-            sched.requeue_thread_after_save(thread_id);
-            sched.set_need_resched_inner();
-            // Send self-IPI to drain the deferred requeue slot on CPU 0.
-            // DEFERRED_REQUEUE[0] may hold the old thread from the context
-            // switch; without an interrupt to trigger processing, it would
-            // be stranded because CPU 0's vtimer is dead. The SGI fires
-            // when idle_loop_arm64 enables IRQs (daifclr), causing
-            // check_need_resched_and_switch_arm64 to run and drain the slot.
-            crate::arch_impl::aarch64::gic::send_sgi(
-                crate::arch_impl::aarch64::constants::SGI_RESCHEDULE as u8,
-                0, // target CPU 0 (self)
-            );
-            return;
-        }
+        // (Removed) CPU 0 user-guard — redirect EL0 away from CPU0 under SMP.
+        // The guard's requeue path (`requeue_thread_after_save`) puts the
+        // thread right back on CPU0's own ready queue, so CPU0's scheduler
+        // immediately re-dispatches it, hits the guard again, requeues, loops
+        // at ~24 kHz — never reaching userspace and starving CPU0's timer ISR
+        // of chance to run anything else. Evidence from cpu0-trace-dump-probe
+        // at 30s uptime: CPU0 ran the dispatch→redirect→requeue loop with no
+        // progress while CPUs 1-7 accumulated 28K-30K timer ticks.
+        //
+        // The guard's original rationale was "ERET to EL0 kills CPU0 vtimer
+        // on HVF", but the redirect loop kills CPU0 just as effectively
+        // while also starving userspace entirely. Remove the guard and let
+        // CPU0 run EL0 normally. If HVF vtimer-death on EL0-return is still
+        // a real issue, it will reproduce as a distinct signature we can
+        // target with a non-looping fix.
 
         if !has_started {
             if let Some(thread) = sched.get_thread_mut(thread_id) {


### PR DESCRIPTION
## Root cause

The CPU0 user-guard at \`context_switch.rs:2070\` (SMP online check on CPU0) redirected every EL0 candidate. Its requeue call \`requeue_thread_after_save(thread_id)\` put the thread **back on CPU0's own ready queue**, not onto CPUs 1–7 as the comment claimed. CPU0's scheduler then picked the same thread, hit the guard, requeued, spun — at ~24 kHz per CPU0 timer tick, never reaching userspace.

## Evidence

Probe dump at 30s uptime on unmodified main (\`5780377f\`) showed:

\`\`\`
[probe] tick_count per cpu: 372 29676 29679 29091 30000 29551 29549 28341
                            ^CPU0^CPU1 ...
\`\`\`

CPU0's trace buffer was 1024 events of repeating:
\`\`\`
USER_DISPATCH_STAGE tid=11 → DISPATCH_REDIRECT reason=6 (CPU0_USER_GUARD) → CTX_SWITCH_ENTRY tid=11 → DEFER_REQUEUE tid=11 → (loop)
\`\`\`

~42µs per iteration. CPU0 timer IRQs still fired, just fed the spin.

## Fix

Delete the guard block. CPU0 now dispatches EL0 threads like every other CPU.

## Validation

With this fix applied:
- \`[timer] cpu0 ticks=5000/10000/.../65000\` progresses normally
- Probe dump shows CPU0 **ahead** of siblings: \`tick_count per cpu: 32855 29639 29649 29510 29120 30000 29745 28209\`
- Cursor tracks mouse (HID polling from CPU0 timer ISR now runs)
- bsshd + bounce start, frames render through #16000+
- No AHCI timeouts during first 60s

## Note on HVF claim

The guard's rationale in the comment ("ERET to EL0 kills HVF vtimer on Parallels") is **empirically unsupported**. CPU0 runs EL0 normally and the timer keeps firing. The HVF-vtimer-death narrative drove several dead-end investigations this week; this PR is the evidence that CPU0 EL0 execution is fine on Parallels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)