### PR TITLE
instrument(trace): include PENDING_HANDOFF counters in soft-lockup dump

### DIFF
--- a/kernel/src/arch_impl/aarch64/timer_interrupt.rs
+++ b/kernel/src/arch_impl/aarch64/timer_interrupt.rs
@@ -1262,6 +1262,22 @@ fn dump_trace_counters() {
     print_timer_count_decimal(crate::time::get_ticks());
     raw_serial_str(b"\n  Timer IRQ count:  ");
     print_timer_count_decimal(TIMER_INTERRUPT_COUNT.load(Ordering::Relaxed));
+    // PR #355 wake-handoff visibility: PUSHED counts Case B deferred wakes,
+    // DRAINED counts trampoline-tail consumptions, FULL counts buffer-saturation
+    // fallbacks (should stay 0). PUSHED > DRAINED at lockup time means the owning
+    // CPU's trampoline never ran (CPU stuck in non-preemptible loop with IRQs masked).
+    raw_serial_str(b"\n  PENDING_HANDOFF_PUSHED:  ");
+    print_timer_count_decimal(
+        crate::task::scheduler::PENDING_HANDOFF_PUSHED.load(Ordering::Relaxed),
+    );
+    raw_serial_str(b"\n  PENDING_HANDOFF_DRAINED: ");
+    print_timer_count_decimal(
+        crate::task::scheduler::PENDING_HANDOFF_DRAINED.load(Ordering::Relaxed),
+    );
+    raw_serial_str(b"\n  PENDING_HANDOFF_FULL:    ");
+    print_timer_count_decimal(
+        crate::task::scheduler::PENDING_HANDOFF_FULL.load(Ordering::Relaxed),
+    );
     raw_serial_str(b"\n");
 }
 


### PR DESCRIPTION
PR #355 added `PENDING_HANDOFF_PUSHED/DRAINED/FULL` counters but the soft-lockup postmortem doesn't print them, so we can't tell whether the explicit-handoff path is being exercised on lockup. This adds the three counters to `dump_trace_counters()` (only called from the lockup postmortem, not the timer hot path — Tier 1 budget unaffected).

User has a fresh lockup with my fix in place; need this visibility to diagnose whether (a) Case B is firing at all, (b) drains are matching pushes, or (c) the buffer ever saturated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)