### PR TITLE
revert: drop entire PENDING_HANDOFF wake-handoff churn (PRs #355/#356/#357/#359)

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -2335,31 +2335,12 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
             );
             sched.cpu_state[cpu_id].previous_thread = None;
             sched.requeue_thread_after_save(deferred_tid);
-            // Also drain PENDING_HANDOFF: a wake observed for a thread owned by
-            // this CPU was pushed here by wake_io_thread_locked Case B and is
-            // waiting for us to enqueue it. We piggyback on the lock we just
-            // acquired.
-            sched.drain_pending_handoff_for_current_cpu();
         }
         drop(guard);
         true
     } else {
         false
     };
-
-    // NOTE: PR #357 added an unconditional top-of-path-1 PENDING_HANDOFF
-    // drain here that regressed the long-standing CPU0 timer death watchdog
-    // (PR #334) — the added work in path-1 disrupted CPU0 timer delivery
-    // somehow. Reverted in PR #360. The remaining drain points are:
-    //   - inside the deferred_tid != 0 block above (piggybacks on existing lock)
-    //   - inside the slow-path schedule below
-    //   - inline_schedule_trampoline tail (path-2)
-    // These cover normal cases. If the wake-handoff race re-emerges, the next
-    // attempt should NOT add new top-of-path-1 lock acquisitions; instead
-    // investigate sending a directed IPI from Case B to the target CPU
-    // (Linux's ttwu_queue_wakelist pattern) so the existing trampoline-tail
-    // drains fire on the owner CPU without needing to acquire the lock at the
-    // top of every exception return.
 
     if (preempt_count & PREEMPT_GUARD_MASK) != 0 {
         // Kernel or interrupt context is not safe to preempt.
@@ -2610,14 +2591,6 @@ pub extern "C" fn check_need_resched_and_switch_arm64(
         }
     }
 
