### PR TITLE
fix(sched): drain PENDING_HANDOFF at top of path-1, not just slow path

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -2335,12 +2335,51 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
             );
             sched.cpu_state[cpu_id].previous_thread = None;
             sched.requeue_thread_after_save(deferred_tid);
+            // Also drain PENDING_HANDOFF: a wake observed for a thread owned by
+            // this CPU was pushed here by wake_io_thread_locked Case B and is
+            // waiting for us to enqueue it. We piggyback on the lock we just
+            // acquired.
+            sched.drain_pending_handoff_for_current_cpu();
         }
         drop(guard);
         true
     } else {
         false
     };
+
+    // Drain PENDING_HANDOFF even when no DEFERRED_REQUEUE was pending. Wake
+    // pushes in Case B set NEED_RESCHED globally, but that flag is consumed by
+    // the first CPU to read it — the owning CPU might never see it set when its
+    // path-1 timer fires, in which case the fast-path early-return below would
+    // skip the slow path's drain at the bottom of this function. We must drain
+    // here unconditionally so every timer tick on every CPU drains its own
+    // pending-handoff buffer, with at most a 1ms latency from wake-push to
+    // ready-queue enqueue.
+    //
+    // Safety: drain_pending_handoff_for_current_cpu calls requeue_thread_after_save,
+    // which re-checks "still current on any CPU" / "is_in_deferred_requeue" / state
+    // == Ready / not already queued before pushing. We are running at exception
+    // return — the current thread is still set to cpu_state[cpu_id].current_thread
+    // (no commit has happened yet), so any TID equal to that current thread will
+    // be correctly skipped by requeue_thread_after_save's "current on any CPU"
+    // check, and we won't double-process it later in the slow path.
+    if !deferred_already_processed {
+        // Cheap probe: only take the lock if there is at least one pending
+        // entry in our buffer. The buffer is per-CPU and accessed via atomics.
+        let buf_idx = cpu_id;
+        let have_pending = if buf_idx < crate::task::scheduler::PENDING_HANDOFF_BUFFER_COUNT {
+            crate::task::scheduler::pending_handoff_buffer_has_entries(buf_idx)
+        } else {
+            false
+        };
+        if have_pending {
+            let mut guard = crate::task::scheduler::lock_for_context_switch();
+            if let Some(sched) = guard.as_mut() {
+                sched.drain_pending_handoff_for_current_cpu();
+            }
+            drop(guard);
+        }
+    }
 
     if (preempt_count & PREEMPT_GUARD_MASK) != 0 {
         // Kernel or interrupt context is not safe to preempt.

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -137,6 +137,23 @@ static ISR_WAKEUP_BUFFERS: [IsrWakeupBuffer; 8] = [const { IsrWakeupBuffer::new(
 /// vulnerable to lost wakeups after the rescue infrastructure was deleted in PR #344.
 static PENDING_HANDOFF_BUFFERS: [IsrWakeupBuffer; 8] = [const { IsrWakeupBuffer::new() }; 8];
 
+/// Number of PENDING_HANDOFF buffers (one per logical CPU).
+pub const PENDING_HANDOFF_BUFFER_COUNT: usize = 8;
+
+/// Lock-free probe: returns true if the given CPU's PENDING_HANDOFF buffer
+/// contains at least one entry. Safe to call from interrupt context. Used by
+/// the path-1 fast-path drain to avoid taking the scheduler lock when there
+/// is nothing to do.
+pub fn pending_handoff_buffer_has_entries(cpu: usize) -> bool {
+    if cpu >= PENDING_HANDOFF_BUFFER_COUNT {
+        return false;
+    }
+    PENDING_HANDOFF_BUFFERS[cpu]
+        .slots
+        .iter()
+        .any(|slot| slot.load(Ordering::Acquire) != ISR_WAKEUP_EMPTY)
+}
+
 /// Counter: TID pushed to PENDING_HANDOFF in Case B of wake_io_thread_locked.
 pub static PENDING_HANDOFF_PUSHED: AtomicU64 = AtomicU64::new(0);
 /// Counter: TID successfully drained from PENDING_HANDOFF by a trampoline tail.


### PR DESCRIPTION
Direct follow-up to PR #355. Diagnostic from the latest Parallels lockup (`/tmp/breenix-parallels-serial.log`, 24,370 stacked dumps, 16GB) shows the new symptom: 4 processes `[ready]`, 0 blocked, 1 running — the wake-deferral fix is delivering wakes (no more Blocked-forever) but threads then sit Ready without being dispatched.

## Why

PR #355 placed the path-1 drain inside the slow path, AFTER `commit_cpu_state_after_save`. That only runs when an actual reschedule fires. But `set_need_resched()` is a GLOBAL atomic — the first CPU to read it clears it. The owning CPU (the one whose `PENDING_HANDOFF[X]` holds the wake) may never see `NEED_RESCHED == true` on its own timer tick, takes the fast-path at line 2377, and skips the drain entirely. Wake rots in the buffer until X happens to reschedule for some other reason — which may never happen with a busy/sleeping current thread.

## Fix

Drain `PENDING_HANDOFF[cpu_id]` UNCONDITIONALLY at the TOP of path-1, alongside the existing `DEFERRED_REQUEUE` drain. Every CPU's every-1ms timer tick now drains its own buffer — max 1ms wake-to-enqueue latency regardless of `NEED_RESCHED` race outcomes.

Adds a lock-free atomic probe (`pending_handoff_buffer_has_entries`) so the no-pending-wake fast path skips the scheduler-lock acquisition. Cost is one atomic load per slot (32 slots, ~few hundred cycles) per timer tick per CPU when buffer is empty — comfortably inside the Tier-1 timer budget.

## Why this is the actual missing piece, not a band-aid

Linux's `sched_ttwu_pending()` is called at `__schedule()`'s tail AND from every IPI handler entry — explicit handoff plus IPI-triggered drain. Breenix doesn't send a directed IPI from Case B yet, so the only thing forcing a drain is the per-CPU timer tick. Without unconditional drain at path-1 entry, that 1ms tick can be skipped indefinitely.

## Test plan

- [x] arm64 + x86 build clean, zero warnings
- [ ] Boot Parallels, run >5 min, no SOFT LOCKUP
- [ ] If lockup recurs: read `PENDING_HANDOFF_PUSHED/DRAINED` from postmortem (now visible thanks to PR #356) — if PUSHED still > DRAINED, the drain isn't the only leak path; investigate other Case B paths or other wake sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)