### PR TITLE
Freeze two more CPU0-liveness gold-master regions (arm-at-top + dispatch-ERET ISB)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,7 +386,9 @@ the constraints.
 |---|---|---|
 | `kernel/src/arch_impl/aarch64/context_switch.rs` (EL0 dispatch site) | NO CPU0-specific EL0 dispatch guard | `docs/planning/cpu0-user-guard-autopsy/README.md` |
 | `kernel/src/arch_impl/aarch64/context_switch.rs::idle_loop_arm64` | Sleep gate + `dsb sy; wfi; daifclr` sequence | same |
+| `kernel/src/arch_impl/aarch64/context_switch.rs::aarch64_enter_exception_frame` | ISB before dispatch ERET (narrow placement — do NOT add ISBs at other ERETs) | same |
 | `kernel/src/arch_impl/aarch64/gic.rs::init_gicv3_redistributor` (SGI enable block) | `GICR_ISENABLER0` write for SGI_RESCHEDULE + SGI_TIMER_REARM | same |
+| `kernel/src/arch_impl/aarch64/timer_interrupt.rs` (handler arm-at-top) | Unconditional re-arm BEFORE any handler work (prevents IMASK death if handler hangs) | same |
 | `kernel/src/arch_impl/aarch64/timer_interrupt.rs` (CPU0 regression alarm) | Panic at 30s if CPU0 tick_count < 10% of max peer | same |
 
 The CPU0 user-guard regression (PR #334 fixed it) burned ~1 week because

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -645,21 +645,37 @@ aarch64_enter_exception_frame:
     str x17, [x16]
 5:
 
-    // CRITICAL: ISB before ERET — required for HVF (Apple Hypervisor Framework).
+    // ═════════════════════════════════════════════════════════════════════
+    // 🔒 GOLD-MASTER REGION — ISB before dispatch ERET
+    // ═════════════════════════════════════════════════════════════════════
     //
-    // Without this ISB, the SPSR_EL1/ELR_EL1 writes above may not be visible
-    // to HVF when it processes the ERET trap. HVF reads guest SPSR to determine
-    // PSTATE.DAIF for the vtimer injection decision. If it sees stale SPSR with
-    // DAIF.I=1 (interrupts masked), it permanently masks the virtual timer,
-    // killing all timer interrupts on this CPU.
+    // Frozen by PR #336. Original fix: aeb3e989 (added ISB at 6 ERET sites)
+    // then aade0871 (narrowed to this ONE site). Narrow placement is
+    // load-bearing: ISBs at the other ERET sites (IRQ return, syscall
+    // return, first-entry-to-userspace) caused a DIFFERENT timer death at
+    // ~10K ticks. Only the dispatch ERET needs the ISB.
     //
-    // On real hardware, ERET is itself a context synchronization event, so ISB
-    // before ERET is architecturally redundant. But HVF intercepts ERET before
-    // it executes, and the interception sees pre-synchronization register state.
+    // Bisection evidence (aeb3e989 commit message):
+    //   - ret-based dispatch (no ERET): timer survives 55000+ ticks
+    //   - ERET without ISB: timer dies after ~4 ticks
+    //   - ERET with ISB: timer survives 300000+ ticks indefinitely
     //
-    // Evidence: without ISB, timer dies after ~4 ticks. With ISB, timer survives
-    // 300000+ ticks indefinitely. The ret-based path (daifclr+br) was immune
-    // because it doesn't go through HVF's ERET trap.
+    // Rationale: HVF intercepts ERET before it executes as a context-sync
+    // event. Without the ISB, HVF reads guest SPSR_EL1/ELR_EL1 pre-sync.
+    // On real hardware ERET is itself a sync, so this ISB is architecturally
+    // redundant — but HVF doesn't get the sync until it runs the interception.
+    //
+    // DO NOT:
+    //   - Remove this isb.
+    //   - Add ISBs before other ERETs (boot.S sync/irq handlers, syscall
+    //     return in syscall_entry.S). aade0871 specifically removed them
+    //     from those sites because they caused timer death.
+    //   - Inline additional instructions between this isb and the eret
+    //     below unless you've verified (via boot + 30s trace) that the
+    //     timer still survives.
+    //
+    // See docs/planning/cpu0-user-guard-autopsy/README.md.
+    // ═════════════════════════════════════════════════════════════════════
     isb
     mrs x16, mpidr_el1
     and x16, x16, #0xFF

--- a/kernel/src/arch_impl/aarch64/timer_interrupt.rs
+++ b/kernel/src/arch_impl/aarch64/timer_interrupt.rs
@@ -631,10 +631,35 @@ pub extern "C" fn timer_interrupt_handler(frame: *const Aarch64ExceptionFrame) {
         }
     }
 
