### PR TITLE
fix(bwm): use full window bounds (not content rect) as occluder for span clip (retry)

### DIFF
--- a/userspace/programs/src/bwm.rs
+++ b/userspace/programs/src/bwm.rs
@@ -1245,10 +1245,14 @@ fn blit_window_contents(vram: &mut [u32], screen_w: usize, screen_h: usize, wind
                     continue;
                 }
 
-                let ox0 = occ.content_x();
-                let oy0 = occ.content_y();
-                let ox1 = ox0 + occ.content_width() as i32;
-                let oy1 = oy0 + occ.content_height() as i32;
+                // Use full window bounds (chrome + border + shadow), not
+                // content rect. The lower window's content row at y just below
+                // an upper window's bottom border was overpainting that border
+                // pixel (and the +3 drop shadow), because the content-rect-only
+                // occluder span stopped at content_y + content_height — leaving
+                // the title bar / borders / shadow unprotected. Matches the
+                // gold-master span-clip occluder at 34a6c51e:766-771.
+                let (ox0, oy0, ox1, oy1) = occ.bounds();
                 if py as i32 >= oy1 || (py as i32) < oy0 {
                     continue;
                 }


### PR DESCRIPTION
Re-apply of PR #351, which was reverted in PR #352 when I incorrectly suspected it of causing the soft-lockup. That lockup was actually the scheduler wake-handoff race fixed by PRs #355/#357.

User screenshot today confirms the original clipping bug is still present on main — Self-Check title bar text is clipped where Bounce overlaps from above, and the bottom-border of an upper window over a lower window gets overpainted by the lower window's content row at y = bottom-border-y.

Identical one-line change to PR #351: in `blit_window_contents` swap the per-occluder rect from `content_x/y/width/height` to `occ.bounds()` (which already includes chrome + border + +3 drop-shadow). Matches gold-master at `34a6c51e:766-771`.

Test plan:
- [x] Builds clean on arm64 + x86 userspace
- [ ] Boot Parallels, overlap two windows, visually verify the right border and title bar of the lower window are no longer eaten where they meet the upper window

🤖 Generated with [Claude Code](https://claude.com/claude-code)