-    // Drain this CPU's PENDING_HANDOFF buffer: wakes that landed for threads
-    // that were "current on this CPU" or in this CPU's deferred-requeue slot
-    // were pushed here by wake_io_thread_locked Case B and trust this trampoline
-    // to convert them into ready-queue enqueues now that commit_cpu_state_after_save
-    // has removed those threads as "current". Linux equivalent: sched_ttwu_pending()
-    // at the __schedule() tail.
-    sched.drain_pending_handoff_for_current_cpu();
-
     let is_idle = sched.is_idle_thread_inner(new_id);
     let ret_dispatch_info = if !is_idle {
         inline_ret_dispatch_info_if_ready(sched, new_id)
@@ -2822,14 +2795,6 @@ extern "C" fn inline_schedule_trampoline() -> ! {
     if should_requeue_old || old_ready_after_save {
         sched.requeue_thread_after_save(old_id);
     }
-    // Explicit wake handoff drain (Linux ttwu_pending equivalent): any wake
-    // pushed to this CPU's PENDING_HANDOFF buffer by wake_io_thread_locked
-    // Case B (because the target was current on this CPU at wake time) is
-    // converted to a ready-queue enqueue now that commit removed the thread
-    // as "current". Without this, such wakes were silently trusted to the
-    // owner and could be lost if neither should_requeue_old nor
-    // old_ready_after_save was true at the trampoline's state-read window.
-    sched.drain_pending_handoff_for_current_cpu();
     cpu0_breadcrumb(cpu_id, 33); // after requeue_thread_after_save
 
     // Determine dispatch mode for the new thread.

--- a/kernel/src/arch_impl/aarch64/timer_interrupt.rs
+++ b/kernel/src/arch_impl/aarch64/timer_interrupt.rs
@@ -1262,22 +1262,6 @@ fn dump_trace_counters() {
     print_timer_count_decimal(crate::time::get_ticks());
     raw_serial_str(b"\n  Timer IRQ count:  ");
     print_timer_count_decimal(TIMER_INTERRUPT_COUNT.load(Ordering::Relaxed));
-    // PR #355 wake-handoff visibility: PUSHED counts Case B deferred wakes,
-    // DRAINED counts trampoline-tail consumptions, FULL counts buffer-saturation
-    // fallbacks (should stay 0). PUSHED > DRAINED at lockup time means the owning
-    // CPU's trampoline never ran (CPU stuck in non-preemptible loop with IRQs masked).
-    raw_serial_str(b"\n  PENDING_HANDOFF_PUSHED:  ");
-    print_timer_count_decimal(
-        crate::task::scheduler::PENDING_HANDOFF_PUSHED.load(Ordering::Relaxed),
-    );
-    raw_serial_str(b"\n  PENDING_HANDOFF_DRAINED: ");
-    print_timer_count_decimal(
-        crate::task::scheduler::PENDING_HANDOFF_DRAINED.load(Ordering::Relaxed),
-    );
-    raw_serial_str(b"\n  PENDING_HANDOFF_FULL:    ");
-    print_timer_count_decimal(
-        crate::task::scheduler::PENDING_HANDOFF_FULL.load(Ordering::Relaxed),
-    );
     raw_serial_str(b"\n");
 }
 

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -127,40 +127,6 @@ impl IsrWakeupBuffer {
 
 static ISR_WAKEUP_BUFFERS: [IsrWakeupBuffer; 8] = [const { IsrWakeupBuffer::new() }; 8];
 
-/// Per-CPU pending-handoff buffers for wakes that observed the target thread
-/// as "owned" (still current on a CPU or sitting in that CPU's deferred-requeue
-/// slot). Pushed from `wake_io_thread_locked` Case B; drained unconditionally
-/// by the owning CPU's context-switch trampolines AFTER commit_cpu_state_after_save
-/// has run (so the thread is no longer current). Equivalent shape to Linux's
-/// per-CPU `wake_list` drained by `sched_ttwu_pending()` at every `__schedule()`
-/// tail. Replaces the prior silent-defer-then-trust-the-owner pattern that was
-/// vulnerable to lost wakeups after the rescue infrastructure was deleted in PR #344.
-static PENDING_HANDOFF_BUFFERS: [IsrWakeupBuffer; 8] = [const { IsrWakeupBuffer::new() }; 8];
-
-/// Number of PENDING_HANDOFF buffers (one per logical CPU).
-pub const PENDING_HANDOFF_BUFFER_COUNT: usize = 8;
-
-/// Lock-free probe: returns true if the given CPU's PENDING_HANDOFF buffer
-/// contains at least one entry. Safe to call from interrupt context. Used by
-/// the path-1 fast-path drain to avoid taking the scheduler lock when there
-/// is nothing to do.
-pub fn pending_handoff_buffer_has_entries(cpu: usize) -> bool {
-    if cpu >= PENDING_HANDOFF_BUFFER_COUNT {
-        return false;
-    }
-    PENDING_HANDOFF_BUFFERS[cpu]
-        .slots
-        .iter()
-        .any(|slot| slot.load(Ordering::Acquire) != ISR_WAKEUP_EMPTY)
-}
-
-/// Counter: TID pushed to PENDING_HANDOFF in Case B of wake_io_thread_locked.
-pub static PENDING_HANDOFF_PUSHED: AtomicU64 = AtomicU64::new(0);
-/// Counter: TID successfully drained from PENDING_HANDOFF by a trampoline tail.
-pub static PENDING_HANDOFF_DRAINED: AtomicU64 = AtomicU64::new(0);
-/// Counter: PENDING_HANDOFF push failed because target CPU's buffer was full.
-pub static PENDING_HANDOFF_FULL: AtomicU64 = AtomicU64::new(0);
-
 const WAKE_ATTRIB_MAX_TIDS: usize = 4096;
 const READY_SITE_NONE: u64 = 0;
 const READY_SITE_SCHEDULE: u64 = 1;
@@ -319,16 +285,6 @@ pub fn increment_context_switch_count() {
 #[cfg(target_arch = "aarch64")]
 pub fn lock_for_context_switch() -> spin::MutexGuard<'static, Option<Scheduler>> {
     SCHEDULER.lock()
-}
-
-/// Non-blocking lock acquisition. Returns None if the scheduler lock is
-/// currently held by another CPU. Used by best-effort paths (e.g. the
-/// path-1 PENDING_HANDOFF drain) that can safely defer their work to a
-/// later iteration if the lock is contended.
-#[cfg(target_arch = "aarch64")]
-pub fn try_lock_for_context_switch(
-) -> Option<spin::MutexGuard<'static, Option<Scheduler>>> {
-    SCHEDULER.try_lock()
 }
 
 /// Force-unlock the scheduler mutex after an inline AArch64 context switch.
@@ -1317,27 +1273,6 @@ impl Scheduler {
     /// This completes the deferred requeue from `schedule_deferred_requeue()`.
     /// Must be called only after the thread's context has been fully saved
     /// to prevent other CPUs from dispatching it with stale state.
-    /// Drain this CPU's PENDING_HANDOFF buffer and requeue each TID.
-    ///
-    /// Called by both context-switch trampolines AFTER `commit_cpu_state_after_save`
-    /// has run (so threads pushed here by `wake_io_thread_locked` Case B can be
-    /// safely enqueued — they are no longer "current on this CPU"). This is the
-    /// explicit-handoff side of the wake protocol that matches Linux's
-    /// `sched_ttwu_pending()` shape and replaces the prior silent-defer pattern.
-    #[cfg(target_arch = "aarch64")]
-    pub fn drain_pending_handoff_for_current_cpu(&mut self) {
-        let cpu = Self::current_cpu_id();
-        if cpu >= PENDING_HANDOFF_BUFFERS.len() {
-            return;
-        }
-        let mut drained: alloc::vec::Vec<u64> = alloc::vec::Vec::with_capacity(8);
-        PENDING_HANDOFF_BUFFERS[cpu].drain(&mut drained);
-        for tid in drained {
-            PENDING_HANDOFF_DRAINED.fetch_add(1, Ordering::Relaxed);
-            self.requeue_thread_after_save(tid);
-        }
-    }
-
     #[cfg(target_arch = "aarch64")]
     pub fn requeue_thread_after_save(&mut self, thread_id: u64) {
         // Don't requeue idle threads (they are never in the ready queue)
@@ -1975,37 +1910,6 @@ impl Scheduler {
                         ENQUEUE_SAME_LOCK_OK.fetch_add(1, Ordering::Relaxed);
                     }
                 } else if published_ready && (wake.current_cpu.is_some() || is_in_deferred) {
-                    // Explicit handoff: push the TID to the owning CPU's pending-handoff
-                    // buffer instead of trusting the owner to requeue. The owner's
-                    // trampoline drains this buffer unconditionally after commit
-                    // (see context_switch.rs and inline_schedule_trampoline below).
-                    // Replaces the prior silent-defer pattern that depended on
-                    // `should_requeue_old || old_ready_after_save` being true at the
-                    // trampoline's state read — a race window where the wake could be
-                    // observed only AFTER both flags were sampled false, losing the wake.
-                    let target_cpu = if let Some(cpu) = wake.current_cpu {
-                        cpu
-                    } else {
-                        // is_in_deferred is true: find the CPU whose previous_thread
-                        // marker holds this TID. Falls back to current CPU if not
-                        // located (should not happen given is_in_deferred==true).
-                        (0..MAX_CPUS)
-                            .find(|&c| self.cpu_state[c].previous_thread == Some(tid))
-                            .unwrap_or_else(Self::current_cpu_id)
-                    };
-                    if target_cpu < PENDING_HANDOFF_BUFFERS.len() {
-                        if PENDING_HANDOFF_BUFFERS[target_cpu].push(tid) {
-                            PENDING_HANDOFF_PUSHED.fetch_add(1, Ordering::Relaxed);
-                        } else {
-                            // Buffer full — fall back to direct enqueue. This is
-                            // safe because requeue_thread_after_save is idempotent
-                            // and re-checks "still current on any CPU" / "already
-                            // queued" before pushing.
-                            PENDING_HANDOFF_FULL.fetch_add(1, Ordering::Relaxed);
-                            self.per_cpu_queues[self.find_target_cpu_for_wakeup(tid)]
-                                .push_back(tid);
-                        }
-                    }
                     ENQUEUE_DEFERRED.fetch_add(1, Ordering::Relaxed);
                 } else if already_queued {
                     ENQUEUE_ALREADY_QUEUED_OK.fetch_add(1, Ordering::Relaxed);


### PR DESCRIPTION
Composite revert of all my session work that tried to fix the 5-minute Parallels lockup. The actual lockup root cause was never identified — I was chasing symptoms.

## What this removes

- PR #355: PENDING_HANDOFF_BUFFERS + Case B push + trampoline-tail drains
- PR #356: PENDING_HANDOFF counter prints in lockup postmortem
- PR #357: top-of-path-1 drain (already reverted by PR #360 but kept as a doc comment)
- PR #359: try_lock_for_context_switch helper

Single composite revert avoids cascading 3 separate git-revert commits with merge conflicts. Removes 147 lines, adds 0.

## What this preserves

- PR #334: original CPU0 timer death fix (gold-master invariant, unchanged)
- PR #344: scheduler atomic wake-enqueue (last-evidenced clean baseline)
- PR #349: polling-elimination Phase 1 (Linux-semantics, operator-approved)
- PR #350: VMware GIC EOImode (VMware Fusion compat, operator-approved)
- PR #358: BWM bounds-correct occlusion clip (operator-approved visible fix)

## Why this is the right move

The user-evidenced last-known-good is PR #344 with 5×285s of stable boots in the scheduler-wake-atomic Ralph closing report. Everything HONEST/NECESSARY since then is preserved. Everything PROBLEMATIC (mine) is removed.

## What we do NOT yet have

The actual 5-minute Parallels lockup that started this whole mess (per the user's "this was working fine until a day ago" baseline) is still unidentified. After this lands, the next move should be bisecting between PRs #344 and #350 to find the actual regressor — likely in one of the four investigation/audit PRs (#345-#348) or polling-elimination Phase 1 (#349).

## Future wake-handoff fix

If the wake-handoff race re-emerges as a real problem, the right shape is Linux's `ttwu_queue_wakelist` + `sched_ttwu_pending` with a directed IPI from the wake site to the target CPU. NOT a top-of-exception-return drain.

Both arm64 and x86 build clean, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)