-    // IMMEDIATELY re-arm the timer — clears IMASK and sets a future CVAL.
-    // This MUST happen before any potentially-blocking handler work (keyboard
-    // poll, USB XHCI poll, etc.). If that work hangs on a spinlock, the timer
-    // is still re-armed with IMASK=0, preventing permanent timer death on this CPU.
+    // ═══════════════════════════════════════════════════════════════════════
+    // 🔒 GOLD-MASTER REGION — arm_timer at TOP of handler
+    // ═══════════════════════════════════════════════════════════════════════
+    //
+    // Frozen by PR #336 after review. Original fix in commit e4e16b68
+    // (2026-03-29): "move arm_timer to top of handler — prevents IMASK death
+    // when handler work hangs".
+    //
+    // Invariant: after the IMASK=1 write above (which tells HVF the guest is
+    // acknowledging the interrupt), the very next thing is an unconditional
+    // re-arm that clears IMASK and sets a future CVAL. This MUST happen
+    // BEFORE any potentially-blocking handler work (keyboard poll, USB XHCI
+    // poll, scheduler bookkeeping). If the handler later hangs on a lock,
+    // the timer is already re-armed with IMASK=0 so the CPU's vtimer keeps
+    // ticking instead of dying permanently.
+    //
+    // DO NOT:
+    //   - Move this re-arm later in the handler ("just a quick poll first,
+    //     then arm" has been tried and regresses to IMASK-death).
+    //   - Gate it on any condition — every timer-handler entry re-arms,
+    //     unconditionally, even if the previous arm happened 1µs ago.
+    //   - Replace the direct CNTV_CTL=1 + CVAL write with an arm function
+    //     that could take a lock.
+    //
+    // Diagnostic proof of the IMASK-death class is in the e4e16b68 commit
+    // message: `timer_ctl[0]=0x7 (ENABLE=1, IMASK=1, ISTATUS=1)` on a dead
+    // CPU0 before the fix. See also docs/planning/cpu0-user-guard-autopsy
+    // for the broader CPU0-liveness story.
+    // ═══════════════════════════════════════════════════════════════════════
     let ticks = TICKS_PER_INTERRUPT.load(Ordering::Relaxed);
     if crate::platform_config::is_vmware() {
         // VMware: re-arm both timers using CVAL (absolute compare value)
@@ -654,6 +679,7 @@ pub extern "C" fn timer_interrupt_handler(frame: *const Aarch64ExceptionFrame) {
     } else {
         arm_timer(ticks);
     }
+    // ═══════════════════════════════════════════════════════════════════════
 
     // Snapshot CNTV_CTL_EL0 for this CPU — captures the timer hardware state
     // after re-arm. Should show CTL=1 (ENABLE=1, IMASK=0) or CTL=5 if ISTATUS.


### PR DESCRIPTION
## What

Adds gold-master markers to two additional CPU0-liveness regions and indexes them in CLAUDE.md:

1. **\`timer_interrupt.rs\`** — arm_timer at TOP of handler (originally e4e16b68)
2. **\`context_switch.rs::aarch64_enter_exception_frame\`** — ISB before dispatch ERET (aeb3e989 narrowed by aade0871)

Both have strong empirical evidence and clear rationale; freezing protects against future regressions.

## Why only these two

Asked myself: \"am I highly confident the current code is correct?\" for each tier-2 candidate. Answered yes for these two. Answered no for:

- **AHCI arm_completion / detect_completed_slots** — F35 may need to modify while fixing the blauncher/fork-exec lockup. Freezing now would fight the fix.
- **IMASK=1 before first timer arm (26bfcea9)** — cites \"HVF vtimer protocol\" which post-PR #334 is known to be empirically unnecessary. Might be cargo-cult. Needs a re-test before we freeze.

## Content

Each region gets a big inline comment block with:
- The freeze origin (PR + commit)
- The invariant being preserved
- Bisection evidence (where available)
- DO-NOT rules
- Pointer to \`docs/planning/cpu0-user-guard-autopsy/\`

CLAUDE.md \"Gold-Master Regions\" table now lists 6 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)