### PR TITLE
fix(aarch64): scheduler/AHCI/inline-ret bug class on Parallels HVF

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -2730,6 +2730,10 @@ extern "C" fn inline_schedule_trampoline() -> ! {
 
     if sched_ptr.is_null() {
         inline_schedule_breadcrumb(cpu_id, INLINE_BC_NULL_FALLBACK, 0);
+        unsafe {
+            inline_schedule_breadcrumb(cpu_id, INLINE_BC_FORCE_UNLOCK_RET, 1);
+            crate::task::scheduler::force_unlock_scheduler();
+        }
         idle_loop_arm64();
     }
 

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -2734,7 +2734,42 @@ extern "C" fn inline_schedule_trampoline() -> ! {
             inline_schedule_breadcrumb(cpu_id, INLINE_BC_FORCE_UNLOCK_RET, 1);
             crate::task::scheduler::force_unlock_scheduler();
         }
-        idle_loop_arm64();
+
+        let idle_sp = crate::task::scheduler::with_scheduler(|sched| {
+            let idle_id = sched.cpu_state[cpu_id].idle_thread;
+            let idle_sp = sched
+                .get_thread(idle_id)
+                .and_then(|thread| thread.kernel_stack_top.map(|stack| stack.as_u64()))
+                .unwrap_or_else(|| scheduler_stack_top(cpu_id));
+            sched.fix_exception_cleanup_cpu_state();
+            idle_sp
+        })
+        .unwrap_or_else(|| scheduler_stack_top(cpu_id));
+
+        unsafe {
+            Aarch64PerCpu::set_user_rsp_scratch(idle_sp);
+            Aarch64PerCpu::set_kernel_stack_top(idle_sp);
+            Aarch64PerCpu::set_current_thread_ptr(core::ptr::null_mut());
+            Aarch64PerCpu::clear_preempt_active();
+        }
+        crate::arch_impl::aarch64::timer_interrupt::reset_quantum();
+        if crate::arch_impl::aarch64::timer_interrupt::is_initialized() {
+            crate::arch_impl::aarch64::timer_interrupt::rearm_timer();
+        }
+
+        inline_schedule_breadcrumb(cpu_id, INLINE_BC_IDLE_RET_BRANCH, 1);
+        let idle_addr = crate::arch_impl::aarch64::idle_loop_arm64 as *const () as u64;
+        unsafe {
+            core::arch::asm!(
+                "mov sp, {stack}",
+                "msr daifclr, #0xf",
+                "isb",
+                "br {target}",
+                stack = in(reg) idle_sp,
+                target = in(reg) idle_addr,
+                options(noreturn)
+            );
+        }
     }
 
     let sched = unsafe { &mut *sched_ptr };

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -1206,7 +1206,11 @@ fn take_inline_ret_dispatch_info(
 
     let thread_ptr = thread as *const _ as *mut u8;
     let ctx_ptr = &thread.context as *const CpuContext;
-    let resume_pc = thread.context.elr_el1;
+    // WHY: inline ret-dispatch restores only callee-saved registers + SP, so
+    // it must resume at the safe post-inline-switch return target, not a
+    // mid-function ELR that may require stale volatile registers.
+    let resume_pc = thread.context.x30;
+    thread.context.elr_el1 = resume_pc;
     let kst = thread.kernel_stack_top;
     let sp_el0 = thread.context.sp_el0;
     let resume_sp = thread.context.sp;

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -816,6 +816,51 @@ static INLINE_SCHEDULE_STATE: [InlineScheduleState;
     },
 ];
 
