### PR TITLE
Skip virtio-blk MMIO self-test on Parallels

### DIFF
--- a/kernel/src/drivers/mod.rs
+++ b/kernel/src/drivers/mod.rs
@@ -384,7 +384,15 @@ pub fn run_post_init_self_tests() {
     use crate::serial_println;
 
     serial_println!("[drivers] Running post-init self-tests...");
-    if let Err(e) = virtio::block_mmio::test_read() {
-        serial_println!("[drivers] VirtIO block test failed: {}", e);
+    if virtio::block_mmio::is_initialized() {
+        if let Err(e) = virtio::block_mmio::test_read() {
+            serial_println!("[drivers] VirtIO block test failed: {}", e);
+        }
+    } else if crate::platform_config::is_parallels() {
+        serial_println!(
+            "[drivers] VirtIO block self-test skipped: no VirtIO MMIO block device on Parallels; using AHCI"
+        );
+    } else {
+        serial_println!("[drivers] VirtIO block self-test skipped: no VirtIO MMIO block device");
     }
 }

--- a/kernel/src/drivers/virtio/block_mmio.rs
+++ b/kernel/src/drivers/virtio/block_mmio.rs
@@ -456,6 +456,11 @@ fn virt_to_phys(addr: u64) -> u64 {
 /// Number of initialized block devices
 static DEVICE_COUNT: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
 
+/// Return true when at least one VirtIO MMIO block device initialized.
+pub fn is_initialized() -> bool {
+    DEVICE_COUNT.load(core::sync::atomic::Ordering::Acquire) > 0
+}
+
 /// Initialize all VirtIO block devices
 pub fn init() -> Result<(), &'static str> {
     crate::serial_println!("[virtio-blk] Searching for block devices...");


### PR DESCRIPTION
## Summary
- Gate the ARM64 virtio-blk MMIO sector-0 self-test on actual MMIO block initialization.
- Report an explicit Parallels skip because the platform exposes PCI VirtIO net/GPU and AHCI disks, not MMIO virtio-blk.
- Keep AHCI as the storage path on Parallels.

## Root Cause
The failing log was not a virtio-blk initialization race. On Parallels, driver init takes the PCI path, initializes VirtIO PCI net/GPU, then AHCI. The post-init self-test unconditionally called the MMIO virtio-blk test anyway, so it reported Block device not initialized even though there was no MMIO block device to test.

## Validation
- Baseline ARM/Parallels reproduced: VirtIO block test failed: Block device not initialized.
- After ARM/Parallels run shows: VirtIO block self-test skipped: no VirtIO MMIO block device on Parallels; using AHCI.
- After log still mounts ext2 via AHCI device 1.
- cargo build --release --features testing,external_test_bins --bin qemu-uefi produced no warning/error grep output.
- After run/build warning/error grep produced no output.
- After serial fault-marker scan produced no panic/fault markers.