### PR TITLE
fix(arm64): port Linux IRQ completion + nesting gate (closes CPU0 active+pending)

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -23,6 +23,7 @@ use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 use super::exception_frame::Aarch64ExceptionFrame;
 use super::percpu::Aarch64PerCpu;
+use crate::arch_impl::aarch64::constants::{HARDIRQ_MASK, NMI_MASK, PREEMPT_MASK, SOFTIRQ_MASK};
 use crate::arch_impl::traits::PerCpuOps;
 use crate::task::scheduler::Scheduler;
 use crate::task::thread::{CpuContext, Thread, ThreadPrivilege, ThreadState};
@@ -31,6 +32,7 @@ use crate::tracing::providers::sched::trace_ctx_switch;
 const SPSR_MODE_MASK: u64 = 0xF;
 const SPSR_EL1H: u64 = 0x5;
 const SPSR_DAIF_IRQ_BIT: u64 = 1 << 7;
+const PREEMPT_GUARD_MASK: u32 = PREEMPT_MASK | SOFTIRQ_MASK | HARDIRQ_MASK | NMI_MASK;
 const TRACE_CTX_PUBLISH_SAVE_USER: u16 = 1;
 const TRACE_CTX_PUBLISH_SAVE_KERNEL: u16 = 2;
 const TRACE_CTX_PUBLISH_INLINE_SAVE: u16 = 3;
@@ -2291,8 +2293,8 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
         false
     };
 
-    if !from_el0 && (preempt_count & 0xFF) > 0 {
-        // Kernel code holding locks — not safe to preempt.
+    if (preempt_count & PREEMPT_GUARD_MASK) != 0 {
+        // Kernel or interrupt context is not safe to preempt.
         // Deferred requeue was already processed above.
         return;
     }

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -1191,6 +1191,120 @@ fn interrupted_context_had_irqs_unmasked(frame: *const Aarch64ExceptionFrame) ->
     !frame.is_null() && unsafe { ((*frame).spsr & 0xC0) == 0 }
 }
 