+const INLINE_SCHEDULE_BREADCRUMB_CPUS: usize = crate::arch_impl::aarch64::constants::MAX_CPUS;
+const INLINE_SCHEDULE_BREADCRUMB_SLOTS: usize = 16;
+const INLINE_BC_TRAMPOLINE_ENTRY: u8 = 0x30;
+const INLINE_BC_STATE_SWAP: u8 = 0x31;
+const INLINE_BC_STATE_IDS: u8 = 0x32;
+const INLINE_BC_NULL_FALLBACK: u8 = 0x3f;
+const INLINE_BC_FORCE_UNLOCK_RET: u8 = 0x45;
+const INLINE_BC_FORCE_UNLOCK_ERET: u8 = 0x46;
+const INLINE_BC_IDLE_RET_BRANCH: u8 = 0x47;
+
+#[no_mangle]
+pub static INLINE_SCHEDULE_BREADCRUMB_TRAIL: [[AtomicU64; INLINE_SCHEDULE_BREADCRUMB_SLOTS];
+    INLINE_SCHEDULE_BREADCRUMB_CPUS] = [const {
+    [const { AtomicU64::new(0) }; INLINE_SCHEDULE_BREADCRUMB_SLOTS]
+}; INLINE_SCHEDULE_BREADCRUMB_CPUS];
+
+#[no_mangle]
+pub static INLINE_SCHEDULE_BREADCRUMB_INDEX: [AtomicU64; INLINE_SCHEDULE_BREADCRUMB_CPUS] =
+    [const { AtomicU64::new(0) }; INLINE_SCHEDULE_BREADCRUMB_CPUS];
+
+#[inline(always)]
+fn inline_schedule_breadcrumb(cpu_id: usize, site: u8, extra: u16) {
+    if cpu_id >= INLINE_SCHEDULE_BREADCRUMB_CPUS {
+        return;
+    }
+
+    let timestamp: u64;
+    unsafe {
+        core::arch::asm!(
+            "mrs {}, CNTVCT_EL0",
+            out(reg) timestamp,
+            options(nomem, nostack, preserves_flags)
+        );
+    }
+
+    let idx = (INLINE_SCHEDULE_BREADCRUMB_INDEX[cpu_id].fetch_add(1, Ordering::Relaxed)
+        as usize)
+        & (INLINE_SCHEDULE_BREADCRUMB_SLOTS - 1);
+    let value = ((timestamp & 0xffff_ffff) << 32)
+        | ((site as u64) << 24)
+        | (((cpu_id as u64) & 0xff) << 16)
+        | (extra as u64);
+    INLINE_SCHEDULE_BREADCRUMB_TRAIL[cpu_id][idx].store(value, Ordering::Relaxed);
+}
+
 static mut INLINE_SCHEDULE_ERET_FRAMES: [MaybeUninit<Aarch64ExceptionFrame>;
     crate::arch_impl::aarch64::constants::MAX_CPUS] =
     [const { MaybeUninit::zeroed() }; crate::arch_impl::aarch64::constants::MAX_CPUS];
