### PR TITLE
fix(sched): use try_lock for top-of-path-1 PENDING_HANDOFF drain

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -2364,7 +2364,7 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
     // be correctly skipped by requeue_thread_after_save's "current on any CPU"
     // check, and we won't double-process it later in the slow path.
     if !deferred_already_processed {
-        // Cheap probe: only take the lock if there is at least one pending
+        // Cheap probe: only attempt the lock if there is at least one pending
         // entry in our buffer. The buffer is per-CPU and accessed via atomics.
         let buf_idx = cpu_id;
         let have_pending = if buf_idx < crate::task::scheduler::PENDING_HANDOFF_BUFFER_COUNT {
@@ -2373,11 +2373,23 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
             false
         };
         if have_pending {
-            let mut guard = crate::task::scheduler::lock_for_context_switch();
-            if let Some(sched) = guard.as_mut() {
-                sched.drain_pending_handoff_for_current_cpu();
+            // try_lock, not lock: this path runs on EVERY exception return
+            // (timer ticks + IRQs + syscall returns) on every CPU. If we used
+            // a blocking lock here, the global SCHEDULER mutex would serialize
+            // every CPU on every exception return, producing severe contention
+            // that manifests as an apparent hard-lockup (all CPUs spinning on
+            // lock-acquire, lock holder cycling too fast for the soft-lockup
+            // detector to trip its 1-second threshold). If the lock is held by
+            // another CPU, skip the drain — the buffer is per-CPU and will be
+            // drained on this CPU's next path-1 entry (at most 1ms later via
+            // the next timer tick), or by the slow-path drain at the bottom
+            // of this function when need_resched is set.
+            if let Some(mut guard) = crate::task::scheduler::try_lock_for_context_switch() {
+                if let Some(sched) = guard.as_mut() {
+                    sched.drain_pending_handoff_for_current_cpu();
+                }
+                drop(guard);
             }
-            drop(guard);
         }
     }
 

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -321,6 +321,16 @@ pub fn lock_for_context_switch() -> spin::MutexGuard<'static, Option<Scheduler>>
     SCHEDULER.lock()
 }
 
+/// Non-blocking lock acquisition. Returns None if the scheduler lock is
+/// currently held by another CPU. Used by best-effort paths (e.g. the
+/// path-1 PENDING_HANDOFF drain) that can safely defer their work to a
+/// later iteration if the lock is contended.
+#[cfg(target_arch = "aarch64")]
+pub fn try_lock_for_context_switch(
+) -> Option<spin::MutexGuard<'static, Option<Scheduler>>> {
+    SCHEDULER.try_lock()
+}
+
 /// Force-unlock the scheduler mutex after an inline AArch64 context switch.
 ///
 /// The inline scheduler path intentionally leaks the lock guard before hopping


### PR DESCRIPTION
Direct follow-up to PR #357. After PR #357 landed and the system rebooted, the operator hit a HARD lockup (all CPUs spinning at 100% CPU, no log progress, no frame progress, but **no SOFT LOCKUP DETECTED in the log** — too fast for the 1-sec detector to trip).

Root cause: PR #357 added a top-of-path-1 PENDING_HANDOFF drain that acquires the global `SCHEDULER` mutex via blocking `lock()`. Path-1 fires on every exception return (timer + IRQ + syscall return), so on 8 CPUs under load this serializes everything through one critical section every exception return. Lock holder cycles too fast to trip soft-lockup, too slow to leave anyone real progress.

Fix: switch the new drain to `try_lock`. On contention, skip — the per-CPU buffer is preserved and drained on the next path-1 entry (at most 1ms later) or by the existing slow-path drain when need_resched is set. Keeps the wake-handoff correctness fix while removing the unbounded serialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)