+#[inline(always)]
+fn dispatch_irq_action(irq_id: u32, frame: *const Aarch64ExceptionFrame) {
+    // Handle the interrupt based on ID
+    match irq_id {
+        // Timer interrupt — virtual (PPI 27) or physical (PPI 30)
+        // This is the scheduling timer - calls into scheduler
+        irq if irq == crate::arch_impl::aarch64::timer_interrupt::timer_irq() => {
+            // Call the timer interrupt handler which handles:
+            // - Re-arming the timer
+            // - Updating global time
+            // - Decrementing time quantum
+            // - Setting need_resched flag
+            crate::arch_impl::aarch64::timer_interrupt::timer_interrupt_handler(frame);
+        }
+
+        // UART0 receive interrupt (SPI 1 = IRQ 33)
+        UART0_IRQ => {
+            handle_uart_interrupt();
+        }
+
+        // SGIs (0-15) - Inter-processor interrupts
+        0..=15 => {
+            if irq_id == constants::SGI_RESCHEDULE {
+                // IPI reschedule: another CPU unblocked a thread and wants us to pick it up
+                crate::per_cpu_aarch64::set_need_resched(true);
+            } else if irq_id == constants::SGI_TIMER_REARM {
+                // IPI timer re-arm: another CPU detected our timer is dead
+                // and wants us to re-arm it. This fixes Parallels HVF vtimer
+                // death where PPI 27 is pending but never delivered — the SGI
+                // proves the CPU CAN receive interrupts, so re-arming the
+                // timer here should make PPI 27 deliverable again.
+                crate::arch_impl::aarch64::timer_interrupt::rearm_timer();
+            }
+        }
+
+        // PPIs (16-31) - Private peripheral interrupts (excluding timer)
+        // On VMware, we enable both virtual (27) and physical (30) timers
+        // to discover which fires. Handle either as a timer interrupt.
+        irq @ 16..=31 => {
+            if irq == crate::arch_impl::aarch64::timer_interrupt::VIRT_TIMER_IRQ
+                || irq == crate::arch_impl::aarch64::timer_interrupt::PHYS_TIMER_IRQ
+            {
+                crate::arch_impl::aarch64::timer_interrupt::timer_interrupt_handler(frame);
+            }
+            // Diagnostic: emit raw serial for any unexpected PPI
+            if irq != crate::arch_impl::aarch64::timer_interrupt::timer_irq()
+                && irq != crate::arch_impl::aarch64::timer_interrupt::VIRT_TIMER_IRQ
+                && irq != crate::arch_impl::aarch64::timer_interrupt::PHYS_TIMER_IRQ
+            {
+                crate::serial_aarch64::raw_serial_char(b'P');
+                crate::serial_aarch64::raw_serial_char(b'0' + (irq / 10) as u8);
+                crate::serial_aarch64::raw_serial_char(b'0' + (irq % 10) as u8);
+            }
+        }
+
+        // SPIs (32-1019) - Shared peripheral interrupts
+        // Note: No logging here - interrupt handlers must be < 1000 cycles
+        32..=1019 => {
+            // VirtIO input (keyboard) interrupt dispatch
+            if let Some(input_irq) = crate::drivers::virtio::input_mmio::get_irq() {
+                if irq_id == input_irq {
+                    crate::drivers::virtio::input_mmio::handle_interrupt();
+                }
+            }
+            // VirtIO tablet (pointer) interrupt dispatch
+            if let Some(tablet_irq) = crate::drivers::virtio::input_mmio::get_tablet_irq() {
+                if irq_id == tablet_irq {
+                    crate::drivers::virtio::input_mmio::handle_tablet_interrupt();
+                }
+            }
+            // VirtIO network interrupt dispatch
+            if let Some(net_irq) = crate::drivers::virtio::net_mmio::get_irq() {
+                if irq_id == net_irq {
+                    crate::drivers::virtio::net_mmio::handle_interrupt();
+                }
+            }
+            // XHCI USB interrupt dispatch
+            if let Some(xhci_irq) = crate::drivers::usb::xhci::get_irq() {
+                if irq_id == xhci_irq {
+                    crate::drivers::usb::xhci::handle_interrupt();
+                }
+            }
+            // VirtIO GPU PCI interrupt dispatch (MSI completion)
+            if let Some(gpu_irq) = crate::drivers::virtio::gpu_pci::get_irq() {
+                if irq_id == gpu_irq {
+                    crate::drivers::virtio::gpu_pci::handle_interrupt();
+                }
+            }
+            // VirtIO network PCI interrupt dispatch (GICv2m MSI)
+            if let Some(net_pci_irq) = crate::drivers::virtio::net_pci::get_irq() {
+                if irq_id == net_pci_irq {
+                    crate::drivers::virtio::net_pci::handle_interrupt();
+                }
+            }
+            // AHCI storage interrupt dispatch (GICv2m MSI/MSI-X)
+            #[cfg(target_arch = "aarch64")]
+            if let Some(ahci_irq) = crate::drivers::ahci::get_irq() {
+                if irq_id == ahci_irq {
+                    crate::drivers::ahci::handle_interrupt();
+                }
+            }
+        }
+
+        // Should not happen - GIC filters invalid IDs (1020+)
+        _ => {}
+    }
+}
+
+#[inline(always)]
+fn handle_irq_event(irq_id: u32, frame: *const Aarch64ExceptionFrame) {
+    dispatch_irq_action(irq_id, frame);
+    gic::deactivate_irq(irq_id);
+}
+
 /// Handle IRQ interrupts
 ///
 /// Called from assembly after saving registers.
@@ -1222,110 +1336,7 @@ pub extern "C" fn handle_irq(frame: *const Aarch64ExceptionFrame) {
             }
         }
 
