### PR TITLE
Fix bsh ls hang on ARM64

### DIFF
--- a/scripts/create_ext2_disk.sh
+++ b/scripts/create_ext2_disk.sh
@@ -173,6 +173,15 @@ if [[ "$(uname)" == "Darwin" ]]; then
             echo "  Installed $cbin_count C binaries in /usr/local/cbin"
             echo "  Installed $test_count test binaries in /usr/local/test/bin"
 
+            # Prefer the native Breenix ls over the BusyBox applet. The
+            # BusyBox ARM64 build currently faults in its libc path under bsh.
+            if [ -f /mnt/ext2/bin/bls ]; then
+                rm -f /mnt/ext2/bin/ls
+                cp /mnt/ext2/bin/bls /mnt/ext2/bin/ls
+                chmod 755 /mnt/ext2/bin/ls
+                echo "  Installed native Breenix ls as /bin/ls"
+            fi
+
             # Create /etc with passwd and group for musl getpwuid/getgrgid
             mkdir -p /mnt/ext2/etc
             cat > /mnt/ext2/etc/passwd << PASSWD
@@ -440,6 +449,15 @@ else
     echo "  Installed $cbin_count C binaries in /usr/local/cbin"
     echo "  Installed $test_count test binaries in /usr/local/test/bin"
 
+    # Prefer the native Breenix ls over the BusyBox applet. The BusyBox ARM64
+    # build currently faults in its libc path under bsh.
+    if [ -f "$MOUNT_DIR/bin/bls" ]; then
+        rm -f "$MOUNT_DIR/bin/ls"
+        cp "$MOUNT_DIR/bin/bls" "$MOUNT_DIR/bin/ls"
+        chmod 755 "$MOUNT_DIR/bin/ls"
+        echo "  Installed native Breenix ls as /bin/ls"
+    fi
+
     # Create /etc with passwd and group for musl getpwuid/getgrgid
     mkdir -p "$MOUNT_DIR/etc"
     cat > "$MOUNT_DIR/etc/passwd" << PASSWD
@@ -613,7 +631,8 @@ if [[ -f "$OUTPUT_FILE" ]]; then
     echo ""
     echo "Contents:"
     echo "  /bin/busybox - BusyBox multi-call binary"
-    echo "  /bin/{cat,ls,head,...} - BusyBox hardlinks"
+    echo "  /bin/ls - native Breenix ls"
+    echo "  /bin/{cat,head,tail,...} - BusyBox hardlinks"
     echo "  /sbin/{true,false} - BusyBox hardlinks"
     echo "  /bin/* - Other userspace binaries (demos)"
     echo "  /usr/local/test/bin/* - Test binaries (*_test, test_*)"


### PR DESCRIPTION
## Summary
- install native Breenix `bls` as `/bin/ls` when building the ext2 image
- remove `ls` from the BusyBox hardlink set in the generated image while leaving other BusyBox applets intact
- track the underlying BusyBox ARM64 applet fault separately as `breenix-b7u`

## Root cause / evidence
- Reproduced bare `ls` in bterm/bsh on ARM64 Parallels: command echoed, then no listing/prompt.
- Serial showed EL0 DATA_ABORT at `ELR=0x40028a1c`, `FAR=0xffffffffffffff5c`; disassembly maps that PC to BusyBox `ldr w19, [x21]`.
- Direct native `run("bls")` completed, printed the directory, exited 0, and returned to `bsh />`.
- After this image change, bare `ls` completed, printed the directory, exited 0 as `/bin/ls`, and returned to `bsh />`; no DATA_ABORT in the proof log.

## Verification
- `bash -n scripts/create_ext2_disk.sh`
- `git diff --check`
- `scripts/create_ext2_disk.sh --arch aarch64` shows `Installed native Breenix ls as /bin/ls`, `/bin/ls` size 325832, BusyBox hardlinks count 50
- Prior final clean builds for this turn: `cargo build --release --features testing,external_test_bins --bin qemu-uefi`; `userspace/programs/build.sh --arch aarch64`
- `cargo run -p xtask -- boot-stages` still fails at existing x86 ARP stage 22, unrelated to this ARM64 bsh ls fix

Artifacts: `turn31-artifacts/nb3-ls-hang/`