### PR TITLE
fix(aarch64): cache-line-align deferred-requeue statics to fix CPU0 timer death under Parallels HVF

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -19,6 +19,7 @@
 //! - Memory barriers (DSB, ISB) required after page table switches
 
 use core::mem::MaybeUninit;
+use core::ops::Deref;
 use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 use super::exception_frame::Aarch64ExceptionFrame;
@@ -725,6 +726,17 @@ pub static TTBR_PROCESS_GONE_COUNT: AtomicU64 = AtomicU64::new(0);
 /// (PROCESS_MANAGER lock was contended during TTBR0 lookup).
 pub static TTBR_PM_LOCK_BUSY_COUNT: AtomicU64 = AtomicU64::new(0);
 
+#[repr(align(64))]
+struct CacheLineAligned<T>(T);
+
+impl<T> Deref for CacheLineAligned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// Per-CPU deferred requeue storage.
 ///
 /// CRITICAL SMP FIX: After a context switch, the old thread must NOT be
@@ -741,7 +753,7 @@ pub static TTBR_PM_LOCK_BUSY_COUNT: AtomicU64 = AtomicU64::new(0);
 /// the boot stack after ERET).
 ///
 /// Value 0 = no pending requeue. Non-zero = thread ID to requeue.
-static DEFERRED_REQUEUE: [AtomicU64; 8] = [
+static DEFERRED_REQUEUE: CacheLineAligned<[AtomicU64; 8]> = CacheLineAligned([
     AtomicU64::new(0),
     AtomicU64::new(0),
     AtomicU64::new(0),
@@ -750,12 +762,16 @@ static DEFERRED_REQUEUE: [AtomicU64; 8] = [
     AtomicU64::new(0),
     AtomicU64::new(0),
     AtomicU64::new(0),
-];
+]);
 
-static LAST_DEFER_REQUEUE_INFO: [AtomicU64; 8] = [const { AtomicU64::new(0) }; 8];
-static LAST_DEFER_REQUEUE_SP: [AtomicU64; 8] = [const { AtomicU64::new(0) }; 8];
-static LAST_DEFER_REQUEUE_ELR: [AtomicU64; 8] = [const { AtomicU64::new(0) }; 8];
-static LAST_DEFER_REQUEUE_X30: [AtomicU64; 8] = [const { AtomicU64::new(0) }; 8];
+static LAST_DEFER_REQUEUE_INFO: CacheLineAligned<[AtomicU64; 8]> =
+    CacheLineAligned([const { AtomicU64::new(0) }; 8]);
+static LAST_DEFER_REQUEUE_SP: CacheLineAligned<[AtomicU64; 8]> =
+    CacheLineAligned([const { AtomicU64::new(0) }; 8]);
+static LAST_DEFER_REQUEUE_ELR: CacheLineAligned<[AtomicU64; 8]> =
+    CacheLineAligned([const { AtomicU64::new(0) }; 8]);
+static LAST_DEFER_REQUEUE_X30: CacheLineAligned<[AtomicU64; 8]> =
+    CacheLineAligned([const { AtomicU64::new(0) }; 8]);
 
 struct InlineScheduleState {
     scheduler_ptr: AtomicUsize,


### PR DESCRIPTION
## Summary

- **Root cause:** Five 64-byte deferred-requeue context-switch statics in `kernel/src/arch_impl/aarch64/context_switch.rs` (`DEFERRED_REQUEUE`, `LAST_DEFER_REQUEUE_INFO/SP/ELR/X30`) were declared as bare `static [AtomicU64; 8]` arrays. Default linker placement landed them at addresses crossing 64-byte cache-line boundaries (Sub-F failing layout: `0x...e8, 0xa8, 0x28, 0x68, 0xe8`), causing CPU0 virtual timer (PPI 27) death within ~350 ms of boot on Parallels Desktop HVF on Apple Silicon.
- **Fix:** Wrap each in `#[repr(align(64))] struct CacheLineAligned<T>(T)` so they sit cache-line-aligned and cache-line-contained.
- **Supersedes** the 256-byte BSS workaround on `fix/cpu0-ahci-isr-storm` (commit `0c8903e7`), which incidentally rescued CPU0 by shifting BSS until these specific statics happened to land aligned. After this lands, that workaround branch should be reverted.

## Validation

- **10/10 conclusive boots** across Turns 21 + 23 of the long-running investigation. All boots reached ≥100,000 cpu0 ticks on the strict-validation pass (well above the 10,000-tick watchdog threshold).
- **0 CPU0 REGRESSION ALARM** firings, 0 `FIRE` markers, 0 inconclusive boots.
- ~38 min total kernel runtime across the 10 boots.
- All 5 deferred-requeue statics confirmed cache-line aligned in the fixed binary (`0xffff0000402f9400/9440/9480/94c0/9500`, all 64 B aligned + contained).

## Diff scope

Single file, +23/-7 lines: `kernel/src/arch_impl/aarch64/context_switch.rs`. No public API changes.

## Test plan

- [ ] CI green (build + test matrix)
- [ ] Operator runs final local boot on Parallels VM to confirm 5/5 PASS on this exact commit
- [ ] After merge, revert the 256-byte BSS workaround on `fix/cpu0-ahci-isr-storm` (separate PR, per the supersedes note above)

## Investigation trail

~22 turns of bisection on the long-running Ralph project at `~/Downloads/Ralph/breenix-cpu0-timer-death-1779729262/`. Key artifacts: `turn18-bss-diff-findings.md`, `turn19-alignment-findings.md`, `turn20-sub-u-results.txt`, `turn21-fix-results.txt`, `turn23-fix-results.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)