-        // Handle the interrupt based on ID
-        match irq_id {
-            // Timer interrupt — virtual (PPI 27) or physical (PPI 30)
-            // This is the scheduling timer - calls into scheduler
-            irq if irq == crate::arch_impl::aarch64::timer_interrupt::timer_irq() => {
-                // Call the timer interrupt handler which handles:
-                // - Re-arming the timer
-                // - Updating global time
-                // - Decrementing time quantum
-                // - Setting need_resched flag
-                crate::arch_impl::aarch64::timer_interrupt::timer_interrupt_handler(frame);
-            }
-
-            // UART0 receive interrupt (SPI 1 = IRQ 33)
-            UART0_IRQ => {
-                handle_uart_interrupt();
-            }
-
-            // SGIs (0-15) - Inter-processor interrupts
-            0..=15 => {
-                if irq_id == constants::SGI_RESCHEDULE {
-                    // IPI reschedule: another CPU unblocked a thread and wants us to pick it up
-                    crate::per_cpu_aarch64::set_need_resched(true);
-                } else if irq_id == constants::SGI_TIMER_REARM {
-                    // IPI timer re-arm: another CPU detected our timer is dead
-                    // and wants us to re-arm it. This fixes Parallels HVF vtimer
-                    // death where PPI 27 is pending but never delivered — the SGI
-                    // proves the CPU CAN receive interrupts, so re-arming the
-                    // timer here should make PPI 27 deliverable again.
-                    crate::arch_impl::aarch64::timer_interrupt::rearm_timer();
-                }
-            }
-
-            // PPIs (16-31) - Private peripheral interrupts (excluding timer)
-            // On VMware, we enable both virtual (27) and physical (30) timers
-            // to discover which fires. Handle either as a timer interrupt.
-            irq @ 16..=31 => {
-                if irq == crate::arch_impl::aarch64::timer_interrupt::VIRT_TIMER_IRQ
-                    || irq == crate::arch_impl::aarch64::timer_interrupt::PHYS_TIMER_IRQ
-                {
-                    crate::arch_impl::aarch64::timer_interrupt::timer_interrupt_handler(frame);
-                }
-                // Diagnostic: emit raw serial for any unexpected PPI
-                if irq != crate::arch_impl::aarch64::timer_interrupt::timer_irq()
-                    && irq != crate::arch_impl::aarch64::timer_interrupt::VIRT_TIMER_IRQ
-                    && irq != crate::arch_impl::aarch64::timer_interrupt::PHYS_TIMER_IRQ
-                {
-                    crate::serial_aarch64::raw_serial_char(b'P');
-                    crate::serial_aarch64::raw_serial_char(b'0' + (irq / 10) as u8);
-                    crate::serial_aarch64::raw_serial_char(b'0' + (irq % 10) as u8);
-                }
-            }
-
-            // SPIs (32-1019) - Shared peripheral interrupts
-            // Note: No logging here - interrupt handlers must be < 1000 cycles
-            32..=1019 => {
-                // VirtIO input (keyboard) interrupt dispatch
-                if let Some(input_irq) = crate::drivers::virtio::input_mmio::get_irq() {
-                    if irq_id == input_irq {
-                        crate::drivers::virtio::input_mmio::handle_interrupt();
-                    }
-                }
-                // VirtIO tablet (pointer) interrupt dispatch
-                if let Some(tablet_irq) = crate::drivers::virtio::input_mmio::get_tablet_irq() {
-                    if irq_id == tablet_irq {
-                        crate::drivers::virtio::input_mmio::handle_tablet_interrupt();
-                    }
-                }
-                // VirtIO network interrupt dispatch
-                if let Some(net_irq) = crate::drivers::virtio::net_mmio::get_irq() {
-                    if irq_id == net_irq {
-                        crate::drivers::virtio::net_mmio::handle_interrupt();
-                    }
-                }
-                // XHCI USB interrupt dispatch
-                if let Some(xhci_irq) = crate::drivers::usb::xhci::get_irq() {
-                    if irq_id == xhci_irq {
-                        crate::drivers::usb::xhci::handle_interrupt();
-                    }
-                }
-                // VirtIO GPU PCI interrupt dispatch (MSI completion)
-                if let Some(gpu_irq) = crate::drivers::virtio::gpu_pci::get_irq() {
-                    if irq_id == gpu_irq {
-                        crate::drivers::virtio::gpu_pci::handle_interrupt();
-                    }
-                }
-                // VirtIO network PCI interrupt dispatch (GICv2m MSI)
-                if let Some(net_pci_irq) = crate::drivers::virtio::net_pci::get_irq() {
-                    if irq_id == net_pci_irq {
-                        crate::drivers::virtio::net_pci::handle_interrupt();
-                    }
-                }
-                // AHCI storage interrupt dispatch (GICv2m MSI/MSI-X)
-                #[cfg(target_arch = "aarch64")]
-                if let Some(ahci_irq) = crate::drivers::ahci::get_irq() {
-                    if irq_id == ahci_irq {
-                        crate::drivers::ahci::handle_interrupt();
-                    }
-                }
-            }
-
-            // Should not happen - GIC filters invalid IDs (1020+)
-            _ => {}
-        }
+        handle_irq_event(irq_id, frame);
 
         if reopen_nested_irq_window {
             unsafe {
@@ -1336,8 +1347,6 @@ pub extern "C" fn handle_irq(frame: *const Aarch64ExceptionFrame) {
                 );
             }
         }
