### PR TITLE
Fix BWM overlap clipping on ARM64

### DIFF
--- a/userspace/programs/src/bwm.rs
+++ b/userspace/programs/src/bwm.rs
@@ -1245,10 +1245,11 @@ fn blit_window_contents(vram: &mut [u32], screen_w: usize, screen_h: usize, wind
                     continue;
                 }
 
-                let ox0 = occ.content_x();
-                let oy0 = occ.content_y();
-                let ox1 = ox0 + occ.content_width() as i32;
-                let oy1 = oy0 + occ.content_height() as i32;
+                // Occlude lower window content against the full upper window,
+                // including titlebar, borders, and shadow. The client content
+                // rect starts below the chrome, so using only content bounds
+                // lets lower content overpaint upper chrome at overlaps.
+                let (ox0, oy0, ox1, oy1) = occ.bounds();
                 if py as i32 >= oy1 || (py as i32) < oy0 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- clip lower window client-content spans against the full higher-z window bounds
- protects upper titlebars, borders, and shadows from being overpainted by lower content
- leaves the existing span subtraction state machine unchanged

## Root cause
The ARM64 BWM direct-blit path draws window chrome into the compositor buffer first, then blits each client window's mapped content. The existing span clip subtracted only each higher-z window's content rect:

`content_x/content_y/content_width/content_height`

That protected upper client content, but not the upper titlebar, borders, or +3 shadow. A lower window's content row could therefore overpaint the already-drawn upper chrome at overlap boundaries.

Fix: use `occ.bounds()`, which is the full window rect including chrome and shadow.

## Parallels proof
A temporary userspace-only init harness spawned Terminal above Bounce to create deterministic overlap. The harness was reverted before commit; retained diff is only `userspace/programs/src/bwm.rs`.

Artifacts in `turn32-artifacts/nb4-overlap-clipping/`:
- `before-overlap.png`: Terminal over Bounce with chrome overpaint visible
- `after-overlap.png`: same overlap geometry after fix, clean titlebar/borders
- `pixel-titlebar-analysis.txt`: Terminal titlebar region x=80..835 y=88..122 changed from 46.8% dark overpaint to 0.1% dark pixels; blue titlebar coverage rose from 50.1% to 96.1%
- `before-serial.log`, `after-serial.log`: Bounce at (30,38), Terminal at (80,88), bwm-fps continuing, no DATA_ABORT/UNHANDLED_EC/panic markers in scanned logs

## Verification
- `cargo build --release --features testing,external_test_bins --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64`
- `userspace/programs/build.sh --arch aarch64`
- `scripts/create_ext2_disk.sh --arch aarch64`
- `git diff --check`
- warning/error grep across final build logs: no output

Per TURN 32 directive, I did not run x86 boot-stages.