### PR TITLE
revert: PR #358 BWM bounds-correct clip (perf regression test)

### DIFF
--- a/userspace/programs/src/bwm.rs
+++ b/userspace/programs/src/bwm.rs
@@ -1245,14 +1245,10 @@ fn blit_window_contents(vram: &mut [u32], screen_w: usize, screen_h: usize, wind
                     continue;
                 }
 
-                // Use full window bounds (chrome + border + shadow), not
-                // content rect. The lower window's content row at y just below
-                // an upper window's bottom border was overpainting that border
-                // pixel (and the +3 drop shadow), because the content-rect-only
-                // occluder span stopped at content_y + content_height — leaving
-                // the title bar / borders / shadow unprotected. Matches the
-                // gold-master span-clip occluder at 34a6c51e:766-771.
-                let (ox0, oy0, ox1, oy1) = occ.bounds();
+                let ox0 = occ.content_x();
+                let oy0 = occ.content_y();
+                let ox1 = ox0 + occ.content_width() as i32;
+                let oy1 = oy0 + occ.content_height() as i32;
                 if py as i32 >= oy1 || (py as i32) < oy0 {
                     continue;
                 }


### PR DESCRIPTION
Operator reports system perf dropped from ~149 fps baseline (PR #344, May 19) to ~120 fps after recent session work. PR #358 is the only piece of session work still in main and is in the userspace render hot path (per-row × per-occluder span subtraction in `blit_window_contents`). Hypothesis: `occ.bounds()` is a larger rect than `content_*`, forcing more per-row prefix/suffix splits in the 8-span fixed array, increasing inner-loop work even though math complexity is the same.

This revert restores the original `content_x/y/width/height` occluder rect. The visible clipping bug (lower window's content row overpainting upper window's bottom-border pixels) returns temporarily.

NOT touching the sacred PRs #344 (scheduler atomic wake-enqueue), #349 (polling-elimination Phase 1), #350 (VMware GIC EOImode).

Test plan:
- [ ] Boot Parallels with this revert applied, observe FPS over 30+ seconds, compare to the ~120 fps current state.
- [ ] If FPS returns to ~149 baseline → hypothesis confirmed, #358 is the perf regressor. Redesign span algorithm for performance (precompute occluder rects per frame, not per row × per occluder) before re-fixing the clipping bug.
- [ ] If FPS unchanged → look elsewhere (polling-elimination IRQ overhead, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)