### PR TITLE
fix(bwm): use full window bounds (not content rect) as occluder for span clip

### DIFF
--- a/userspace/programs/src/bwm.rs
+++ b/userspace/programs/src/bwm.rs
@@ -1186,7 +1186,7 @@ fn redraw_all_windows(fb: &mut FrameBuf, windows: &[Window], focused_win: usize,
 
 #[cfg(target_arch = "aarch64")]
 fn blit_window_contents(vram: &mut [u32], screen_w: usize, screen_h: usize, windows: &[Window]) {
-    for win in windows {
+    for (idx, win) in windows.iter().enumerate() {
         if win.minimized {
             continue;
         }
@@ -1216,10 +1216,81 @@ fn blit_window_contents(vram: &mut [u32], screen_w: usize, screen_h: usize, wind
 
         let _ = graphics::check_window_dirty(win.window_id);
 
+        let has_occluders = windows[idx + 1..].iter().any(|occ| {
+            !occ.minimized
+                && occ.mapped_pixels.is_some()
+                && occ.content_width() > 0
+                && occ.content_height() > 0
+        });
+        if !has_occluders {
+            for row in 0..copy_h {
+                let src_start = row * win.mapped_width;
+                let dst_start = (dst_y + row) * screen_w + dst_x;
+                vram[dst_start..dst_start + copy_w].copy_from_slice(&src[src_start..src_start + copy_w]);
+            }
+            continue;
+        }
+
         for row in 0..copy_h {
-            let src_start = row * win.mapped_width;
-            let dst_start = (dst_y + row) * screen_w + dst_x;
-            vram[dst_start..dst_start + copy_w].copy_from_slice(&src[src_start..src_start + copy_w]);
+            let py = dst_y + row;
+
+            // Port of 34a6c51e lines 438-461: start with the full row span,
+            // then subtract columns covered by higher-z window content.
+            let mut spans = [(0usize, 0usize); 8];
+            let mut n_spans = 1;
+            spans[0] = (dst_x, dst_x + copy_w);
+
+            for occ in &windows[idx + 1..] {
+                if occ.minimized || occ.mapped_pixels.is_none() {
+                    continue;
+                }
+
+                let ox0 = occ.content_x();
+                let oy0 = occ.content_y();
+                let ox1 = ox0 + occ.content_width() as i32;
+                let oy1 = oy0 + occ.content_height() as i32;
+                if py as i32 >= oy1 || (py as i32) < oy0 {
+                    continue;
+                }
+
+                let os = ox0.max(0) as usize;
+                let oe = ox1.max(0) as usize;
+                let mut new_spans = [(0usize, 0usize); 8];
+                let mut nc = 0;
+                for &(sx, ex) in spans[..n_spans].iter() {
+                    if sx >= ex {
+                        continue;
+                    }
+                    if oe <= sx || os >= ex {
+                        if nc < 8 {
+                            new_spans[nc] = (sx, ex);
+                            nc += 1;
+                        }
+                    } else {
+                        if sx < os && nc < 8 {
+                            new_spans[nc] = (sx, os);
+                            nc += 1;
+                        }
+                        if ex > oe && nc < 8 {
+                            new_spans[nc] = (oe, ex);
+                            nc += 1;
+                        }
+                    }
+                }
+                spans = new_spans;
+                n_spans = nc;
+            }
+
+            let src_row = row * win.mapped_width;
+            for &(sx, ex) in spans[..n_spans].iter() {
+                if sx >= ex {
+                    continue;
+                }
+                let count = ex - sx;
+                let src_start = src_row + (sx - dst_x);
+                let dst_start = py * screen_w + sx;
+                vram[dst_start..dst_start + count].copy_from_slice(&src[src_start..src_start + count]);
+            }
         }
     }
 }

--- a/userspace/programs/src/bwm.rs
+++ b/userspace/programs/src/bwm.rs
@@ -1245,10 +1245,11 @@ fn blit_window_contents(vram: &mut [u32], screen_w: usize, screen_h: usize, wind
                     continue;
                 }
 
-                let ox0 = occ.content_x();
-                let oy0 = occ.content_y();
-                let ox1 = ox0 + occ.content_width() as i32;
-                let oy1 = oy0 + occ.content_height() as i32;
+                // Use full window bounds (chrome + border + shadow), not
+                // content rect, so an occluder's title bar and borders also
+                // protect the underlying window's chrome from being overpainted.
+                // Matches gold-master at 34a6c51e:766-771.
+                let (ox0, oy0, ox1, oy1) = occ.bounds();
                 if py as i32 >= oy1 || (py as i32) < oy0 {
                     continue;
                 }


### PR DESCRIPTION
## Summary

- The span-based occlusion clip in `blit_window_contents` was using the occluder's **content rect** (`content_x/y/width/height`) instead of its **full window bounds**. That left the upper window's title bar + border regions unprotected, so a lower window's content row passing under an upper window's chrome would overpaint that chrome — visible as missing right borders and clipped headers on overlapping windows.
- One-line swap to `occ.bounds()`, which already returns the full window rect (chrome + border + drop shadow).
- Matches the gold-master span-clip at `34a6c51e:766-771` (`blit_client_pixels`), which the prior PR #348 ported but used the wrong rect type.

## Repro

Boot on Parallels, spawn two windows (e.g., `bcheck` + `bounce`), drag one to partially cover the other. Before this fix: the lower window's right border and the upper window's bottom-left header pixels visibly disappear at the overlap edge. After: borders + headers preserved.

## Test plan

- [x] `./userspace/programs/build.sh --arch aarch64` builds clean, zero warnings
- [ ] Boot on Parallels via `./run.sh --parallels`, overlap `bcheck` + `bounce`, visually verify borders + headers intact at every overlap edge
- [ ] Confirm no regression in z-order / minimize-restore / drag

🤖 Generated with [Claude Code](https://claude.com/claude-code)