### PR TITLE
Fix ARM64 QEMU GICv3 boot detection

### DIFF
--- a/docker/qemu/run-aarch64-boot-test-native.sh
+++ b/docker/qemu/run-aarch64-boot-test-native.sh
@@ -58,7 +58,8 @@ run_single_test() {
     local EXT2_WRITABLE="$OUTPUT_DIR/ext2-writable.img"
     cp "$EXT2_DISK" "$EXT2_WRITABLE"
 
-    # Run QEMU with 30s timeout
+    # Run QEMU with 30s timeout.
+    # Breenix ARM64 expects a GICv3 CPU interface, matching Parallels.
     # Always include GPU, keyboard, and network so kernel VirtIO enumeration finds them
     # Use writable disk copy (no readonly=on) to allow filesystem writes
     #
@@ -71,7 +72,7 @@ run_single_test() {
         DISK_DEVICE_OPTS="-device virtio-blk-device,drive=ext2"
     fi
     timeout 30 qemu-system-aarch64 \
-        -M virt -cpu max -m 512 -smp 4 \
+        -M virt,gic-version=3 -cpu max -m 512 -smp 4 \
         -kernel "$KERNEL" \
         -display none -no-reboot \
         -device virtio-gpu-device \

--- a/docker/qemu/run-aarch64-boot-test-strict.sh
+++ b/docker/qemu/run-aarch64-boot-test-strict.sh
@@ -68,11 +68,12 @@ run_single_test() {
     local EXT2_WRITABLE="$OUTPUT_DIR/ext2-writable.img"
     cp "$EXT2_DISK" "$EXT2_WRITABLE"
 
-    # Run QEMU with 20s timeout
+    # Run QEMU with 20s timeout.
+    # Breenix ARM64 expects a GICv3 CPU interface, matching Parallels.
     # Always include GPU, keyboard, and network so kernel VirtIO enumeration finds them
     # Use writable disk copy (no readonly=on) to allow filesystem writes
     timeout 20 qemu-system-aarch64 \
-        -M virt -cpu cortex-a72 -m 512 -smp 4 \
+        -M virt,gic-version=3 -cpu cortex-a72 -m 512 -smp 4 \
         -kernel "$KERNEL" \
         -display none -no-reboot \
         -device virtio-gpu-device \

--- a/kernel/src/arch_impl/aarch64/gic.rs
+++ b/kernel/src/arch_impl/aarch64/gic.rs
@@ -102,15 +102,31 @@ fn probe_and_validate_gicr() -> bool {
 
     // Candidate addresses to try in order:
     //   1. Whatever the UEFI loader reported (may be wrong on M5 Max)
-    //   2. Known Parallels GICR on M3 Max
-    //   3. Common alternative addresses seen on real Apple Silicon under Parallels
-    let candidates: &[usize] = &[
+    //   2. QEMU virt GICv3 redistributor base (from its device tree)
+    //   3. Known Parallels GICR fallbacks
+    //
+    // Probe order matters because reads from absent device space can return
+    // zero instead of faulting on some QEMU mappings. Prefer QEMU's known
+    // redistributor base before Parallels fallbacks on the QEMU platform.
+    let qemu_candidates: &[usize] = &[
+        reported_base,
+        0x080A_0000, // QEMU virt GICv3 redistributor
+        0x0250_0000, // Parallels M3 Max
+        0x0260_0000, // potential M5 Max offset
+        0x0200_0000, // the base that causes the crash (wrong, but keep to log)
+    ];
+    let platform_candidates: &[usize] = &[
         reported_base,
         0x0250_0000, // Parallels M3 Max
         0x0260_0000, // potential M5 Max offset
         0x0200_0000, // the base that causes the crash (wrong, but keep to log)
-        0x080A_0000, // another common GICR location
+        0x080A_0000, // QEMU virt GICv3 redistributor
     ];
+    let candidates = if crate::platform_config::is_qemu() {
+        qemu_candidates
+    } else {
+        platform_candidates
+    };
 
     for &base in candidates {
         if base == 0 {
@@ -253,6 +269,7 @@ static LAST_ACK_GROUP: AtomicU32 = AtomicU32::new(0);
 
 /// Peripheral ID Register 2 (contains GIC architecture version)
 const GICD_PIDR2: usize = 0xFE8;
+const GICD_PIDR2_GICV3: usize = 0xFFE8;
 
 // =============================================================================
 // Register Access Helpers
@@ -470,12 +487,17 @@ pub fn init_cpu_interface_secondary() {
 impl Gicv2 {
     /// Detect the GIC architecture version by reading GICD_PIDR2.
     ///
-    /// The GICD base address (0x0800_0000) is present on both GICv2 and GICv3
-    /// on QEMU virt, so this read is safe regardless of GIC version.
+    /// GICv2 exposes peripheral ID registers in the legacy 4KB distributor
+    /// window; GICv3 uses the 64KB distributor window and exposes PIDR2 near
+    /// the end of that window.
     /// Returns the architecture version (2, 3, or 4).
     fn detect_version() -> u8 {
-        let pidr2 = gicd_read(GICD_PIDR2);
-        ((pidr2 >> 4) & 0xF) as u8
+        let legacy_version = (gicd_read(GICD_PIDR2) >> 4) & 0xF;
+        if legacy_version != 0 {
+            return legacy_version as u8;
+        }
+
+        ((gicd_read(GICD_PIDR2_GICV3) >> 4) & 0xF) as u8
     }
 }
 


### PR DESCRIPTION
## Summary
- request QEMU's GICv3 machine model in the ARM64 native and strict boot-test harnesses
- detect QEMU GICv3 using the 64KB distributor PIDR2 offset when the legacy GICv2 PIDR2 location reads as version 0
- prefer QEMU's real GICR base (0x080a0000) before Parallels fallback bases during QEMU redistributor probing

## Evidence
- Baseline native boot test reproduced the directed failure: repeated `[UNHANDLED_EC] cpu=0 EC=0x0 ELR=0xffff00004010f980`; disassembly maps ELR to `idle_loop_arm64+0x2a4`, the `mrs x9, ICC_PMR_EL1` instruction.
- `-M virt,gic-version=3` before the detector fix panicked at `kernel/src/arch_impl/aarch64/gic.rs:522`: `Unknown GIC architecture version 0`, proving the existing detector did not recognize QEMU GICv3.
- After this change, QEMU logs `GIC initialized (version 3)` and `GICR probe 0x080a0000: WAKER=0x00000006 <<< VALID`; the original CPU0 idle-loop EC flood is gone.
- Clean ARM64 build: `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` finished with no warning/error lines.

## Remaining known issue
- The full native boot-test still fails under `-smp 4`, but with a different later failure: after userspace service spawn, bogus ELRs point into data/BSS symbols such as `0xffff00004022d000` and `0xffff00004024f418`.
- Bounded comparison: `-M virt,gic-version=3 -smp 1` reaches init, heartbeat, bsshd, bounce, and 30s of CPU0 timer ticks without fatal exception markers.
- Follow-up tracked as Beads `breenix-tjh`: ARM64 QEMU GICv3 `-smp 4` context corruption.

## Artifacts
- `turn36-artifacts/nb7-aarch64-qemu/native-serial.txt` baseline failure
- `turn36-artifacts/nb7-aarch64-qemu/native-final-serial.txt` post-fix `-smp 4` later failure
- `turn36-artifacts/nb7-aarch64-qemu/gicv3-smp1-serial.txt` bounded `-smp 1` success evidence
