### PR TITLE
fix(aarch64,net): VMware Fusion network work-in-progress + EOImode platform-gate

### DIFF
--- a/kernel/src/arch_impl/aarch64/gic.rs
+++ b/kernel/src/arch_impl/aarch64/gic.rs
@@ -241,6 +241,11 @@ static USE_GROUP0: AtomicBool = AtomicBool::new(false);
 /// the hypervisor/firmware maps Group 0 physical delivery to Group 1 NS.
 static DS_ENABLED: AtomicBool = AtomicBool::new(false);
 
+/// Whether this platform supports split EOI/DIR interrupt deactivation.
+/// VMware Fusion's HVF rejects two-step deactivation, so it stays in
+/// EOImode=0 and performs EOI+deactivate together after the handler.
+static SPLIT_DEACTIVATE_SUPPORTED: AtomicBool = AtomicBool::new(false);
+
 /// Tracks which group the last acknowledged interrupt came from.
 /// 0 = Group 1 (normal), 1 = Group 0. Per-CPU would be ideal but
 /// a single atomic suffices for the boot CPU (VMware is single-CPU for now).
@@ -694,15 +699,8 @@ pub fn acknowledge_irq() -> Option<u32> {
 pub fn priority_drop_irq(irq_id: u32) {
     let version = ACTIVE_GIC_VERSION.load(Ordering::Relaxed);
     if version >= 3 {
-        let group = LAST_ACK_GROUP.load(Ordering::Relaxed);
-        if group == 0 && DS_ENABLED.load(Ordering::Relaxed) {
-            unsafe {
-                core::arch::asm!("msr icc_eoir0_el1, {}", in(reg) irq_id as u64, options(nomem, nostack));
-            }
-        } else {
-            unsafe {
-                core::arch::asm!("msr icc_eoir1_el1, {}", in(reg) irq_id as u64, options(nomem, nostack));
-            }
+        if SPLIT_DEACTIVATE_SUPPORTED.load(Ordering::Acquire) {
+            write_gicv3_eoir(irq_id);
         }
     }
 }
@@ -712,12 +710,30 @@ pub fn priority_drop_irq(irq_id: u32) {
 pub fn deactivate_irq(irq_id: u32) {
     let version = ACTIVE_GIC_VERSION.load(Ordering::Relaxed);
     if version >= 3 {
-        unsafe {
-            core::arch::asm!("msr icc_dir_el1, {}", in(reg) irq_id as u64, options(nomem, nostack));
+        if SPLIT_DEACTIVATE_SUPPORTED.load(Ordering::Acquire) {
+            unsafe {
+                core::arch::asm!("msr icc_dir_el1, {}", in(reg) irq_id as u64, options(nomem, nostack));
+            }
+        } else {
+            write_gicv3_eoir(irq_id);
         }
     } else {
         // GICv2: Write GICC_EOIR
         gicc_write(GICC_EOIR, irq_id);
+    }
+}
+
+#[inline(always)]
+fn write_gicv3_eoir(irq_id: u32) {
+    let group = LAST_ACK_GROUP.load(Ordering::Relaxed);
+    if group == 0 && DS_ENABLED.load(Ordering::Relaxed) {
+        unsafe {
+            core::arch::asm!("msr icc_eoir0_el1, {}", in(reg) irq_id as u64, options(nomem, nostack));
+        }
+    } else {
+        unsafe {
+            core::arch::asm!("msr icc_eoir1_el1, {}", in(reg) irq_id as u64, options(nomem, nostack));
+        }
     }
 }
 
@@ -1522,15 +1538,26 @@ fn init_gicv3_cpu_interface() {
         core::arch::asm!("msr icc_sre_el1, {}", in(reg) sre, options(nomem, nostack));
         core::arch::asm!("isb", options(nomem, nostack));
 
-        // Explicitly set ICC_CTLR_EL1.EOImode = 1 (bit 1) so GICv3 uses split
-        // priority-drop and deactivate semantics. This matches Linux's regular
-        // gic_handle_irq() admission path: EOIR before handler dispatch, DIR
-        // after the handler body completes.
+        let supports_split = !crate::platform_config::is_vmware();
+        SPLIT_DEACTIVATE_SUPPORTED.store(supports_split, Ordering::Release);
+
+        // Set ICC_CTLR_EL1.EOImode from platform support. Split mode matches
+        // Linux's regular gic_handle_irq() path; VMware Fusion stays in
+        // single-step mode because HVF rejects ICC_DIR_EL1 deactivation.
         let icc_ctlr: u64;
         core::arch::asm!("mrs {}, icc_ctlr_el1", out(reg) icc_ctlr, options(nomem, nostack));
-        let new_ctlr = icc_ctlr | (1u64 << 1);
+        let new_ctlr = if supports_split {
+            icc_ctlr | (1u64 << 1)
+        } else {
+            icc_ctlr & !(1u64 << 1)
+        };
         core::arch::asm!("msr icc_ctlr_el1, {}", in(reg) new_ctlr, options(nomem, nostack));
         core::arch::asm!("isb", options(nostack, preserves_flags));
+        if supports_split {
+            crate::serial_println!("[gic] EOImode=1 (split EOI/DIR) - non-VMware path");
+        } else {
+            crate::serial_println!("[gic] EOImode=0 (single-step EOI+deactivate) - VMware path");
+        }
         crate::serial_println!(
             "[gic] ICC_CTLR_EL1: {:#x} -> {:#x} (EOImode={})",
             icc_ctlr,

--- a/kernel/src/drivers/e1000/mod.rs
+++ b/kernel/src/drivers/e1000/mod.rs
@@ -163,6 +163,112 @@ impl E1000 {
         unsafe { write_volatile((self.mmio_base + reg as usize) as *mut u32, value) }
     }
 
+    /// Poll MDIC until the MAC finishes a PHY transaction.
+    ///
+    /// Linux e1000e does the same bounded READY poll in
+    /// drivers/net/ethernet/intel/e1000e/phy.c:141-156 and :195-210.
+    fn poll_mdic_ready(&self) -> Result<u32, &'static str> {
+        for _ in 0..100_000 {
+            let mdic = self.read_reg(REG_MDIC);
+            if mdic & MDIC_READY != 0 {
+                return Ok(mdic);
+            }
+            core::hint::spin_loop();
+        }
+
+        Err("MDIC timeout")
+    }
+
+    /// Read one PHY register through MDIC.
+    ///
+    /// Matches Linux e1000e's MDIC read command shape in
+    /// drivers/net/ethernet/intel/e1000e/phy.c:119-170.
+    fn read_phy_reg(&self, reg: u32) -> Result<u16, &'static str> {
+        if reg > 0x1f {
+            return Err("PHY register out of range");
+        }
+
+        let mdic = (reg << MDIC_REG_SHIFT) | (PHY_ADDR_82574 << MDIC_PHY_SHIFT) | MDIC_OP_READ;
+        self.write_reg(REG_MDIC, mdic);
+
+        let mdic = self.poll_mdic_ready()?;
+        if mdic & MDIC_ERROR != 0 {
+            return Err("MDIC read error");
+        }
+        if ((mdic & MDIC_REG_MASK) >> MDIC_REG_SHIFT) != reg {
+            return Err("MDIC read offset mismatch");
+        }
+
+        Ok((mdic & MDIC_DATA_MASK) as u16)
+    }
+
+    /// Write one PHY register through MDIC.
+    ///
+    /// Matches Linux e1000e's MDIC write command shape in
+    /// drivers/net/ethernet/intel/e1000e/phy.c:176-224.
+    fn write_phy_reg(&self, reg: u32, data: u16) -> Result<(), &'static str> {
+        if reg > 0x1f {
+            return Err("PHY register out of range");
+        }
+
+        let mdic = (data as u32)
+            | (reg << MDIC_REG_SHIFT)
+            | (PHY_ADDR_82574 << MDIC_PHY_SHIFT)
+            | MDIC_OP_WRITE;
+        self.write_reg(REG_MDIC, mdic);
+
+        let mdic = self.poll_mdic_ready()?;
+        if mdic & MDIC_ERROR != 0 {
+            return Err("MDIC write error");
+        }
+        if ((mdic & MDIC_REG_MASK) >> MDIC_REG_SHIFT) != reg {
+            return Err("MDIC write offset mismatch");
+        }
+
+        Ok(())
+    }
+
+    /// Restart copper PHY autoneg on VMware's 82574L.
+    ///
+    /// This is the minimal BM/M88 setup path from Linux e1000e:
+    /// MDIC transactions from phy.c:119-232, copper setup from phy.c:675-812,
+    /// and autoneg start/check flow from phy.c:1135-1175 and :1728-1762.
+    fn init_phy_82574(&self) {
+        let control = match self.read_phy_reg(PHY_CONTROL) {
+            Ok(control) => control,
+            Err(err) => {
+                #[cfg(target_arch = "x86_64")]
+                log::warn!("E1000: 82574 PHY control read failed: {}", err);
+                #[cfg(target_arch = "aarch64")]
+                crate::serial_println!("[e1000] 82574 PHY control read failed: {}", err);
+                return;
+            }
+        };
+
+        let new_control = control | PHY_CONTROL_AUTONEG_EN | PHY_CONTROL_RESTART_AUTONEG;
+        if let Err(err) = self.write_phy_reg(PHY_CONTROL, new_control) {
+            #[cfg(target_arch = "x86_64")]
+            log::warn!("E1000: 82574 PHY autoneg restart failed: {}", err);
+            #[cfg(target_arch = "aarch64")]
+            crate::serial_println!("[e1000] 82574 PHY autoneg restart failed: {}", err);
+            return;
+        }
+
+        let status = self.read_phy_reg(PHY_STATUS).unwrap_or(0);
+        #[cfg(target_arch = "x86_64")]
+        log::info!(
+            "E1000: 82574 PHY autoneg restarted (PHY_CONTROL={:#x}, PHY_STATUS={:#x})",
+            new_control,
+            status
+        );
+        #[cfg(target_arch = "aarch64")]
+        crate::serial_println!(
+            "[e1000] 82574 PHY autoneg restarted (PHY_CONTROL={:#x}, PHY_STATUS={:#x})",
+            new_control,
+            status
+        );
+    }
+
     /// Read MAC address from EEPROM (with timeout)
     /// Returns None if the EEPROM doesn't respond within the timeout.
     fn read_eeprom(&self, addr: u8) -> Option<u16> {
@@ -315,6 +421,20 @@ impl E1000 {
         // IPG transmit time: 10 + 8 + 6 (for IEEE 802.3 standard)
         self.write_reg(REG_TIPG, 10 | (8 << 10) | (6 << 20));
 
+        if self.device_id == E1000E_DEVICE_ID {
+            let threshold_mask = TXDCTL_PTHRESH | TXDCTL_HTHRESH | TXDCTL_WTHRESH;
+            let mut txdctl = self.read_reg(REG_TXDCTL);
+            txdctl &= !threshold_mask;
+            txdctl |= TXDCTL_MAX_TX_DESC_PREFETCH | TXDCTL_FULL_TX_DESC_WB | TXDCTL_COUNT_DESC;
+            self.write_reg(REG_TXDCTL, txdctl);
+            self.write_reg(REG_TXDCTL1, txdctl);
+
+            #[cfg(target_arch = "x86_64")]
+            log::info!("E1000: 82574 TXDCTL writeback policy {:#x}", txdctl);
+            #[cfg(target_arch = "aarch64")]
+            crate::serial_println!("[e1000] 82574 TXDCTL writeback policy {:#x}", txdctl);
+        }
+
         #[cfg(target_arch = "x86_64")]
         log::info!("E1000: TX initialized with {} descriptors", TX_RING_SIZE);
         #[cfg(target_arch = "aarch64")]
@@ -345,8 +465,13 @@ impl E1000 {
     /// Enable link
     fn enable_link(&self) {
         let ctrl = self.read_reg(REG_CTRL);
-        // Set Link Up, Auto-Speed Detection Enable
+        // Set Link Up and Auto-Speed Detection Enable, matching Linux
+        // drivers/net/ethernet/intel/e1000e/82571.c:1421-1429.
         self.write_reg(REG_CTRL, ctrl | CTRL_SLU | CTRL_ASDE);
+
+        if self.device_id == E1000E_DEVICE_ID {
+            self.init_phy_82574();
+        }
     }
 
     /// Check if link is up

--- a/kernel/src/drivers/e1000/regs.rs
+++ b/kernel/src/drivers/e1000/regs.rs
@@ -36,6 +36,8 @@ pub const REG_ICS: u32 = 0x00C8;
 pub const REG_IMS: u32 = 0x00D0;
 /// Interrupt Mask Clear
 pub const REG_IMC: u32 = 0x00D8;
+/// MDI Control (Linux e1000e regs.h:13)
+pub const REG_MDIC: u32 = 0x0020;
 
 // Receive Registers
 /// Receive Control Register
@@ -80,6 +82,41 @@ pub const REG_TDT: u32 = 0x3818;
 pub const REG_TIDV: u32 = 0x3820;
 /// Transmit Absolute Interrupt Delay Value
 pub const REG_TADV: u32 = 0x382C;
+/// Transmit Descriptor Control 0 (Linux e1000e regs.h:104)
+pub const REG_TXDCTL: u32 = 0x3828;
+/// Transmit Descriptor Control 1 (Linux e1000e regs.h:104)
+pub const REG_TXDCTL1: u32 = 0x3928;
+
+// TXDCTL bitfields match Linux e1000e defines.h:458-465.
+pub const TXDCTL_PTHRESH: u32 = 0x0000003F;
+pub const TXDCTL_HTHRESH: u32 = 0x00003F00;
+pub const TXDCTL_WTHRESH: u32 = 0x003F0000;
+pub const TXDCTL_GRAN: u32 = 0x01000000;
+pub const TXDCTL_FULL_TX_DESC_WB: u32 = 0x01010000;
+pub const TXDCTL_MAX_TX_DESC_PREFETCH: u32 = 0x0100001F;
+pub const TXDCTL_COUNT_DESC: u32 = 0x00400000;
+
+// MDIC bitfields match Linux e1000e defines.h:797-803 and e1000_hw.h:1585-1594.
+pub const MDIC_DATA_MASK: u32 = 0x0000FFFF;
+pub const MDIC_REG_MASK: u32 = 0x001F0000;
+pub const MDIC_REG_SHIFT: u32 = 16;
+pub const MDIC_PHY_SHIFT: u32 = 21;
+pub const MDIC_OP_WRITE: u32 = 0x04000000;
+pub const MDIC_OP_READ: u32 = 0x08000000;
+pub const MDIC_READY: u32 = 0x10000000;
+pub const MDIC_INT_EN: u32 = 0x20000000;
+pub const MDIC_ERROR: u32 = 0x40000000;
+
+// 82574 PHY address follows Linux e1000e phy.c MDIC access via hw->phy.addr.
+pub const PHY_ADDR_82574: u32 = 1;
+
+// Standard MII registers and BMCR/BMSR bits match Linux include/uapi/linux/mii.h:16-57.
+pub const PHY_CONTROL: u32 = 0x00;
+pub const PHY_STATUS: u32 = 0x01;
+pub const PHY_AUTONEG_ADV: u32 = 0x04;
+pub const PHY_CONTROL_RESTART_AUTONEG: u16 = 0x0200;
+pub const PHY_CONTROL_AUTONEG_EN: u16 = 0x1000;
+pub const PHY_STATUS_LINK_UP: u16 = 0x0004;
 
 // Receive Address Registers
 /// Receive Address Low

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -31,6 +31,9 @@ use crate::drivers::virtio::net_pci;
 
 use crate::task::softirqd::{register_softirq_handler, SoftirqType};
 
+const E1000_CARRIER_WAIT_MS: u32 = 5000;
+const E1000_CARRIER_POLL_MS: u32 = 50;
+
 /// Disable IRQs and return saved DAIF state. Prevents timer interrupt →
 /// softirq → process_rx from deadlocking on shared locks (ARP_CACHE,
 /// NET_CONFIG) that the interrupted thread may hold.
@@ -122,6 +125,9 @@ fn get_mac_address() -> Option<[u8; 6]> {
 fn driver_transmit(data: &[u8]) -> Result<(), &'static str> {
     #[cfg(target_arch = "x86_64")]
     {
+        if !e1000::link_up() {
+            return Err("e1000 link down");
+        }
         e1000::transmit(data)
     }
     #[cfg(target_arch = "aarch64")]
@@ -129,10 +135,24 @@ fn driver_transmit(data: &[u8]) -> Result<(), &'static str> {
         if net_pci::is_initialized() {
             net_pci::transmit(data)
         } else if e1000::is_initialized() {
+            if !e1000::link_up() {
+                return Err("e1000 link down");
+            }
             e1000::transmit(data)
         } else {
             net_mmio::transmit(data)
         }
+    }
+}
+
+fn active_tx_driver_is_e1000() -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        e1000::is_initialized()
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        !net_pci::is_initialized() && e1000::is_initialized()
     }
 }
 
@@ -356,6 +376,32 @@ fn init_common() {
     arp::init();
 
     net_log!("Network stack initialized");
+
+    if active_tx_driver_is_e1000() {
+        // Linux e1000e only wakes TX/carrier after link is confirmed:
+        // drivers/net/ethernet/intel/e1000e/netdev.c:5197-5304.
+        let mut elapsed_ms = 0;
+        while !e1000::link_up() && elapsed_ms < E1000_CARRIER_WAIT_MS {
+            for _ in 0..2_500_000u32 {
+                core::hint::spin_loop();
+            }
+            elapsed_ms += E1000_CARRIER_POLL_MS;
+        }
+
+        if e1000::link_up() {
+            net_log!(
+                "[net] e1000 link up after {}ms -- proceeding with ARP",
+                elapsed_ms
+            );
+        } else {
+            net_log!(
+                "[net] e1000 link did not come up after {}ms -- skipping ARP (carrier-gated)",
+                E1000_CARRIER_WAIT_MS
+            );
+            net_log!("NET: Network initialization complete");
+            return;
+        }
+    }
 
     // Send ARP request for gateway to test network connectivity
     let gateway = gw;

--- a/turn6-validation.md
+++ b/turn6-validation.md
@@ -1,0 +1,66 @@
+# Turn 6 Validation
+
+## Scope
+
+- Source change limited to `kernel/src/arch_impl/aarch64/gic.rs`.
+- Added a runtime split-deactivate gate:
+  - VMware Fusion: `EOImode=0` single-step EOI+deactivate.
+  - Parallels/non-VMware: `EOImode=1` split EOI/DIR preserved.
+- `exception.rs` call sites unchanged.
+
+## Build Gate
+
+Artifacts are under:
+
+`/Users/wrb/Downloads/Ralph/breenix-vmware-feature-parity-1779352066/turn6-artifacts`
+
+Commands run:
+
+- `./userspace/programs/build.sh --arch aarch64`
+- `./scripts/create_ext2_disk.sh --arch aarch64`
+- `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64`
+- `cargo build --release --features testing,external_test_bins --bin qemu-uefi`
+- `scripts/parallels/build-efi.sh --kernel`
+
+All warning/error grep artifacts are 0 bytes.
+
+## VMware Boot Gate
+
+Single boot artifact directory:
+
+`/Users/wrb/Downloads/Ralph/breenix-vmware-feature-parity-1779352066/turn6-artifacts/vmware-boot-1`
+
+Pass evidence:
+
+- `EOImode=0 (single-step EOI+deactivate) - VMware path`
+- `ICC_CTLR_EL1: 0x400 -> 0x400 (EOImode=0)`
+- `GIC initialized (version 3)`
+- `4 CPUs online`
+- `Breenix ARM64 Boot Complete!`
+- Reached userspace and ran `bcheck`.
+- CPU0 timer ticks reached `70000`.
+- No `EOR/DIR two-step deactivation is not supported` VMX panic.
+
+Remaining VMware gap observed: e1000 TX timeout causes DNS/http checks to fail.
+
+## Parallels Boot Gate
+
+Single boot command:
+
+- `./run.sh --parallels --test 65`
+
+Pass evidence:
+
+- `EOImode=1 (split EOI/DIR) - non-VMware path`
+- CPU0 regression scan: 0 bytes.
+- Heartbeat reached `uptime_ms=112298`.
+- CPU0 timer ticks reached `75000`.
+- T33 network markers present:
+  - VirtIO GPU PCI initialized.
+  - VirtIO-net MSI-X SPI 55 enabled post-init.
+  - Callback suppression synchronously cleared.
+  - NetRx softirq pre-primed.
+- Live ping to `10.211.55.100`: 1 transmitted, 1 received, 0.0% packet loss.
+- AHCI/ext2 sanity: `[ext2] Found ext2 superblock on AHCI device 1`.
+
+Result: COMPLETE/PASS.


### PR DESCRIPTION
## Summary

Brings up VMware Fusion as a supported ARM64 target through to userspace, with substantial-but-incomplete work on the VMware e1000 network path. Bundles two commits on `fix/vmware-gic-eoimode`:

1. **`17f57d92`** — *fix(aarch64): platform-gate GIC EOImode for VMware Fusion compatibility* (T6, already validated)
2. **`8e739225`** — *feat(aarch64,net): VMware Fusion e1000 work-in-progress — TXDCTL + carrier gate + MDIC/PHY* (T8+T10+T11 bundled, work-in-progress)

### What works

- **VMware Fusion ARM64 boot reaches userspace** with 4 CPUs online, AHCI/ext2 mount, bcheck running (21/23 — only DNS + HTTP fail due to known link-down state). Previously panicked with `EOR/DIR two-step deactivation is not supported`.
- **Parallels regression: clean.** EOImode=1 path preserved, VirtIO GPU + net initialized, ext2 mount, Boot Complete, `cpu0 ticks=95000`, `uptime_ms=60346`, CPU0 regression scan 0 bytes, warning scan 0 bytes. All e1000 changes are no-op on Parallels (VirtIO-net path doesn't traverse them).
- **Carrier gate eliminates phantom TX timeouts** — Breenix no longer floods the serial log with `TX timeout TDH=0 TDT=N desc.status=0x0` when the link is genuinely down. This is independently valuable kernel hygiene.
- **MDIC PHY infrastructure now exists** — `read_phy_reg`/`write_phy_reg` helpers + 82574 PHY autoneg restart. Validated end-to-end on VMware (`PHY_CONTROL=0x1340, PHY_STATUS=0x7949` are real 16-bit register reads from the emulated PHY).

### What does NOT work (yet)

- **VMware e1000 link never comes up.** Autoneg gets restarted (`BMCR.AUTONEG_EN | RESTART_AUTONEG`), but the PHY never raises `BMSR.AUTONEG_COMPLETE` (bit 5) or `BMSR.LINK_STATUS` (bit 2) within the 5s carrier wait. bcheck DNS + HTTP fail as a consequence. **See REMAINING WORK below.**
- **Parallels live ping host→VM** returned 0/1 received in the most recent validation. This is **not a regression from this PR** (e1000 source is no-op on Parallels' VirtIO-net path). It's pre-existing Breenix ICMP-echo-responder flakiness or Parallels bridge filtering. T6 happened to capture ping success once; later boots haven't.

## Test plan

- [x] `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` clean (0 warnings)
- [x] `cargo build --release --features testing,external_test_bins --bin qemu-uefi` clean (0 warnings)
- [x] `scripts/parallels/build-efi.sh --kernel` clean
- [x] VMware Fusion boot reaches userspace; new T8/T10/T11 markers appear in serial
- [x] Parallels regression boot: EOImode=1 path preserved, no CPU0 regression alarm, ext2 mount, ticks ≥ 35000, uptime ≥ 60000ms

## Linux references (every constant cited in code comments)

- `drivers/net/ethernet/intel/e1000e/82571.c:1101-1105` — 82574 TXDCTL setup
- `drivers/net/ethernet/intel/e1000e/netdev.c:2942-2960` — generic e1000e TX configure with DMA_BURST_ENABLE
- `drivers/net/ethernet/intel/e1000e/defines.h:457-465` — TXDCTL bitfield constants
- `drivers/net/ethernet/intel/e1000e/netdev.c:5197-5304` — watchdog carrier gating pattern
- `drivers/net/ethernet/intel/e1000e/phy.c:119-232` — MDIC transaction shape
- `drivers/net/ethernet/intel/e1000e/82571.c:45-113` — 82574 PHY type/ops setup
- `drivers/irqchip/irq-gic-v3.c:2006-2007` — `supports_deactivate_key` gated on `is_hyp_mode_available()`

## REMAINING WORK — for a future session

> *Pick up where we left off on VMware:* the foundation is committed; the remaining work is narrow and well-mapped.

### Empirical state to start from

- Branch state after this PR merges: T6 EOImode platform-gate + this T8+T10+T11 bundle on `main`
- VMware boot reaches userspace; carrier gate fires; PHY autoneg restart fires; *link never comes up within 5s*
- Reading `PHY_STATUS=0x7949`: AUTONEG_ABILITY set (bit 3), AUTONEG_COMPLETE = 0, LINK_STATUS = 0

### The remaining gap (T12+ work)

Linux's `e1000_copper_link_setup_*` does substantially more than `BMCR autoneg restart`. The likely missing pieces (ranked by expected impact):

1. **Write `MII_ADVERTISE` (PHY reg 0x04)** before `RESTART_AUTONEG`. Linux explicitly programs what speed/duplex pairs the PHY should advertise. Breenix never touches reg 0x04, so the device's reset-default advertisement may not match what VMware's link partner expects.
2. **PHY soft reset** — write `BMCR.RESET` (bit 15 = 0x8000) before configuring. Linux does this; Breenix doesn't.
3. **Switch link detection from `STATUS_LU` (MAC-side) to `BMSR.LINK_STATUS` (PHY-side, reg 0x01 bit 2)**. Breenix currently polls `STATUS_LU` which only asserts when the MAC sees an LSC event; reading BMSR directly may bypass an LSC-handling gap.
4. **LSC IRQ handling** — link-up may be inherently async; Breenix's carrier wait is bounded at 5s but may simply be too short if VMware needs >5s to negotiate. Add LSC IRQ handler to update an atomic link-state flag from interrupt context.
5. **BM PHY-specific config** — Linux's `e1000_copper_link_setup_bm` writes downshift, MDI/MDIX, polarity per the BM-family PHY. May or may not matter for VMware.

### Recommended next-session bootstrap

Where to resume:
1. **Read** `/Users/wrb/Downloads/Ralph/breenix-vmware-feature-parity-1779352066/final-2026-05-21T103349Z.md` for the full campaign retro (T1-T11 with status, evidence, and decision tree)
2. **Read** `turn9-artifacts/link-up-verdict.md` for the T9 Linux-profile analysis (still valid)
3. **Read** `turn9-artifacts/citation-pack.txt` + the `linux-phy-*-numbered.txt` files for Linux source extracts
4. **Re-fire the T12 directive** (intact at the project's `current-directive.md`) — it dispatches deeper Linux-profile analysis of full 82574 copper link setup
5. **Or skip T12 and try option 1 directly** — write `MII_ADVERTISE` (reg 0x04) with a sensible advertisement (e.g., all-speeds-full-duplex = `0x01E1`) before `RESTART_AUTONEG`, rebuild, boot — that's a ~5-line source change

### Parallels regression-harness fragility (separate issue)

The Parallels host→VM live-ping result is unreliable. Two possible root causes:
- **Breenix's ICMP echo responder may be broken** — kernel receives ICMP echo requests but doesn't reply. Worth grep'ing `kernel/src/net/` for ICMP receive handling and verifying a packet-receive path actually sends ECHO_REPLY.
- **Parallels host bridge filtering** — macOS pf or bridge100 interface may drop ICMP from VM. Unlikely if T6 worked once.

This is independent of the VMware work and shouldn't block future VMware iterations.

### What this PR does NOT include

- USB HID parity with Parallels (still on goal contract)
- VMware GPU display quality work (likely VirGL-on-VMware-VMX investigation)
- Performance benchmarks (bounce demo FPS comparison, etc.)
- VMware live ping success (blocked on link-up above)
- Parallels ICMP echo responder fix

These are all candidates for follow-up campaigns once VMware link-up is solved.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)