@@ -2665,6 +2710,7 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
 
 extern "C" fn inline_schedule_trampoline() -> ! {
     let cpu_id = Aarch64PerCpu::cpu_id() as usize;
+    inline_schedule_breadcrumb(cpu_id, INLINE_BC_TRAMPOLINE_ENTRY, 0);
     cpu0_breadcrumb(cpu_id, 30); // trampoline entry
     let state = &INLINE_SCHEDULE_STATE[cpu_id];
     let sched_ptr = state.scheduler_ptr.swap(0, Ordering::Relaxed) as *mut Scheduler;
@@ -2672,9 +2718,18 @@ extern "C" fn inline_schedule_trampoline() -> ! {
     let new_id = state.new_thread_id.load(Ordering::Relaxed);
     let should_requeue_old = state.should_requeue_old.swap(false, Ordering::Relaxed);
 
+    let state_extra =
+        ((if sched_ptr.is_null() { 0u16 } else { 1u16 }) << 8) | should_requeue_old as u16;
+    inline_schedule_breadcrumb(cpu_id, INLINE_BC_STATE_SWAP, state_extra);
+    inline_schedule_breadcrumb(
+        cpu_id,
+        INLINE_BC_STATE_IDS,
+        (((old_id as u16) & 0xff) << 8) | ((new_id as u16) & 0xff),
+    );
     cpu0_breadcrumb(cpu_id, 31); // after reading INLINE_SCHEDULE_STATE
 
     if sched_ptr.is_null() {
+        inline_schedule_breadcrumb(cpu_id, INLINE_BC_NULL_FALLBACK, 0);
         idle_loop_arm64();
     }
 
@@ -2748,6 +2803,7 @@ extern "C" fn inline_schedule_trampoline() -> ! {
         }
 
         unsafe {
+            inline_schedule_breadcrumb(cpu_id, INLINE_BC_FORCE_UNLOCK_RET, 0);
             crate::task::scheduler::force_unlock_scheduler();
         }
 
@@ -2813,6 +2869,7 @@ extern "C" fn inline_schedule_trampoline() -> ! {
     unsafe {
         Aarch64PerCpu::set_dispatch_elr(frame.elr);
         Aarch64PerCpu::set_dispatch_spsr(frame.spsr);
+        inline_schedule_breadcrumb(cpu_id, INLINE_BC_FORCE_UNLOCK_ERET, is_idle as u16);
         crate::task::scheduler::force_unlock_scheduler();
     }
 
@@ -2832,6 +2889,7 @@ extern "C" fn inline_schedule_trampoline() -> ! {
         // ret-based dispatch for idle — avoids ERET which kills HVF vtimer on Parallels.
         // setup_idle_return_locked already set kernel_stack_top and current_thread_ptr.
         // We just set SP to the idle stack, enable IRQs, and branch directly.
+        inline_schedule_breadcrumb(cpu_id, INLINE_BC_IDLE_RET_BRANCH, 0);
         cpu0_breadcrumb(cpu_id, 45); // ret-based idle dispatch (NOT ERET)
         let idle_addr = crate::arch_impl::aarch64::idle_loop_arm64 as *const () as u64;
         let idle_sp = Aarch64PerCpu::kernel_stack_top();

--- a/kernel/src/arch_impl/aarch64/gic.rs
+++ b/kernel/src/arch_impl/aarch64/gic.rs
@@ -259,6 +259,16 @@ const GIC_HHDM: usize = crate::arch_impl::aarch64::constants::HHDM_BASE as usize
 /// Active GIC version: 2 for GICv2, 3 for GICv3. Set during init.
 static ACTIVE_GIC_VERSION: AtomicU8 = AtomicU8::new(0);
 
+pub static LAST_ENABLE_SPI_IRQ: AtomicU32 = AtomicU32::new(0);
+pub static LAST_ENABLE_SPI_CPU: AtomicU32 = AtomicU32::new(0);
+pub static LAST_ENABLE_SPI_GIC_VERSION: AtomicU32 = AtomicU32::new(0);
+pub static LAST_ENABLE_SPI_MAPPED_AFFINITY: AtomicU64 = AtomicU64::new(0);
+pub static LAST_ENABLE_SPI_AFFINITY_WRITTEN: AtomicU64 = AtomicU64::new(0);
+pub static LAST_ENABLE_SPI_IROUTER_READBACK: AtomicU64 = AtomicU64::new(0);
+pub static LAST_ENABLE_SPI_ISENABLER_READBACK: AtomicU32 = AtomicU32::new(0);
+pub static LAST_ENABLE_SPI_RETRY_COUNT: AtomicU32 = AtomicU32::new(0);
+pub static LAST_ENABLE_SPI_OUTCOME: AtomicU32 = AtomicU32::new(0);
+
 /// Read a 32-bit GICD register (address from platform_config).
 #[inline]
 fn gicd_read(offset: usize) -> u32 {
@@ -885,12 +895,30 @@ pub fn enable_spi(irq: u32) {
 /// intentionally need a non-default target.
 pub fn enable_spi_on_cpu(irq: u32, cpu_id: usize) {
     if irq < 32 || cpu_id >= GICR_RDIST_SLOTS {
+        LAST_ENABLE_SPI_IRQ.store(irq, Ordering::Release);
+        LAST_ENABLE_SPI_CPU.store(cpu_id as u32, Ordering::Release);
+        LAST_ENABLE_SPI_GIC_VERSION.store(0, Ordering::Release);
+        LAST_ENABLE_SPI_MAPPED_AFFINITY.store(0, Ordering::Release);
+        LAST_ENABLE_SPI_AFFINITY_WRITTEN.store(0, Ordering::Release);
+        LAST_ENABLE_SPI_IROUTER_READBACK.store(0, Ordering::Release);
+        LAST_ENABLE_SPI_ISENABLER_READBACK.store(0, Ordering::Release);
+        LAST_ENABLE_SPI_RETRY_COUNT.store(0, Ordering::Release);
+        LAST_ENABLE_SPI_OUTCOME.store(3, Ordering::Release);
         return; // Only SPIs (32+) and known CPU targets.
     }
 
     let version = ACTIVE_GIC_VERSION.load(Ordering::Relaxed);
     let reg_index = irq / 32;
     let bit = irq % 32;
+    LAST_ENABLE_SPI_IRQ.store(irq, Ordering::Release);
+    LAST_ENABLE_SPI_CPU.store(cpu_id as u32, Ordering::Release);
+    LAST_ENABLE_SPI_GIC_VERSION.store(version as u32, Ordering::Release);
+    LAST_ENABLE_SPI_MAPPED_AFFINITY.store(0, Ordering::Release);
+    LAST_ENABLE_SPI_AFFINITY_WRITTEN.store(0, Ordering::Release);
+    LAST_ENABLE_SPI_IROUTER_READBACK.store(0, Ordering::Release);
+    LAST_ENABLE_SPI_ISENABLER_READBACK.store(0, Ordering::Release);
+    LAST_ENABLE_SPI_RETRY_COUNT.store(0, Ordering::Release);
+    LAST_ENABLE_SPI_OUTCOME.store(0, Ordering::Release);
 
     if version >= 3 {
         let mapped_affinity = GICR_PER_CPU_AFFINITY[cpu_id].load(Ordering::Acquire);
@@ -899,11 +927,68 @@ pub fn enable_spi_on_cpu(irq: u32, cpu_id: usize) {
         } else {
             expected_gicr_affinity_for_cpu(cpu_id) as u64
         };
-        gicd_write(GICD_IROUTER + (irq as usize * 8), affinity as u32);
-        gicd_write(
-            GICD_IROUTER + (irq as usize * 8) + 4,
-            (affinity >> 32) as u32,
-        );
+        let enable_offset = GICD_ISENABLER + (reg_index as usize * 4);
+        let router_offset = GICD_IROUTER + (irq as usize * 8);
+        let bit_mask = 1 << bit;
+
+        LAST_ENABLE_SPI_MAPPED_AFFINITY.store(mapped_affinity, Ordering::Release);
+        LAST_ENABLE_SPI_AFFINITY_WRITTEN.store(affinity, Ordering::Release);
+
+        gicd_write(GICD_ICENABLER + (reg_index as usize * 4), bit_mask);
+        unsafe {
+            core::arch::asm!("dsb sy", options(nomem, nostack));
+            core::arch::asm!("isb", options(nomem, nostack));
+        }
+
+        gicd_write(GICD_ICPENDR + (reg_index as usize * 4), bit_mask);
+        unsafe {
+            core::arch::asm!("dsb sy", options(nomem, nostack));
+            core::arch::asm!("isb", options(nomem, nostack));
+        }
+
+        gicd_write(router_offset, affinity as u32);
+        gicd_write(router_offset + 4, (affinity >> 32) as u32);
+        unsafe {
+            core::arch::asm!("dsb sy", options(nomem, nostack));
+            core::arch::asm!("isb", options(nomem, nostack));
+        }
+
+        let mut readback =
+            gicd_read(router_offset) as u64 | ((gicd_read(router_offset + 4) as u64) << 32);
+        let mut retries = 0u32;
+        while readback != affinity && retries < 3 {
+            retries += 1;
+            gicd_write(router_offset, affinity as u32);
+            gicd_write(router_offset + 4, (affinity >> 32) as u32);
+            unsafe {
+                core::arch::asm!("dsb sy", options(nomem, nostack));
+                core::arch::asm!("isb", options(nomem, nostack));
+            }
+            readback =
+                gicd_read(router_offset) as u64 | ((gicd_read(router_offset + 4) as u64) << 32);
+        }
+
+        let outcome = if readback == affinity {
+            if retries == 0 {
+                0
+            } else {
+                1
+            }
+        } else {
+            2
+        };
+
+        LAST_ENABLE_SPI_IROUTER_READBACK.store(readback, Ordering::Release);
+        LAST_ENABLE_SPI_RETRY_COUNT.store(retries, Ordering::Release);
+        LAST_ENABLE_SPI_OUTCOME.store(outcome, Ordering::Release);
+
+        gicd_write(enable_offset, bit_mask);
+        unsafe {
+            core::arch::asm!("dsb sy", options(nomem, nostack));
+            core::arch::asm!("isb", options(nomem, nostack));
+        }
+        LAST_ENABLE_SPI_ISENABLER_READBACK.store(gicd_read(enable_offset), Ordering::Release);
+        return;
     } else {
         if cpu_id >= 8 {
             return;

--- a/kernel/src/arch_impl/aarch64/gic.rs
+++ b/kernel/src/arch_impl/aarch64/gic.rs
@@ -879,6 +879,53 @@ pub fn enable_spi(irq: u32) {
     }
 }
 
+/// Enable an SPI and route it to a specific CPU.
+///
+/// Existing callers should continue using `enable_spi()` unless they
+/// intentionally need a non-default target.
+pub fn enable_spi_on_cpu(irq: u32, cpu_id: usize) {
+    if irq < 32 || cpu_id >= GICR_RDIST_SLOTS {
+        return; // Only SPIs (32+) and known CPU targets.
+    }
+
+    let version = ACTIVE_GIC_VERSION.load(Ordering::Relaxed);
+    let reg_index = irq / 32;
+    let bit = irq % 32;
+
+    if version >= 3 {
+        let mapped_affinity = GICR_PER_CPU_AFFINITY[cpu_id].load(Ordering::Acquire);
+        let affinity = if mapped_affinity != 0 {
+            mapped_affinity
+        } else {
+            expected_gicr_affinity_for_cpu(cpu_id) as u64
+        };
+        gicd_write(GICD_IROUTER + (irq as usize * 8), affinity as u32);
+        gicd_write(
+            GICD_IROUTER + (irq as usize * 8) + 4,
+            (affinity >> 32) as u32,
+        );
+    } else {
+        if cpu_id >= 8 {
+            return;
+        }
+        let target_reg = irq / 4;
+        let target_byte = irq % 4;
+        let current = gicd_read(GICD_ITARGETSR + (target_reg as usize * 4));
+        let mask = 0xFFu32 << (target_byte * 8);
+        let target_val = (1u32 << cpu_id) << (target_byte * 8);
+        gicd_write(
+            GICD_ITARGETSR + (target_reg as usize * 4),
+            (current & !mask) | target_val,
+        );
+    }
+
+    gicd_write(GICD_ISENABLER + (reg_index as usize * 4), 1 << bit);
+    unsafe {
+        core::arch::asm!("dsb sy", options(nomem, nostack));
+        core::arch::asm!("isb", options(nomem, nostack));
+    }
+}
+
 /// Disable an SPI in the GIC distributor (GICD_ICENABLER).
 ///
 /// Only valid for IRQs >= 32 (SPIs).

--- a/kernel/src/drivers/ahci/mod.rs
+++ b/kernel/src/drivers/ahci/mod.rs
@@ -200,6 +200,12 @@ static AHCI_ABAR: AtomicU64 = AtomicU64::new(0);
 /// GIC SPI number allocated for AHCI MSI/MSI-X/wired. 0 = polling mode.
 static AHCI_IRQ: AtomicU32 = AtomicU32::new(0);
 
+/// Returns the SPI number currently allocated to AHCI, or 0 if AHCI has not
+/// been initialized / no SPI was allocated.
+pub fn ahci_irq() -> u32 {
+    AHCI_IRQ.load(core::sync::atomic::Ordering::Acquire)
+}
+
 /// Whether the AHCI IRQ is edge-triggered (MSI) or level-triggered (wired).
 /// For edge-triggered, the ISR must clear the SPI pending bit.
 /// For level-triggered, clearing PORT_IS de-asserts the line; no SPI clear needed.

--- a/kernel/src/drivers/ahci/mod.rs
+++ b/kernel/src/drivers/ahci/mod.rs
@@ -2239,15 +2239,33 @@ fn probe_platform_irq(ctrl: &AhciController) {
 
     crate::serial_println!("[ahci] Platform IRQ probe: discovered SPI {}", found_spi);
 
-    gic::clear_spi_pending(found_spi);
-    AHCI_IRQ_EDGE.store(false, Ordering::Release);
-    AHCI_IRQ.store(found_spi, Ordering::Release);
-    // Route platform AHCI away from CPU0; on Parallels, CPU0 delivery can stop its timer.
-    gic::enable_spi_on_cpu(found_spi, 2);
-    crate::serial_println!(
-        "[ahci] Platform IRQ enabled: SPI {} (wired, level-triggered)",
-        found_spi
-    );
+    #[cfg(target_arch = "aarch64")]
+    {
+        // Parallels GICv3 quirk (Turn 10 E4): GICD_IROUTER writes are RAZ/WI for
+        // platform AHCI SPI even with GICD_CTLR.ARE_NS set. Combined with the
+        // observation that AHCI ISR delivery on CPU0 deterministically kills the
+        // CPU0 vtimer on Parallels HVF (Turn 11 Path A, 5/5 boots), the only
+        // production-safe configuration on aarch64 is AHCI polling mode.
+        //
+        // The existing AHCI driver path already uses timer-tick polling when
+        // AHCI_IRQ remains 0. Silence the discovered SPI in the distributor and
+        // return without storing AHCI_IRQ.
+        gic::disable_spi(found_spi);
+        return;
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        gic::clear_spi_pending(found_spi);
+        AHCI_IRQ_EDGE.store(false, Ordering::Release);
+        AHCI_IRQ.store(found_spi, Ordering::Release);
+        // Route platform AHCI away from CPU0; on Parallels, CPU0 delivery can stop its timer.
+        gic::enable_spi_on_cpu(found_spi, 2);
+        crate::serial_println!(
+            "[ahci] Platform IRQ enabled: SPI {} (wired, level-triggered)",
+            found_spi
+        );
+    }
 }
 
 /// AHCI MSI interrupt handler — called from the IRQ dispatch in `exception.rs`.

--- a/kernel/src/drivers/ahci/mod.rs
+++ b/kernel/src/drivers/ahci/mod.rs
@@ -2236,7 +2236,8 @@ fn probe_platform_irq(ctrl: &AhciController) {
     gic::clear_spi_pending(found_spi);
     AHCI_IRQ_EDGE.store(false, Ordering::Release);
     AHCI_IRQ.store(found_spi, Ordering::Release);
-    gic::enable_spi(found_spi);
+    // Route platform AHCI away from CPU0; on Parallels, CPU0 delivery can stop its timer.
+    gic::enable_spi_on_cpu(found_spi, 2);
     crate::serial_println!(
         "[ahci] Platform IRQ enabled: SPI {} (wired, level-triggered)",
         found_spi

--- a/kernel/src/main_aarch64.rs
+++ b/kernel/src/main_aarch64.rs
@@ -981,17 +981,6 @@ pub extern "C" fn kernel_main(hw_config_ptr: u64) -> ! {
         if ahci_irq != 0 {
             kernel::arch_impl::aarch64::gic::enable_spi_on_cpu(ahci_irq, 2);
         }
-        // TURN 11 DIAGNOSTIC PROBE: disable AHCI SPI to test whether AHCI ISR delivery
-        // on CPU0 is the proximate cause of CPU0 vtimer regression. Parallels' GIC
-        // silently drops GICD_IROUTER writes (Turn 10 E4 verdict), so we cannot move
-        // AHCI off CPU0 via standard mechanisms. By disabling the SPI entirely, AHCI
-        // will fall back to no interrupt delivery (polling-only via the existing
-        // driver code paths). If CPU0 timer regression DISAPPEARS in this run, AHCI
-        // ISR on CPU0 is confirmed as the cause. If it PERSISTS, AHCI is innocent
-        // and the bug lives in the vtimer / CPU0 interrupt path.
-        if ahci_irq != 0 {
-            kernel::arch_impl::aarch64::gic::disable_spi(ahci_irq);
-        }
     }
 
     // Test kthread lifecycle BEFORE creating userspace processes

--- a/kernel/src/main_aarch64.rs
+++ b/kernel/src/main_aarch64.rs
@@ -971,6 +971,16 @@ pub extern "C" fn kernel_main(hw_config_ptr: u64) -> ! {
         kernel::arch_impl::aarch64::gic::init_gicr_rdist_map(
             kernel::arch_impl::aarch64::smp::cpus_online() as usize,
         );
+        // Re-apply AHCI SPI routing now that the per-CPU redistributor affinity
+        // map is initialized. The early call in AHCI init ran before SMP bring-up
+        // and used `expected_gicr_affinity_for_cpu` as a fallback, which does
+        // not match Parallels' actual CPU2 affinity. Without this re-route, AHCI
+        // SPI34 continues to deliver on CPU0, which correlates with the CPU0
+        // vtimer regression class seen in Turn 5-8.
+        let ahci_irq = kernel::drivers::ahci::ahci_irq();
+        if ahci_irq != 0 {
+            kernel::arch_impl::aarch64::gic::enable_spi_on_cpu(ahci_irq, 2);
+        }
     }
 
     // Test kthread lifecycle BEFORE creating userspace processes

--- a/kernel/src/main_aarch64.rs
+++ b/kernel/src/main_aarch64.rs
@@ -981,6 +981,17 @@ pub extern "C" fn kernel_main(hw_config_ptr: u64) -> ! {
         if ahci_irq != 0 {
             kernel::arch_impl::aarch64::gic::enable_spi_on_cpu(ahci_irq, 2);
         }
+        // TURN 11 DIAGNOSTIC PROBE: disable AHCI SPI to test whether AHCI ISR delivery
+        // on CPU0 is the proximate cause of CPU0 vtimer regression. Parallels' GIC
+        // silently drops GICD_IROUTER writes (Turn 10 E4 verdict), so we cannot move
+        // AHCI off CPU0 via standard mechanisms. By disabling the SPI entirely, AHCI
+        // will fall back to no interrupt delivery (polling-only via the existing
+        // driver code paths). If CPU0 timer regression DISAPPEARS in this run, AHCI
+        // ISR on CPU0 is confirmed as the cause. If it PERSISTS, AHCI is innocent
+        // and the bug lives in the vtimer / CPU0 interrupt path.
+        if ahci_irq != 0 {
+            kernel::arch_impl::aarch64::gic::disable_spi(ahci_irq);
+        }
     }
 
     // Test kthread lifecycle BEFORE creating userspace processes


### PR DESCRIPTION
## Summary

This branch fixes three ARM64 Parallels HVF boot/workload failure classes: the inline scheduler trampoline mutex leak, the AHCI-triggered CPU0 virtual timer death, and the inline ret-dispatch resume-PC contract violation.

## Fixes

| Class | Commit | File:Function |
|---|---|---|
| Scheduler mutex leak silent freeze | `f434f5d7` (building on `b430b2ad`) | `kernel/src/arch_impl/aarch64/context_switch.rs::inline_schedule_trampoline` |
| CPU0 vtimer death via AHCI ISR | `ede8246a` | `kernel/src/drivers/ahci/mod.rs::probe_platform_irq` |
| Inline ret-dispatch resume-PC contract | `5c11937e` | `kernel/src/arch_impl/aarch64/context_switch.rs::take_inline_ret_dispatch_info` |

## Root causes

1. **Scheduler mutex leak:** `inline_schedule_trampoline`'s null-`scheduler_ptr` fallback didn't release the leaked scheduler lock or prepare idle return state before branching to `idle_loop_arm64`, causing `schedule_from_kernel` to spin on the global mutex.
2. **CPU0 vtimer death:** Parallels HVF's GIC silently drops `GICD_IROUTER[N]` writes for the platform AHCI SPI even with `GICD_CTLR.ARE_NS` set (proven 5/5 via atomic readback). AHCI ISRs delivered to CPU0 deterministically kill its virtual timer. Fix is to force polling mode on aarch64 — leave `AHCI_IRQ=0` and disable the discovered SPI before storing it.
3. **Inline ret-dispatch contract:** The inline switch assembly saves the safe post-inline-switch return PC in `context.x30` but only restores callee-saved registers + SP. Pre-fix code used `context.elr_el1` as the resume PC, which could be a mid-function PC inside `schedule_from_kernel`. Resuming there required volatile registers that weren't restored, faulting at `FAR=0x7c9` (decoded: `str x10, [x9, #0x7c8]` with stale `x9=0x1`).

## Validation

- Turn 5 (scheduler mutex fix): 5/5 runs with `sched_lock=ok`, 0/5 BAD_THREAD_SP / IDLE_CTX markers, original silent-freeze class eliminated.
- Turn 12 (AHCI polling fix): 0/5 CPU0 timer regression, 0/5 AHCI timeouts, 0/5 BAD_THREAD_SP, 5/5 endpoint GDB confirms AHCI polling (`ahci_irq=0`, `ahci_isr_count=0`).
- Turn 15 (inline ret-dispatch fix): 1/1 targeted pass + 4/5 stress pass. Across all 6 boots: 0 \`queue_empty stuck_tid=13\`, 0 \`FAR=0x7c9\`, no recurrence of the Turn 13 dominant rescue-abort signature.

Full audit trail (16 turns): \`/Users/wrb/Downloads/Ralph/breenix-scheduler-mutex-leak-1779100838/\`.

## Test plan

- [x] aarch64 release build clean (0 warnings/errors)
- [x] qemu-uefi release build clean (0 warnings/errors)
- [x] \`git diff --check\` clean
- [x] Targeted BWM boot on Parallels (Turn 15 Run 1): PASS
- [x] 5-boot Parallels stress on Parallels (Turn 15 Runs 2-6): 4/5 PASS, 1 GPU-residual (see Follow-up below)
- [ ] CI gate runs on this PR

## Follow-up (separate investigation)

One known residual remains outside this investigation's ownership: a virtio-gpu \`send_command\` near-null deref with \`FAR=0xccd ELR=0xffff000040104484\` at \`ldrh w8, [x17, #0xccc]\`. Observed 1/6 in Turn 13 stress and 1/6 in Turn 15 stress — rate unchanged by these fixes, confirming it's orthogonal. This is a virtio-gpu driver/MMIO polling bug, not a scheduler bug. Captures available at \`turn13-artifacts/reproduce-run5/\` and \`turn15-artifacts/reproduce-run4/\`. A separate Ralph investigation will be opened for it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>