-
-        gic::deactivate_irq(irq_id);
 
         if have_percpu {
             crate::per_cpu_aarch64::irq_exit();


### PR DESCRIPTION
## Summary

Port Linux's structural IRQ-completion-before-schedule invariant into Breenix's ARM64 IRQ path. Closes the original PPI 27 active+pending CPU0 timer death mechanism that's blocked progress across multiple investigations.

Two commits, both required for the invariant to hold:

1. **`92c407a3` — Per-handler GIC deactivation.** Moves `gic::deactivate_irq()` from the outer `handle_irq()` tail into a new per-handler wrapper `handle_irq_event()`, so GIC completion runs INSIDE the IRQ dispatch chain — before any nested-IRQ reopen window or scheduler-entry path can act. Matches Linux's `handle_percpu_devid_irq() { action(); chip->irq_eoi(); }` pattern.

2. **`4870a1c6` — Full preempt_count gate on schedule entry.** Replaces `check_need_resched_and_switch_arm64`'s guard from `!from_el0 && (preempt_count & 0xFF) > 0` to `(preempt_count & PREEMPT_GUARD_MASK) != 0` where the mask = PREEMPT | SOFTIRQ | HARDIRQ | NMI. Matches Linux's `arm64_preempt_schedule_irq()` `preempt_count() != 0` gate. Without this, the per-handler change alone is incomplete — nested IRQs from EL0 context could still trigger context-switch during the outer IRQ's window.

## The mechanism this closes

Previously, a nested IRQ during the outer's `handle_irq()` window could context-switch the CPU away before the outer's `deactivate_irq()` ran, leaving the outer IRQ's active bit set in `ICACTIVER0`. On the next vtimer deadline the line re-asserted, producing active+pending state (`ISPENDR0` bit 27 set AND `ICACTIVER0` bit 27 set) — a state the GIC does NOT signal to the PE per spec, so WFI never woke. CPU0 went silent permanently.

## Linux references

Per `~/Downloads/cpu0-ralph-linux/linux-invariant.md`:
- `drivers/irqchip/irq-gic-v3.c:634-637` — `gic_eoi_irq()` writes `ICC_EOIR1_EL1` (EOImode 0 → also deactivates)
- `kernel/irq/chip.c:940-956` — `handle_percpu_devid_irq()` calls `chip->irq_eoi()` after the action
- `arch/arm64/kernel/entry-common.c:519-528` — `__el1_irq()` ordering: `do_interrupt_handler()` (which includes chip completion) → `irq_exit_rcu()` → `arm64_preempt_schedule_irq()`
- `arch/arm64/kernel/entry-common.c:236-267` — `arm64_preempt_schedule_irq()` gate on full `preempt_count()`

## Investigation evidence

Ralph loop on this branch (7 turns, artifacts under `~/Downloads/Ralph/cpu0-linux/`):

| Stage | Result |
|---|---|
| Turn 5 triage (5 boots, STRICT) | 5/5 PASS — ticks 80k-100k, no active+pending bit observed |
| Turn 6 stress (30 boots, stop-on-first-fail) | 4/5 PASS, run 5 wedged |
| Turn 7 wedge analysis | Run 5 wedge is at `[spawn] path='/bin/bwm'` BEFORE `manager.create_process_with_argv` ENTRY — separate pre-existing bug class |

Run 5 wedge shape matches prior stalls documented in `docs/planning/f32h-ahci-wake/evidence.md` and `docs/planning/f32-waitqueue/exit.md` — they predate this fix by months. Most likely a CPU0/global-tick or scheduler-progress bug that was masked by the original active+pending mechanism firing first.

## What's NOT covered

- bwm-spawn wedge: tracked under follow-up Ralph investigation. Per Codex's turn 7 analysis, GDB-attach is the right next tool.
- Original mask removal: this PR removes the active+pending mask via the per-handler deactivate. With the original mechanism closed, other latent bugs in the same class may surface — the wedge above is one such case.

## Gold-master compliance

No regions in the gold-master autopsy list (`docs/planning/cpu0-user-guard-autopsy/`) touched. Specifically:
- `context_switch.rs::idle_loop_arm64` untouched
- `context_switch.rs::aarch64_enter_exception_frame` untouched
- `context_switch.rs` EL0 dispatch site untouched
- `gic.rs::init_gicv3_redistributor` untouched
- `timer_interrupt.rs` arm-at-top untouched
- `timer_interrupt.rs` CPU0 regression alarm untouched

Schedule-entry guard at `context_switch.rs::check_need_resched_and_switch_arm64` is NOT in the gold-master list and is the intended change site.

## Diff stat

```
 kernel/src/arch_impl/aarch64/context_switch.rs |   6 +-
 kernel/src/arch_impl/aarch64/exception.rs      | 221 +++++++++++++------------
 2 files changed, 119 insertions(+), 108 deletions(-)
```

`exception.rs` is mostly mechanical: extract the IRQ-ID match into `dispatch_irq_action()`, wrap in `handle_irq_event()` which calls `deactivate_irq()` immediately after. No handler behavior changes.

## Test plan

- [ ] CI: cargo build aarch64 + x86-64 clean (zero warnings)
- [ ] Local Parallels boot: kernel reaches userspace, BWM compositor active, no CPU0 regression alarm
- [ ] Stress (separate from this PR): re-run 30-boot stop-on-first-fail under the new naming scheme once the bwm-spawn wedge investigation has reduced its incidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)