### PR TITLE
CPU0 user-guard autopsy + gold-master markers + regression alarm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,25 @@ prlctl start breenix-dev
 - Red zone: disabled for interrupt safety
 - Features: `-mmx,-sse,+soft-float`
 
+## 🔒 GOLD-MASTER REGIONS — FROZEN 🔒
+
+Specific code regions are **frozen as gold-master** and must not be modified
+without reading the linked forensic record and obtaining PR signoff from the
+project owner. Each region carries an inline comment block that calls out
+the constraints.
+
+| File:line | Region | Autopsy |
+|---|---|---|
+| `kernel/src/arch_impl/aarch64/context_switch.rs` (EL0 dispatch site) | NO CPU0-specific EL0 dispatch guard | `docs/planning/cpu0-user-guard-autopsy/README.md` |
+| `kernel/src/arch_impl/aarch64/context_switch.rs::idle_loop_arm64` | Sleep gate + `dsb sy; wfi; daifclr` sequence | same |
+| `kernel/src/arch_impl/aarch64/gic.rs::init_gicv3_redistributor` (SGI enable block) | `GICR_ISENABLER0` write for SGI_RESCHEDULE + SGI_TIMER_REARM | same |
+| `kernel/src/arch_impl/aarch64/timer_interrupt.rs` (CPU0 regression alarm) | Panic at 30s if CPU0 tick_count < 10% of max peer | same |
+
+The CPU0 user-guard regression (PR #334 fixed it) burned ~1 week because
+agents kept accepting "HVF kills CPU0 vtimer on EL0 return" as truth without
+evidence. The markers in these regions exist to break that pattern. If you
+think you need to modify one, read the autopsy first.
+
 ## 🚨 PROHIBITED CODE SECTIONS 🚨
 
 The following files are on the **prohibited modifications list**. Agents MUST NOT modify these files without explicit user approval.

--- a/docs/planning/cpu0-user-guard-autopsy/README.md
+++ b/docs/planning/cpu0-user-guard-autopsy/README.md
@@ -1,0 +1,243 @@
+# CPU0 User-Guard Autopsy
+
+**Status: CLOSED. Fix landed in PR #334 (commit `9da897f4`, 2026-04-22).**
+
+This document is the definitive post-mortem on the "CPU0 regression" that
+burned approximately one week of engineering time across factories F32i,
+F32j, F33, F34, and several ad-hoc investigations in early- to mid-April
+2026. Read this *first* before touching any CPU0-adjacent code.
+
+---
+
+## TL;DR
+
+The bug was not an HVF/Parallels vtimer behavior. It was a
+**self-referential requeue loop** in a CPU0-specific dispatch guard inside
+`kernel/src/arch_impl/aarch64/context_switch.rs`. Every theory about "HVF
+kills CPU0 vtimer when guest ERETs to EL0" was empirically false.
+
+Removing the guard produced a fully healthy CPU0 on the same Parallels
+hypervisor, on the same commit, in the same VM configuration. CPU0 now runs
+EL0 indistinguishably from CPUs 1-7.
+
+If you ever add another CPU0-specific EL0 dispatch guard, re-read this
+document first.
+
+---
+
+## The symptom
+
+On any fresh Parallels boot with SMP > 1 CPU online (F29 merge onward):
+
+- CPU0's `TIMER_TICK_COUNT[0]` would advance to ~10-300 then flat-line.
+- Other CPUs' counters would reach tens of thousands over the same interval.
+- Symptoms that follow:
+  - Cursor doesn't move (HID polling runs from CPU0 timer ISR; dead CPU0 timer ⇒ stale `mouse_pos`).
+  - `[timer] cpu0 ticks=5000` serial marker never appears.
+  - Global tick counter (`crate::time::get_ticks()`) stops advancing.
+  - If a fork/exec landed the spawned thread on CPU0, it would loop forever
+    without reaching userspace.
+  - AHCI commands targeting CPU0 for completion work could stall.
+
+The T0-T9 serial breadcrumbs (raw UART writes for the first 10 CPU0 timer
+ticks) always fired, leading to repeated false conclusions that CPU0 timer
+was "dying at tick 10." **Those markers only print when `count <= 10` —
+their absence beyond tick 10 tells us nothing about timer health.** Many
+investigations were derailed by this misreading.
+
+---
+
+## The root cause
+
+`context_switch.rs` contained a block that fired during dispatch of any EL0
+candidate whenever the current CPU was CPU0 and SMP had > 1 CPU online:
+
+```rust
+if cpu_id == 0 && crate::arch_impl::aarch64::smp::cpus_online() > 1 {
+    // ... trace ...
+    trace_dispatch_redirect(thread_id, TRACE_REDIRECT_CPU0_USER_GUARD);
+    if let Some(thread) = sched.get_thread_mut(thread_id) {
+        thread.state = ThreadState::Ready;
+    }
+    setup_idle_return_locked(sched, frame, cpu_id);
+    let idle_id = sched.cpu_state[cpu_id].idle_thread;
+    sched.cpu_state[cpu_id].current_thread = Some(idle_id);
+    // Requeue the thread being dispatched to a non-CPU0 queue.   <-- LIE
+    sched.requeue_thread_after_save(thread_id);
+    sched.set_need_resched_inner();
+    // ... self-IPI ...
+    return;
+}
+```
+
+The comment **lied**: `requeue_thread_after_save()` does not route the
+thread to a non-CPU0 queue. It places the thread back on CPU0's own ready
+queue. On the next scheduler iteration CPU0 picks the same thread, hits
+the guard, requeues, loops. The loop runs at roughly 24 kHz per CPU0 timer
+tick. Timer interrupts still fire; they just feed the spin. CPU0 never
+makes forward progress; userspace never runs on CPU0.
+
+The guard's stated justification:
+
+> "On Parallels/HVF, ERET to EL0 kills CPU 0's vtimer PPI 27 delivery.
+> Without the timer, CPU 0 cannot preempt and any thread dispatched here
+> monopolises the CPU. Redirect to idle and requeue the thread on CPUs 1-7
+> where the timer works."
+
+This claim is **empirically unsupported** as of PR #334. With the guard
+removed, CPU0 ERETs to EL0 and the vtimer keeps firing indefinitely.
+
+---
+
+## The definitive evidence
+
+From `cpu0-trace-dump-probe` branch (30s uptime, one-shot `dump_all_buffers()`
+triggered from any non-CPU0 timer ISR):
+
+**Per-CPU tick_count snapshot at 30s on unmodified `main` (pre-fix):**
+```
+[probe] tick_count per cpu: 372 29676 29679 29091 30000 29551 29549 28341
+                            ^CPU0^CPU1 ...                        ^CPU7
+```
+
+CPU0's trace buffer (1024 events) showed a single repeating pattern:
+
+```
+CPU0 USER_DISPATCH_STAGE  stage=1 tid=11
+CPU0 USER_DISPATCH_ELR
+CPU0 USER_DISPATCH_SPSR
+CPU0 USER_DISPATCH_TTBR0
+CPU0 USER_DISPATCH_STAGE  stage=3 tid=11
+CPU0 USER_DISPATCH_ELR
+CPU0 USER_DISPATCH_SPSR
+CPU0 USER_DISPATCH_TTBR0
+CPU0 DISPATCH_REDIRECT   reason=6 (TRACE_REDIRECT_CPU0_USER_GUARD), tid=11
+CPU0 CTX_SWITCH_ENTRY    new_tid=11
+CPU0 DEFER_REQUEUE_STAGE tid=11
+... (loop, ~42µs per iteration)
+```
+
+Never breaks out. Never reaches EL0. No anomaly in the trace is consistent
+with vtimer masking — the dispatch returns immediately via the guard, not
+through any ERET that could interact with HVF.
+
+**Per-CPU tick_count snapshot at 30s on `9da897f4` (post-fix):**
+```
+[probe] tick_count per cpu: 32855 29639 29649 29510 29120 30000 29745 28209
+                            ^CPU0
+```
+
+CPU0 is now **ahead of** every sibling. `cpu0 ticks=5000, 10000, ..., 65000`
+markers continue at normal cadence. Cursor tracks mouse. bsshd, bounce, and
+every other process spawn normally.
+
+---
+
+## Why it took a week
+
+The guard's comment confidently asserted "HVF kills CPU0 vtimer on ERET to
+EL0." Every factory that investigated used that as a premise rather than
+treating it as a hypothesis.
+
+Theories chased and rejected:
+
+| Hypothesis | Factory | Why it was wrong |
+|---|---|---|
+| ISB before ERET missing | F31, earlier | Already in place at dispatch site; not the issue |
+| DAIF mask uses `#0xf` instead of Linux's `#3` | ad-hoc | Cosmetic divergence, no effect |
+| Idle-loop DAIF state inconsistency (A+D masked) | ad-hoc | Not the cause |
+| `return_to_userspace` missing ISB | ad-hoc | Not the cause; never affected tick count |
+| Idle-loop `rearm_timer()` removed by F20e | ad-hoc | Irrelevant; handler-level re-arm still works |
+| PCI MSI programming order | F32t | Fixed a real bug, but unrelated to CPU0 |
+| xHCI state.irq = 0 | F32p/n | Unrelated sub-bug |
+| HVF vtimer death on IMASK transition | F31 | Empirically fine |
+| SGI admission (ISPENDR without ISENABLER) | F32i/F32j | Fixed a real bug but did not cause CPU0 regression |
+| F32j idle gate spin | F32o | Real bug (caused 800% CPU), but not CPU0 timer death |
+| Per-CPU `need_resched` divergence | F32q/F32r | Unrelated |
+| PCI MSI order breaks CPU0 | F32t | No, unrelated |
+| `ret-based` idle dispatch bypasses HVF-required ERET ISB | F34 | Could not reproduce in its environment |
+
+The actual answer — "the guard has a bug where `requeue_thread_after_save`
+puts threads back on CPU0's own queue" — was never considered until the
+cpu0-trace-dump-probe (2026-04-22) forced a look at CPU0's own trace buffer
+at 30s uptime and revealed the infinite loop.
+
+---
+
+## Detection
+
+Boot-time metric that reliably identifies the regression within 30 seconds:
+
+```
+[probe] tick_count per cpu: [CPU0] [CPU1] [CPU2] [CPU3] [CPU4] [CPU5] [CPU6] [CPU7]
+```
+
+Healthy: all values roughly uniform, no value < 10% of the max.
+
+Regressed: CPU0 value is 1-2 orders of magnitude below every other CPU.
+
+A `panic!` alarm now runs at 30 seconds of uptime and fails boot if CPU0
+is < 10% of the max. Any future regression will surface as a deterministic
+boot failure rather than a cascade of "cursor doesn't work" symptoms.
+
+See `kernel/src/arch_impl/aarch64/timer_interrupt.rs` for the alarm
+implementation.
+
+---
+
+## Commit timeline
+
+| Commit | Date | Role |
+|---|---|---|
+| (guard introduced) | ~2026-03-xx | Author believed HVF kills CPU0 vtimer on EL0. Wrote guard. |
+| `68dc0be6` | 2026-03-xx | Added IMASK-based timer protocol — legitimate fix for a real issue |
+| `26bfcea9` | 2026-03-xx | IMASK=1 before first arm — legitimate HVF protocol handshake |
+| `e4e16b68` | 2026-03-29 | arm_timer at top of handler — legitimate fix for IMASK-death if handler hangs |
+| `aeb3e989` | 2026-03-29 | ISB before ERET — added at 6 sites |
+| `aade0871` | 2026-03-29 | Narrowed to dispatch site only — ISBs at IRQ/syscall return caused separate timer death at ~10K ticks |
+| `66ecc316` (F29) | 2026-04-18 | Re-enabled Parallels SMP bringup. After this, guard actively fired and began causing the loop. |
+| `bff1d92a` (F20e) | 2026-04-17 | DSB before idle WFI — legitimate |
+| `946b2812` (F32j) | 2026-04-19 | GIC `ISENABLER` for SGI_RESCHEDULE + SGI_TIMER_REARM — legitimate fix |
+| **`9da897f4`** (PR #334) | **2026-04-22** | **Guard removed. CPU0 heals.** |
+
+---
+
+## Rules for the future
+
+If you believe CPU0 needs special handling that CPUs 1-7 do not:
+
+1. **Reproduce the problem with evidence**, not with a theory. Use
+   `cpu0-trace-dump-probe` (or re-port it) to get a 30-second trace buffer.
+   Per-CPU `tick_count` parity is the load-bearing signal.
+
+2. **Verify on the Linux probe VM** (10.211.55.3). Linux runs on the same
+   Parallels hypervisor. If Linux works without the behavior you think CPU0
+   needs, Breenix can work without it too. No theory about HVF behavior is
+   acceptable without this validation step.
+
+3. **Inspect your proposed guard's requeue path.** If it calls
+   `requeue_thread_after_save()` or anything that can land the thread on
+   the guarded CPU's own ready queue, you will re-create this bug. The
+   proposed path must demonstrably enqueue onto a **different** CPU's ready
+   queue.
+
+4. **Expect the detection alarm to fire** if you break this. The panic
+   message will reference this document.
+
+5. **PR signoff from the project owner is required** for any change to
+   the gold-master code regions that reference this autopsy.
+
+---
+
+## Files of record
+
+- This document: `docs/planning/cpu0-user-guard-autopsy/README.md`
+- Fix commit: `9da897f4` (PR #334)
+- Probe branch: `origin/cpu0-trace-dump-probe`
+- Gold-master markers in:
+  - `kernel/src/arch_impl/aarch64/context_switch.rs` (dispatch site)
+  - `kernel/src/arch_impl/aarch64/context_switch.rs` (`idle_loop_arm64`)
+  - `kernel/src/arch_impl/aarch64/gic.rs` (`init_gicv3_redistributor`
+    SGI-enable block)
+- Regression alarm: `kernel/src/arch_impl/aarch64/timer_interrupt.rs`
+  (panic if CPU0 tick_count < 10% of max peer at 30s uptime)

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -2062,22 +2062,40 @@ fn dispatch_thread_locked(
                 );
             }
         }
+        // ═══════════════════════════════════════════════════════════════════
+        // 🔒 GOLD-MASTER REGION — DO NOT ADD A CPU0-SPECIFIC EL0 DISPATCH GUARD
+        // ═══════════════════════════════════════════════════════════════════
         //
-        // (Removed) CPU 0 user-guard — redirect EL0 away from CPU0 under SMP.
-        // The guard's requeue path (`requeue_thread_after_save`) puts the
-        // thread right back on CPU0's own ready queue, so CPU0's scheduler
-        // immediately re-dispatches it, hits the guard again, requeues, loops
-        // at ~24 kHz — never reaching userspace and starving CPU0's timer ISR
-        // of chance to run anything else. Evidence from cpu0-trace-dump-probe
-        // at 30s uptime: CPU0 ran the dispatch→redirect→requeue loop with no
-        // progress while CPUs 1-7 accumulated 28K-30K timer ticks.
+        // Frozen by PR #334 (commit 9da897f4, 2026-04-22) after a one-week
+        // investigation attributed CPU0 "timer death" to an HVF vtimer issue.
+        // The real bug was a CPU0-specific guard here that redirected every
+        // EL0 candidate, then called `requeue_thread_after_save(thread_id)`
+        // to "route away from CPU0." That function does NOT route away from
+        // CPU0 — it re-enqueues on CPU0's own ready queue. CPU0 picked the
+        // same thread, hit the guard, requeued, looped at ~24 kHz,
+        // indefinitely, never reaching userspace.
         //
-        // The guard's original rationale was "ERET to EL0 kills CPU0 vtimer
-        // on HVF", but the redirect loop kills CPU0 just as effectively
-        // while also starving userspace entirely. Remove the guard and let
-        // CPU0 run EL0 normally. If HVF vtimer-death on EL0-return is still
-        // a real issue, it will reproduce as a distinct signature we can
-        // target with a non-looping fix.
+        // RULE: CPU0 dispatches EL0 threads IDENTICALLY to CPUs 1-7. Do not
+        // add any CPU-specific branch here.
+        //
+        // IF YOU BELIEVE CPU0 NEEDS SPECIAL HANDLING, DO ALL OF:
+        //   1. Read docs/planning/cpu0-user-guard-autopsy/README.md first.
+        //   2. Reproduce the problem with cpu0-trace-dump-probe evidence,
+        //      specifically per-CPU tick_count parity at 30s uptime.
+        //   3. Verify on the Linux probe VM (10.211.55.3) that Linux needs
+        //      the behavior you're proposing. If Linux works without it,
+        //      Breenix can work without it.
+        //   4. Ensure any requeue you add demonstrably routes to a NON-CPU0
+        //      ready queue (NOT requeue_thread_after_save which re-enqueues
+        //      on the current CPU).
+        //   5. Obtain PR signoff from the project owner.
+        //
+        // The boot-time regression alarm in timer_interrupt.rs (panics if
+        // CPU0 tick_count < 10% of max peer at 30s) will catch you if any
+        // change to this region reintroduces the loop.
+        //
+        // DO NOT REMOVE OR RELAX THIS COMMENT BLOCK.
+        // ═══════════════════════════════════════════════════════════════════
 
         if !has_started {
             if let Some(thread) = sched.get_thread_mut(thread_id) {
@@ -3229,6 +3247,32 @@ fn idle_enter_scheduler_if_needed() -> bool {
 
 /// ARM64 idle loop - wait for interrupts.
 #[no_mangle]
+// ═══════════════════════════════════════════════════════════════════════════
+// 🔒 GOLD-MASTER REGION — idle_loop_arm64
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Frozen by PR #334 (commit 9da897f4, 2026-04-22). The (daifset → gate check
+// → dsb sy → wfi → daifclr) sequence in this loop is the result of F20e
+// (bff1d92a), F32j's sleep gate (part of PR #328), and the empirical
+// finding that Linux runs the same pattern on the same Parallels
+// hypervisor without issue.
+//
+// In particular:
+//   - `dsb sy` BEFORE wfi matches Linux's `arch/arm64/kernel/process.c::cpu_do_idle`
+//   - WFI runs with IRQs masked; masked IRQs still wake WFI per ARM spec
+//   - `daifclr` after WFI unmasks to take the pending IRQ
+//
+// DO NOT:
+//   - Re-add the idle-loop `rearm_timer()` that F20e removed (handler-level
+//     re-arm from e4e16b68 covers this)
+//   - Change the DAIF mask width without citing Linux arch_local_irq_disable
+//   - Add a CPU0-specific branch here (the previous guard was what caused
+//     the week-long "CPU0 regression" — see
+//     docs/planning/cpu0-user-guard-autopsy/README.md)
+//
+// The regression alarm in timer_interrupt.rs fires if CPU0 tick_count
+// diverges from peer CPUs at 30s uptime.
+// ═══════════════════════════════════════════════════════════════════════════
 pub extern "C" fn idle_loop_arm64() -> ! {
     // Get CPU ID once (cheap MRS).
     let cpu_id = crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as usize;

--- a/kernel/src/arch_impl/aarch64/gic.rs
+++ b/kernel/src/arch_impl/aarch64/gic.rs
@@ -1329,10 +1329,27 @@ fn init_gicv3_redistributor(cpu_id: usize) {
     gicr_write_at_rd_base(rd_base, GICR_SGI_OFFSET + GICR_ICFGR0, 0); // SGIs: always edge
     gicr_write_at_rd_base(rd_base, GICR_SGI_OFFSET + GICR_ICFGR0 + 4, 0); // PPIs: level-triggered
 
-    // Linux's GICv3 CPU init configures SGIs/PPIs together before enabling the
-    // CPU interface. Breenix uses SGI0 for reschedule and SGI1 for timer rearm;
-    // leaving them disabled lets ISPENDR0 latch the SGI while HPPIR1/IAR1 stay
-    // spurious.
+    // ═══════════════════════════════════════════════════════════════════════
+    // 🔒 GOLD-MASTER REGION — SGI admission enable
+    // ═══════════════════════════════════════════════════════════════════════
+    //
+    // Frozen by F32j (commit 946b2812, PR #328) and retained by PR #334.
+    // Without enabling the SGIs Breenix actually uses (SGI_RESCHEDULE and
+    // SGI_TIMER_REARM) in each CPU's GICR_ISENABLER0, the SGIs can latch
+    // in GICR_ISPENDR0 but never be admitted by the CPU interface —
+    // ICC_HPPIR1_EL1 returns spurious (1023) and the reschedule IPI is
+    // silently dropped. F32i validated this via linux-probe comparison
+    // (20/20 Linux wakes of idle CPU0 in 14-54µs on same Parallels hypervisor).
+    // Linux parity: /tmp/linux-v6.8/drivers/irqchip/irq-gic-v3.c::gic_cpu_config.
+    //
+    // DO NOT remove or relax this ISENABLER write. Any future SGI Breenix
+    // introduces (beyond SGI 0 and 1) must also be OR'd into this mask.
+    // The `dsb sy; isb` after the write ensures the CPU interface sees
+    // the enable before any subsequent SGI send.
+    //
+    // See docs/planning/cpu0-user-guard-autopsy/README.md for the forensic
+    // record of the CPU0 regression this fix was part of addressing.
+    // ═══════════════════════════════════════════════════════════════════════
     let sgi_enable_mask =
         (1u32 << super::constants::SGI_RESCHEDULE) | (1u32 << super::constants::SGI_TIMER_REARM);
     gicr_write_at_rd_base(rd_base, GICR_SGI_OFFSET + GICR_ISENABLER0, sgi_enable_mask);
@@ -1340,6 +1357,7 @@ fn init_gicv3_redistributor(cpu_id: usize) {
         core::arch::asm!("dsb sy", options(nomem, nostack));
         core::arch::asm!("isb", options(nomem, nostack));
     }
+    // ═══════════════════════════════════════════════════════════════════════
 }
 
 /// Initialize GICv3 CPU Interface via ICC system registers.

--- a/kernel/src/arch_impl/aarch64/timer_interrupt.rs
+++ b/kernel/src/arch_impl/aarch64/timer_interrupt.rs
@@ -527,6 +527,85 @@ pub extern "C" fn timer_interrupt_handler(frame: *const Aarch64ExceptionFrame) {
         }
     }
 
+    // ═══════════════════════════════════════════════════════════════════════
+    // 🔒 GOLD-MASTER REGION — CPU0 divergence regression alarm
+    // ═══════════════════════════════════════════════════════════════════════
+    //
+    // Installed by PR #334 (2026-04-22) after the CPU0 user-guard dispatch
+    // loop cost ~1 week to diagnose. The alarm fires a `panic!` at 30s
+    // uptime if CPU0's tick count is less than 10% of the max non-CPU0 CPU.
+    // This would have caught the guard loop on its first boot instead of
+    // letting users hunt "cursor doesn't work" symptoms for days.
+    //
+    // Trigger conditions:
+    //   - Any non-CPU0 CPU reaches tick 30000 (~30s of uptime)
+    //   - CPU0's tick count is < 10% of the max non-CPU0 tick count
+    //
+    // A panic is intentionally loud: this regression SHOULD make the
+    // system unbootable because silent degradation was the whole problem.
+    //
+    // See docs/planning/cpu0-user-guard-autopsy/README.md.
+    // ═══════════════════════════════════════════════════════════════════════
+    if cpu_id >= 1 && cpu_id < 8 {
+        let this_cpu_ticks = TIMER_TICK_COUNT[cpu_id].load(Ordering::Relaxed);
+        if this_cpu_ticks == 30000 {
+            let cpu0 = TIMER_TICK_COUNT[0].load(Ordering::Relaxed);
+            let mut max_peer: u64 = 0;
+            for c in 1..8 {
+                let v = TIMER_TICK_COUNT[c].load(Ordering::Relaxed);
+                if v > max_peer {
+                    max_peer = v;
+                }
+            }
+            // 10% threshold: cpu0 * 10 < max_peer means cpu0 < 10% of max.
+            if cpu0.saturating_mul(10) < max_peer {
+                crate::serial_aarch64::raw_serial_str(
+                    b"\n!!! CPU0 REGRESSION ALARM !!!\n",
+                );
+                crate::serial_aarch64::raw_serial_str(b"CPU0 tick_count = ");
+                let mut n = cpu0;
+                let mut buf = [0u8; 20];
+                let mut i = 20usize;
+                if n == 0 {
+                    i -= 1;
+                    buf[i] = b'0';
+                } else {
+                    while n > 0 {
+                        i -= 1;
+                        buf[i] = b'0' + (n % 10) as u8;
+                        n /= 10;
+                    }
+                }
+                crate::serial_aarch64::raw_serial_str(&buf[i..]);
+                crate::serial_aarch64::raw_serial_str(b", max peer = ");
+                let mut n = max_peer;
+                let mut buf = [0u8; 20];
+                let mut i = 20usize;
+                if n == 0 {
+                    i -= 1;
+                    buf[i] = b'0';
+                } else {
+                    while n > 0 {
+                        i -= 1;
+                        buf[i] = b'0' + (n % 10) as u8;
+                        n /= 10;
+                    }
+                }
+                crate::serial_aarch64::raw_serial_str(&buf[i..]);
+                crate::serial_aarch64::raw_serial_str(
+                    b"\nSee docs/planning/cpu0-user-guard-autopsy/README.md\n",
+                );
+                panic!(
+                    "CPU0 timer regression: tick_count={} but peer max={}; \
+                     read docs/planning/cpu0-user-guard-autopsy/README.md \
+                     before touching anything",
+                    cpu0, max_peer
+                );
+            }
+        }
+    }
+    // ═══════════════════════════════════════════════════════════════════════
+
     // Mask the timer interrupt at the source (set IMASK=1, keep ENABLE=1).
     // This de-asserts the PPI line, which signals the hypervisor (Parallels/HVF)
     // that the guest has acknowledged the interrupt. Without this, the HVF


### PR DESCRIPTION
## Purpose

Lock down the CPU0 fix landed in PR #334 (commit 9da897f4) with:

1. **Full forensic record** — \`docs/planning/cpu0-user-guard-autopsy/README.md\` explains the bug, the wrong theories, the real root cause, and the rules for any future agent tempted to add a CPU0-specific branch.
2. **Gold-master inline markers** on three code regions whose correctness is load-bearing for CPU0 liveness.
3. **Boot-time regression alarm** that panics loudly if CPU0 tick_count < 10% of max peer at 30s uptime — the previous regression would have been caught in seconds instead of days.
4. **CLAUDE.md \"GOLD-MASTER REGIONS\"** section so agents see the frozen list before reading any other code.

## Why

The CPU0 user-guard regression burned ~1 week across F32i/F32j/F33/F34 and ad-hoc investigations. Every one of them accepted \"HVF kills CPU0 vtimer on EL0 return\" as a premise (because the guard's comment said so) rather than treating it as a hypothesis. Probe evidence eventually showed the real bug: the guard's \`requeue_thread_after_save()\` puts the thread back on CPU0's own queue, creating a ~24 kHz dispatch→redirect→requeue loop.

This PR codifies the lesson so a future agent (or a future me) can't repeat the investigation.

## Content

**Autopsy doc** (\`docs/planning/cpu0-user-guard-autopsy/README.md\`):
- TL;DR, symptom, root cause
- Probe evidence: per-CPU tick_count before/after fix
- Wrong-theory table (12 hypotheses chased and rejected)
- Commit timeline
- Detection metric (per-CPU tick parity)
- Rules for the future (4 mandatory steps before any new CPU0 guard)

**Gold-master markers** at:
- \`context_switch.rs\` EL0 dispatch site
- \`context_switch.rs::idle_loop_arm64\`
- \`gic.rs::init_gicv3_redistributor\` SGI enable block

**Regression alarm** in \`timer_interrupt.rs\`:
- Triggers at 30s uptime (any non-CPU0 CPU reaching tick 30000)
- Panics with autopsy-doc pointer if CPU0 is < 10% of max peer

**CLAUDE.md update** with a dedicated section listing all frozen regions.

## Validation

- aarch64 kernel builds clean
- No runtime behavior change except the regression alarm, which only fires under genuine regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)