### PR TITLE
fix: core-aware btop CPU accounting (NB-1a)

### DIFF
--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -791,17 +791,15 @@ fn generate_stat() -> String {
     let mut out = String::with_capacity(512);
 
     // Per-CPU lines: "cpuN <timer_ticks> <idle_ticks>"
-    #[cfg(target_arch = "aarch64")]
-    let num_cpus = crate::arch_impl::aarch64::smp::cpus_online() as usize;
-    #[cfg(not(target_arch = "aarch64"))]
-    let num_cpus = 1usize;
-    let num_cpus = if num_cpus == 0 { 1 } else { num_cpus };
+    let num_cpus = procfs_online_cpus();
 
     for cpu in 0..num_cpus {
         let ticks = TIMER_TICK_TOTAL.get_cpu(cpu);
         let idle = IDLE_TICK_TOTAL.get_cpu(cpu);
         let _ = write!(out, "cpu{} {} {}\n", cpu, ticks, idle);
     }
+
+    let (cpu_online, cpu_sample_ticks, cpu_capacity_ticks) = procfs_cpu_accounting_ticks();
 
     // Aggregate counters (existing format, backwards compatible)
     let _ = write!(
@@ -811,6 +809,9 @@ fn generate_stat() -> String {
          context_switches {}\n\
          timer_ticks {}\n\
          global_ticks {}\n\
+         cpu_online {}\n\
+         cpu_sample_ticks {}\n\
+         cpu_capacity_ticks {}\n\
          forks {}\n\
          execs {}\n\
          cow_faults {}\n\
@@ -822,6 +823,9 @@ fn generate_stat() -> String {
         CTX_SWITCH_TOTAL.aggregate(),
         TIMER_TICK_TOTAL.aggregate(),
         crate::time::get_ticks(),
+        cpu_online,
+        cpu_sample_ticks,
+        cpu_capacity_ticks,
         FORK_TOTAL.aggregate(),
         EXEC_TOTAL.aggregate(),
         COW_FAULT_TOTAL.aggregate(),
@@ -838,6 +842,29 @@ fn generate_stat() -> String {
         );
     }
     out
+}
+
+fn procfs_online_cpus() -> usize {
+    #[cfg(target_arch = "aarch64")]
+    let num_cpus = crate::arch_impl::aarch64::smp::cpus_online() as usize;
+    #[cfg(not(target_arch = "aarch64"))]
+    let num_cpus = 1usize;
+
+    if num_cpus == 0 {
+        1
+    } else {
+        num_cpus
+    }
+}
+
+fn procfs_cpu_accounting_ticks() -> (usize, u64, u64) {
+    use crate::tracing::providers::counters::TIMER_TICK_TOTAL;
+
+    let cpu_online = procfs_online_cpus();
+    let capacity_ticks = TIMER_TICK_TOTAL.aggregate();
+    let sample_ticks = capacity_ticks / cpu_online as u64;
+
+    (cpu_online, sample_ticks, capacity_ticks)
 }
 
 /// Generate /proc/cowinfo content (copy-on-write statistics)
@@ -1002,6 +1029,7 @@ fn generate_pid_status(pid: u64) -> String {
             .map(|&(_, t)| t)
             .sum::<u64>()
     };
+    let (cpu_online, cpu_sample_ticks, cpu_capacity_ticks) = procfs_cpu_accounting_ticks();
 
     let manager_guard = crate::process::manager();
     let manager = match manager_guard.as_ref() {
@@ -1057,7 +1085,10 @@ fn generate_pid_status(pid: u64) -> String {
          VmCode:\t{} kB\n\
          VmHeap:\t{} kB\n\
          VmStack:\t{} kB\n\
-         CpuTicks:\t{}\n",
+         CpuTicks:\t{}\n\
+         CpuSampleTicks:\t{}\n\
+         CpuCapacityTicks:\t{}\n\
+         CpuOnline:\t{}\n",
         process.name,
         pid,
         ppid,
@@ -1068,5 +1099,8 @@ fn generate_pid_status(pid: u64) -> String {
         vm_heap_kb,
         vm_stack_kb,
         cpu_ticks,
+        cpu_sample_ticks,
+        cpu_capacity_ticks,
+        cpu_online,
     )
 }

--- a/userspace/programs/src/btop.rs
+++ b/userspace/programs/src/btop.rs
@@ -199,6 +199,8 @@ struct ProcInfo {
     state: [u8; 16],
     state_len: usize,
     cpu_ticks: u64,
+    cpu_sample_ticks: u64,
+    cpu_online: u64,
     vm_heap_kb: u64,
     vm_stack_kb: u64,
     vm_code_kb: u64,
@@ -214,6 +216,8 @@ impl ProcInfo {
             state: [0; 16],
             state_len: 0,
             cpu_ticks: 0,
+            cpu_sample_ticks: 0,
+            cpu_online: 1,
             vm_heap_kb: 0,
             vm_stack_kb: 0,
             vm_code_kb: 0,
@@ -223,6 +227,13 @@ impl ProcInfo {
     fn total_mem_kb(&self) -> u64 {
         self.vm_code_kb + self.vm_heap_kb + self.vm_stack_kb
     }
+}
+
+#[derive(Clone, Copy)]
+struct ProcTickSample {
+    pid: u64,
+    cpu_ticks: u64,
+    sample_ticks: u64,
 }
 
 /// Parse /proc/<pid>/status into a ProcInfo
@@ -249,7 +260,7 @@ fn parse_proc_status(pid: u64) -> Option<ProcInfo> {
 
     let path_str = core::str::from_utf8(&path_buf[..pos]).ok()?;
 
-    let mut buf = [0u8; 512];
+    let mut buf = [0u8; 768];
     let n = read_procfs(path_str, &mut buf);
     if n == 0 {
         return None;
@@ -276,6 +287,8 @@ fn parse_proc_status(pid: u64) -> Option<ProcInfo> {
 
     // Parse CpuTicks
     info.cpu_ticks = parse_value(content, b"CpuTicks:");
+    info.cpu_sample_ticks = parse_value(content, b"CpuSampleTicks:");
+    info.cpu_online = parse_value(content, b"CpuOnline:").max(1);
 
     // Parse memory
     info.vm_code_kb = parse_value(content, b"VmCode:");
@@ -430,8 +443,7 @@ fn main() {
     let _ = libbreenix::time::sleep_ms(500);
 
     // Previous tick counts for CPU% delta computation
-    let mut prev_ticks: Vec<(u64, u64)> = Vec::new(); // (pid, ticks)
-    let mut prev_global_ticks: u64 = 0;
+    let mut prev_ticks: Vec<ProcTickSample> = Vec::new();
     let mut prev_gpu_bytes: u64 = 0;
     let mut prev_gpu_full: u64 = 0;
     let mut prev_gpu_partial: u64 = 0;
@@ -471,7 +483,6 @@ fn main() {
         let syscalls = parse_value(stat, b"syscalls");
         let interrupts = parse_value(stat, b"interrupts");
         let ctx_switches = parse_value(stat, b"context_switches");
-        let global_ticks = parse_value(stat, b"global_ticks");
         let forks = parse_value(stat, b"forks");
         let execs = parse_value(stat, b"execs");
         let cow_faults = parse_value(stat, b"cow_faults");
@@ -504,18 +515,19 @@ fn main() {
             }
         }
 
-        // Compute CPU% deltas using global_ticks (same clock as per-process ticks).
-        // global_ticks is incremented only by CPU 0, matching the scale of per-process
-        // cpu_ticks_total which uses get_ticks() deltas. This gives htop-style
-        // percentages: 100% = one full CPU.
-        let tick_delta = global_ticks.saturating_sub(prev_global_ticks);
+        // Compute CPU% deltas against the procfs CPU sample clock captured with
+        // each PID. 100% means one full CPU; multi-threaded processes can reach
+        // cpu_online * 100%, but blocked sleepers should remain at 0%.
         let mut cpu_pcts: Vec<(u64, u64)> = Vec::new(); // (pid, pct*10 for 1 decimal)
         for proc in &procs {
-            let prev = prev_ticks.iter().find(|(p, _)| *p == proc.pid);
-            let prev_t = prev.map(|(_, t)| *t).unwrap_or(0);
-            let delta = proc.cpu_ticks.saturating_sub(prev_t);
+            let prev = prev_ticks.iter().find(|sample| sample.pid == proc.pid);
+            let prev_cpu_ticks = prev.map(|sample| sample.cpu_ticks).unwrap_or(0);
+            let prev_sample_ticks = prev.map(|sample| sample.sample_ticks).unwrap_or(0);
+            let delta = proc.cpu_ticks.saturating_sub(prev_cpu_ticks);
+            let tick_delta = proc.cpu_sample_ticks.saturating_sub(prev_sample_ticks);
+            let max_pct10 = proc.cpu_online.saturating_mul(1000);
             let pct10 = if tick_delta > 0 {
-                (delta * 1000) / tick_delta
+                ((delta * 1000) / tick_delta).min(max_pct10)
             } else {
                 0
             };
@@ -525,9 +537,12 @@ fn main() {
         // Save current ticks for next iteration
         prev_ticks.clear();
         for proc in &procs {
-            prev_ticks.push((proc.pid, proc.cpu_ticks));
+            prev_ticks.push(ProcTickSample {
+                pid: proc.pid,
+                cpu_ticks: proc.cpu_ticks,
+                sample_ticks: proc.cpu_sample_ticks,
+            });
         }
-        prev_global_ticks = global_ticks;
 
         // ── Render ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## NB-1a — btop CPU%-accounting fix (ARM64)

Fixes the operator-observed nonsense where btop showed **heartbeat at 189.9%** while the system was mostly idle.

**Root cause:** btop divided per-process ticks (summed across cores/threads per-PID) by `global_ticks`, which is incremented **only by CPU0** → ratios blew past 100%. heartbeat's sleep path was correct all along (`nanosleep` genuinely blocks).

**Fix (procfs + btop only; no gold-master/timer edits):**
- procfs exposes `cpu_online`, `cpu_sample_ticks`, `cpu_capacity_ticks` in `/proc/stat` + per-PID status.
- btop computes per-process % from each PID's `CpuTicks` delta over its `CpuSampleTicks` delta — htop-style (100% = one full core, capped at online×100%).

**Proof:** Parallels before/after — after the fix btop shows heartbeat 0.0%, btop 0.9%, bterm 1.4%, bwm 0.9%; no bogus values (`turn29-artifacts/nb1/parallels-btop-harness-screenshot.png`). Clean x86 + aarch64 builds.

**Note:** NB-1b (the genuine 2-core burn) is tracked separately — evidence points to the bounce/VirGL compositor at high FPS, not a busy-loop; GDB PC-sample proof was blocked by a QEMU ARM64 boot failure in `idle_loop_arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)