### PR TITLE
fix(aarch64): GPU present-fence compositor — eliminate BWM CPU burn + complete-lockup

### DIFF
--- a/kernel/src/drivers/virtio/gpu_pci.rs
+++ b/kernel/src/drivers/virtio/gpu_pci.rs
@@ -103,6 +103,46 @@ fn relax_gpu_lock_wait() {
 /// buffers and virtqueue state.
 static GPU_PCI_LOCK: GpuPciLock = GpuPciLock::new();
 static VIRTGPU_CMD_SEQ: AtomicU32 = AtomicU32::new(0);
+static COMPOSITOR_PRESENT_NEXT_ID: AtomicU64 = AtomicU64::new(1);
+static COMPOSITOR_PRESENT_IN_FLIGHT: AtomicU32 = AtomicU32::new(0);
+
+struct CompositorPresentToken {
+    id: u64,
+    active: bool,
+}
+
+impl CompositorPresentToken {
+    fn begin() -> Result<Self, &'static str> {
+        let previous = COMPOSITOR_PRESENT_IN_FLIGHT.fetch_add(1, Ordering::AcqRel);
+        if previous != 0 {
+            COMPOSITOR_PRESENT_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
+            virtgpu::trace_compositor_present_inflight_gt1();
+            return Err("compositor present already in flight");
+        }
+
+        let id = COMPOSITOR_PRESENT_NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        virtgpu::trace_compositor_present_submitted();
+        Ok(Self { id, active: true })
+    }
+
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    fn complete(mut self) {
+        virtgpu::trace_compositor_present_completed();
+        self.active = false;
+        COMPOSITOR_PRESENT_IN_FLIGHT.store(0, Ordering::Release);
+    }
+}
+
+impl Drop for CompositorPresentToken {
+    fn drop(&mut self) {
+        if self.active {
+            COMPOSITOR_PRESENT_IN_FLIGHT.store(0, Ordering::Release);
+        }
+    }
+}
 
 // =============================================================================
 // VirtIO GPU Protocol (same as gpu_mmio.rs)
@@ -5059,15 +5099,24 @@ fn virgl_composite_single_quad(
         );
     }
 
-    let _fence_id = virgl_submit(cmdbuf.as_slice())?;
-    with_device_state(|state| set_scanout_resource(state, RESOURCE_3D_ID))?;
-    with_device_state(|state| {
+    let present = CompositorPresentToken::begin()?;
+    if present.id() == 0 {
+        return Err("invalid compositor present token");
+    }
+
+    let flush_result = with_device_state(|state| {
+        virgl_submit_sync_locked(state, cmdbuf.as_slice())?;
+        set_scanout_resource(state, RESOURCE_3D_ID)?;
         resource_flush_3d(
             state,
             RESOURCE_3D_ID,
             virtgpu::FLUSH_CALLER_VIRGL_COMPOSITE_SINGLE_QUAD,
         )
-    })
+    });
+    if flush_result.is_ok() {
+        present.complete();
+    }
+    flush_result
 }
 
 /// Multi-window GPU compositor.
@@ -5381,7 +5430,14 @@ pub fn virgl_submit(cmds: &[u32]) -> Result<u64, &'static str> {
 /// (FLAG_FENCE means the device waited for GPU completion), skip the
 /// extra fence verification command entirely.
 pub fn virgl_submit_sync(cmds: &[u32]) -> Result<(), &'static str> {
-    let result = with_device_state(|state| virgl_submit_3d_cmd(state, VIRGL_CTX_ID, cmds))?;
+    with_device_state(|state| virgl_submit_sync_locked(state, cmds))
+}
+
+fn virgl_submit_sync_locked(
+    state: &mut GpuPciDeviceState,
+    cmds: &[u32],
+) -> Result<(), &'static str> {
+    let result = virgl_submit_3d_cmd(state, VIRGL_CTX_ID, cmds)?;
 
     // Fast path: the device response already confirmed our fence completed.
     // With VIRTIO_GPU_FLAG_FENCE, Parallels waits for GPU completion before
@@ -5392,7 +5448,7 @@ pub fn virgl_submit_sync(cmds: &[u32]) -> Result<(), &'static str> {
 
     // Slow path: fence not yet confirmed; issue one interrupt-completed NOP
     // and fail if the host still does not report the target fence.
-    with_device_state(|state| virgl_fence_sync(state, result.submit_id))
+    virgl_fence_sync(state, result.submit_id)
 }
 
 /// Copy 3D framebuffer backing (heap RAM) → BAR0 (display memory).

--- a/kernel/src/syscall/graphics.rs
+++ b/kernel/src/syscall/graphics.rs
@@ -184,6 +184,42 @@ fn wake_presented_client_frames() {
 }
 
 #[cfg(target_arch = "aarch64")]
+fn release_presented_window_frames(
+    windows: &[WindowCompositeInfo],
+) -> [Option<u64>; MAX_WINDOW_BUFFERS] {
+    let mut threads_to_wake: [Option<u64>; MAX_WINDOW_BUFFERS] = [None; MAX_WINDOW_BUFFERS];
+    let mut wake_count = 0usize;
+
+    {
+        let mut reg = WINDOW_REGISTRY.lock();
+        for win in windows.iter().filter(|win| win.dirty) {
+            let Some(buf) = reg.find_mut(win.buffer_id) else {
+                continue;
+            };
+
+            if buf.generation != win.generation {
+                continue;
+            }
+
+            buf.last_uploaded_gen = win.generation;
+            if wake_count < MAX_WINDOW_BUFFERS {
+                threads_to_wake[wake_count] = buf.waiting_thread_id.take();
+                wake_count += 1;
+            }
+        }
+    }
+
+    crate::tracing::providers::virtgpu::trace_compositor_client_waiters_released(
+        threads_to_wake
+            .iter()
+            .filter(|thread_id| thread_id.is_some())
+            .count() as u64,
+    );
+
+    threads_to_wake
+}
+
+#[cfg(target_arch = "aarch64")]
 fn compositor_ready_bits(last_registry_gen: u64, prev_mouse: u64) -> (u64, u64, u64) {
     use core::sync::atomic::Ordering;
 
@@ -1319,10 +1355,6 @@ fn handle_compositor_wait(cmd: &FbDrawCmd) -> SyscallResult {
     let prev_mouse = COMPOSITOR_LAST_MOUSE.load(Ordering::Relaxed);
 
     loop {
-        // WHY: repair the read-but-not-released wedge captured in
-        // turn3-wedge-snapshot.md before BWM sleeps on the compositor latch.
-        wake_presented_client_frames();
-
         let (ready, cur_reg_gen, mouse_packed) =
             compositor_ready_bits(last_registry_gen, prev_mouse);
         if ready != 0 {
@@ -1477,13 +1509,12 @@ fn handle_composite_windows(desc_ptr: u64) -> SyscallResult {
         None
     };
 
-    // Collect window info and waiting thread IDs under lock, then release.
+    // Collect window info under lock, then release. Dirty generations are
+    // advanced only after the GPU present path returns successfully.
     // Also lazy-initialize VirGL textures for windows that don't have them yet.
-    let mut threads_to_wake: [Option<u64>; MAX_WINDOW_BUFFERS] = [None; MAX_WINDOW_BUFFERS];
     let windows: alloc::vec::Vec<WindowCompositeInfo> = {
         let mut reg = WINDOW_REGISTRY.lock();
         let mut result = alloc::vec::Vec::new();
-        let mut win_idx = 0usize;
         for slot in reg.buffers.iter_mut() {
             if let Some(ref mut buf) = slot {
                 if !buf.registered {
@@ -1527,6 +1558,7 @@ fn handle_composite_windows(desc_ptr: u64) -> SyscallResult {
                 }
 
                 result.push(WindowCompositeInfo {
+                    buffer_id: buf.id,
                     virgl_resource_id: buf.virgl_resource_id,
                     virgl_initialized: buf.virgl_initialized,
                     width: buf.width,
@@ -1540,15 +1572,8 @@ fn handle_composite_windows(desc_ptr: u64) -> SyscallResult {
                     title_len: buf.title_len,
                     title: buf.title,
                     chromeless,
+                    generation: buf.generation,
                 });
-
-                if dirty {
-                    buf.last_uploaded_gen = buf.generation;
-                    if win_idx < MAX_WINDOW_BUFFERS {
-                        threads_to_wake[win_idx] = buf.waiting_thread_id.take();
-                    }
-                }
-                win_idx += 1;
             }
         }
         // Sort by z_order so GPU draws back-to-front (lower z = drawn first).
@@ -1596,6 +1621,12 @@ fn handle_composite_windows(desc_ptr: u64) -> SyscallResult {
         }
     };
 
+    let threads_to_wake = if matches!(result, SyscallResult::Ok(0)) {
+        release_presented_window_frames(&windows)
+    } else {
+        [None; MAX_WINDOW_BUFFERS]
+    };
+
     // Wake blocked clients after GPU work completes (frame pacing back-pressure).
     // This must happen OUTSIDE the WINDOW_REGISTRY lock.
     if threads_to_wake.iter().any(|tid| tid.is_some()) {
@@ -1608,6 +1639,7 @@ fn handle_composite_windows(desc_ptr: u64) -> SyscallResult {
 /// Info about a window to be composited, extracted from the registry.
 #[cfg(target_arch = "aarch64")]
 pub struct WindowCompositeInfo {
+    pub buffer_id: u32,
     pub virgl_resource_id: u32,
     pub virgl_initialized: bool,
     pub width: u32,
@@ -1621,6 +1653,7 @@ pub struct WindowCompositeInfo {
     pub title_len: usize,
     pub title: [u8; MAX_TITLE_LEN],
     pub chromeless: bool,
+    pub generation: u64,
 }
 
 /// Handle create_window_buffer: allocate physical pages for a window pixel buffer,

--- a/kernel/src/tracing/providers/virtgpu.rs
+++ b/kernel/src/tracing/providers/virtgpu.rs
@@ -170,6 +170,30 @@ pub static VIRTGPU_WAIT_COMPLETION_EXIT_TOTAL: TraceCounter = TraceCounter::new(
 );
 
 #[no_mangle]
+pub static VIRTGPU_COMPOSITOR_PRESENT_SUBMITTED_TOTAL: TraceCounter = TraceCounter::new(
+    "VIRTGPU_COMPOSITOR_PRESENT_SUBMITTED_TOTAL",
+    "BWM SUBMIT_3D compositor presents submitted",
+);
+
+#[no_mangle]
+pub static VIRTGPU_COMPOSITOR_PRESENT_COMPLETED_TOTAL: TraceCounter = TraceCounter::new(
+    "VIRTGPU_COMPOSITOR_PRESENT_COMPLETED_TOTAL",
+    "BWM SUBMIT_3D compositor presents completed",
+);
+
+#[no_mangle]
+pub static VIRTGPU_COMPOSITOR_PRESENT_INFLIGHT_GT1_TOTAL: TraceCounter = TraceCounter::new(
+    "VIRTGPU_COMPOSITOR_PRESENT_INFLIGHT_GT1_TOTAL",
+    "BWM compositor present attempts rejected because one present was already in flight",
+);
+
+#[no_mangle]
+pub static VIRTGPU_COMPOSITOR_CLIENT_WAITERS_RELEASED_TOTAL: TraceCounter = TraceCounter::new(
+    "VIRTGPU_COMPOSITOR_CLIENT_WAITERS_RELEASED_TOTAL",
+    "Client Window::present waiters released after compositor present completion",
+);
+
+#[no_mangle]
 pub static VIRTGPU_LAST_COMPLETION_MS: AtomicU64 = AtomicU64::new(0);
 
 #[no_mangle]
@@ -317,6 +341,10 @@ pub fn init() {
     register_counter(&VIRTGPU_SUBMIT_3D_EXIT_TOTAL);
     register_counter(&VIRTGPU_WAIT_COMPLETION_ENTER_TOTAL);
     register_counter(&VIRTGPU_WAIT_COMPLETION_EXIT_TOTAL);
+    register_counter(&VIRTGPU_COMPOSITOR_PRESENT_SUBMITTED_TOTAL);
+    register_counter(&VIRTGPU_COMPOSITOR_PRESENT_COMPLETED_TOTAL);
+    register_counter(&VIRTGPU_COMPOSITOR_PRESENT_INFLIGHT_GT1_TOTAL);
+    register_counter(&VIRTGPU_COMPOSITOR_CLIENT_WAITERS_RELEASED_TOTAL);
     register_counter(&VIRTGPU_R2_CREATE);
     register_counter(&VIRTGPU_R2_ATTACH_BACKING);
     register_counter(&VIRTGPU_R2_CTX_ATTACH);
@@ -503,6 +531,28 @@ pub fn trace_wait_completion_exit(cmd_type: u32, resource_id: u32, path: u8, ok:
         flags,
         payload
     );
+}
+
+#[inline(always)]
+pub fn trace_compositor_present_submitted() {
+    crate::trace_count!(VIRTGPU_COMPOSITOR_PRESENT_SUBMITTED_TOTAL);
+}
+
+#[inline(always)]
+pub fn trace_compositor_present_completed() {
+    crate::trace_count!(VIRTGPU_COMPOSITOR_PRESENT_COMPLETED_TOTAL);
+}
+
+#[inline(always)]
+pub fn trace_compositor_present_inflight_gt1() {
+    crate::trace_count!(VIRTGPU_COMPOSITOR_PRESENT_INFLIGHT_GT1_TOTAL);
+}
+
+#[inline(always)]
+pub fn trace_compositor_client_waiters_released(count: u64) {
+    if count > 0 {
+        VIRTGPU_COMPOSITOR_CLIENT_WAITERS_RELEASED_TOTAL.add(count);
+    }
 }
 
 #[inline(always)]

--- a/userspace/programs/src/bwm.rs
+++ b/userspace/programs/src/bwm.rs
@@ -93,15 +93,6 @@ const CLOSE_BTN_TEXT: Color = Color::rgb(255, 255, 255);
 const MINIMIZE_BTN_BG: Color = Color::rgb(80, 85, 100);
 const MINIMIZE_BTN_TEXT: Color = Color::rgb(255, 255, 255);
 
-#[cfg(target_arch = "aarch64")]
-const SOFTWARE_CURSOR_W: usize = 16;
-#[cfg(target_arch = "aarch64")]
-const SOFTWARE_CURSOR_H: usize = 16;
-#[cfg(target_arch = "aarch64")]
-const SOFTWARE_CURSOR_WHITE: u32 = 0x00ff_ffff;
-#[cfg(target_arch = "aarch64")]
-const SOFTWARE_CURSOR_BLACK: u32 = 0x0001_0101;
-
 // ─── Input Parser ────────────────────────────────────────────────────────────
 // Parses stdin bytes (keyboard input) into InputEvents that BWM can either
 // handle internally (F-key focus switching) or route to the focused client
@@ -584,12 +575,6 @@ struct Window {
     /// Chromeless windows have no title bar, border, or chrome buttons.
     /// Detected by title prefix \x01.
     chromeless: bool,
-    #[cfg(target_arch = "aarch64")]
-    mapped_pixels: Option<*const u32>,
-    #[cfg(target_arch = "aarch64")]
-    mapped_width: usize,
-    #[cfg(target_arch = "aarch64")]
-    mapped_height: usize,
 }
 
 impl Window {
@@ -1135,11 +1120,6 @@ fn discover_windows(
 
         let order = *next_order;
         *next_order += 1;
-        #[cfg(target_arch = "aarch64")]
-        let (mapped_pixels, mapped_width, mapped_height) = match graphics::map_window_buffer(info.buffer_id) {
-            Ok((ptr, w, h)) => (Some(ptr), w as usize, h as usize),
-            Err(_) => (None, 0, 0),
-        };
         windows.push(Window {
             x: win_x, y: win_y, width: win_w, height: win_h,
             title, title_len, window_id: info.buffer_id,
@@ -1147,12 +1127,6 @@ fn discover_windows(
             minimized: false,
             creation_order: order,
             chromeless,
-            #[cfg(target_arch = "aarch64")]
-            mapped_pixels,
-            #[cfg(target_arch = "aarch64")]
-            mapped_width,
-            #[cfg(target_arch = "aarch64")]
-            mapped_height,
         });
         added = true;
     }
@@ -1182,214 +1156,6 @@ fn redraw_all_windows(fb: &mut FrameBuf, windows: &[Window], focused_win: usize,
         draw_window_frame(fb, &windows[i], i == focused_win, ui_font);
     }
     draw_appbar(fb, windows, focused_win, ui_font);
-}
-
-#[cfg(target_arch = "aarch64")]
-fn blit_window_contents(vram: &mut [u32], screen_w: usize, screen_h: usize, windows: &[Window]) {
-    for (idx, win) in windows.iter().enumerate() {
-        if win.minimized {
-            continue;
-        }
-        let Some(ptr) = win.mapped_pixels else {
-            continue;
-        };
-
-        let src_w = win.mapped_width.min(win.content_width());
-        let src_h = win.mapped_height.min(win.content_height());
-        if src_w == 0 || src_h == 0 {
-            continue;
-        }
-
-        let dst_x = win.content_x();
-        let dst_y = win.content_y();
-        if dst_x < 0 || dst_y < 0 {
-            continue;
-        }
-        let dst_x = dst_x as usize;
-        let dst_y = dst_y as usize;
-        if dst_x >= screen_w || dst_y >= screen_h {
-            continue;
-        }
-        let copy_w = src_w.min(screen_w - dst_x);
-        let copy_h = src_h.min(screen_h - dst_y);
-        let src = unsafe { core::slice::from_raw_parts(ptr, win.mapped_width * win.mapped_height) };
-
-        let _ = graphics::check_window_dirty(win.window_id);
-
-        let has_occluders = windows[idx + 1..].iter().any(|occ| {
-            !occ.minimized
-                && occ.mapped_pixels.is_some()
-                && occ.content_width() > 0
-                && occ.content_height() > 0
-        });
-        if !has_occluders {
-            for row in 0..copy_h {
-                let src_start = row * win.mapped_width;
-                let dst_start = (dst_y + row) * screen_w + dst_x;
-                vram[dst_start..dst_start + copy_w].copy_from_slice(&src[src_start..src_start + copy_w]);
-            }
-            continue;
-        }
-
-        for row in 0..copy_h {
-            let py = dst_y + row;
-
-            // Port of 34a6c51e lines 438-461: start with the full row span,
-            // then subtract columns covered by higher-z window content.
-            let mut spans = [(0usize, 0usize); 8];
-            let mut n_spans = 1;
-            spans[0] = (dst_x, dst_x + copy_w);
-
-            for occ in &windows[idx + 1..] {
-                if occ.minimized || occ.mapped_pixels.is_none() {
-                    continue;
-                }
-
-                // Occlude lower window content against the full upper window,
-                // including titlebar, borders, and shadow. The client content
-                // rect starts below the chrome, so using only content bounds
-                // lets lower content overpaint upper chrome at overlaps.
-                let (ox0, oy0, ox1, oy1) = occ.bounds();
-                if py as i32 >= oy1 || (py as i32) < oy0 {
-                    continue;
-                }
-
-                let os = ox0.max(0) as usize;
-                let oe = ox1.max(0) as usize;
-                let mut new_spans = [(0usize, 0usize); 8];
-                let mut nc = 0;
-                for &(sx, ex) in spans[..n_spans].iter() {
-                    if sx >= ex {
-                        continue;
-                    }
-                    if oe <= sx || os >= ex {
-                        if nc < 8 {
-                            new_spans[nc] = (sx, ex);
-                            nc += 1;
-                        }
-                    } else {
-                        if sx < os && nc < 8 {
-                            new_spans[nc] = (sx, os);
-                            nc += 1;
-                        }
-                        if ex > oe && nc < 8 {
-                            new_spans[nc] = (oe, ex);
-                            nc += 1;
-                        }
-                    }
-                }
-                spans = new_spans;
-                n_spans = nc;
-            }
-
-            let src_row = row * win.mapped_width;
-            for &(sx, ex) in spans[..n_spans].iter() {
-                if sx >= ex {
-                    continue;
-                }
-                let count = ex - sx;
-                let src_start = src_row + (sx - dst_x);
-                let dst_start = py * screen_w + sx;
-                vram[dst_start..dst_start + count].copy_from_slice(&src[src_start..src_start + count]);
-            }
-        }
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-fn software_cursor_hotspot(shape: u32) -> (i32, i32) {
-    if shape == graphics::cursor_shape::ARROW {
-        (0, 0)
-    } else {
-        (8, 8)
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-fn cursor_body_pixel(shape: u32, row: i32, col: i32) -> bool {
-    match shape {
-        graphics::cursor_shape::RESIZE_NS => {
-            (col == 7 && (3..=12).contains(&row))
-                || (row <= 3 && (col - 7).abs() <= 3 - row)
-                || (row >= 12 && (col - 7).abs() <= row - 12)
-        }
-        graphics::cursor_shape::RESIZE_EW => {
-            (row == 7 && (3..=12).contains(&col))
-                || (col <= 3 && (row - 7).abs() <= 3 - col)
-                || (col >= 12 && (row - 7).abs() <= col - 12)
-        }
-        graphics::cursor_shape::RESIZE_NWSE => {
-            ((2..=13).contains(&row) && (col == row || col == row + 1))
-                || (row <= 4 && col <= 4 && row + col <= 5)
-                || (row >= 11 && col >= 11 && row + col >= 25)
-        }
-        graphics::cursor_shape::RESIZE_NESW => {
-            ((2..=13).contains(&row) && (col == 15 - row || col == 14 - row))
-                || (row <= 4 && col >= 11 && col - row >= 11)
-                || (row >= 11 && col <= 4 && row - col >= 11)
-        }
-        _ => {
-            (row <= 9 && col >= 1 && col < row)
-                || (row == 10 && (1..=5).contains(&col))
-                || (row == 11 && ((1..=3).contains(&col) || (4..=5).contains(&col)))
-                || (row == 12 && (4..=6).contains(&col))
-                || ((13..=14).contains(&row) && (5..=6).contains(&col))
-        }
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-fn cursor_pixel(shape: u32, row: usize, col: usize) -> u32 {
-    let row = row as i32;
-    let col = col as i32;
-    if cursor_body_pixel(shape, row, col) {
-        return SOFTWARE_CURSOR_WHITE;
-    }
-
-    for dy in -1..=1 {
-        for dx in -1..=1 {
-            if dx == 0 && dy == 0 {
-                continue;
-            }
-            if cursor_body_pixel(shape, row + dy, col + dx) {
-                return SOFTWARE_CURSOR_BLACK;
-            }
-        }
-    }
-
-    0
-}
-
-#[cfg(target_arch = "aarch64")]
-fn draw_software_cursor(
-    vram: &mut [u32],
-    screen_w: usize,
-    screen_h: usize,
-    mouse_x: i32,
-    mouse_y: i32,
-    shape: u32,
-) {
-    let shape = shape.min(graphics::cursor_shape::RESIZE_NESW);
-    let (hot_x, hot_y) = software_cursor_hotspot(shape);
-    let base_x = mouse_x - hot_x;
-    let base_y = mouse_y - hot_y;
-
-    for row in 0..SOFTWARE_CURSOR_H {
-        let y = base_y + row as i32;
-        if y < 0 || y >= screen_h as i32 {
-            continue;
-        }
-        for col in 0..SOFTWARE_CURSOR_W {
-            let x = base_x + col as i32;
-            if x < 0 || x >= screen_w as i32 {
-                continue;
-            }
-            let pixel = cursor_pixel(shape, row, col);
-            if pixel != 0 {
-                vram[y as usize * screen_w + x as usize] = pixel;
-            }
-        }
-    }
 }
 
 fn restore_full_background(vram: &mut [u32], fb: &mut FrameBuf, bg: &[u32]) {
@@ -1713,21 +1479,25 @@ fn main() {
     #[cfg(not(target_arch = "aarch64"))]
     hotkey_mgr.load_config("/etc/hotkeys.conf");
 
-    // Initial composite. On ARM64 Parallels, the op16 SUBMIT_3D compositor path
-    // times out after bwm takes over scanout, so present the CPU-composited
-    // desktop through the proven direct VirGL blit path.
+    // Initial composite. ARM64 uses the same op16 SUBMIT_3D compositor path as
+    // steady-state frames so presentation is gated by the GPU present fence.
     #[cfg(target_arch = "aarch64")]
     {
-        let _ = direct_mapped;
-        draw_software_cursor(
-            composite_buf,
-            screen_w,
-            screen_h,
-            mouse_x,
-            mouse_y,
-            active_cursor_shape,
-        );
-        let _ = graphics::virgl_composite(composite_buf, screen_w as u32, screen_h as u32);
+        if direct_mapped {
+            let _ = graphics::virgl_composite_windows_rect(
+                &[],
+                0,
+                0,
+                1,
+                0,
+                0,
+                screen_w as u32,
+                screen_h as u32,
+            );
+        } else {
+            let _ =
+                graphics::virgl_composite_windows(composite_buf, screen_w as u32, screen_h as u32, true);
+        }
     }
     #[cfg(not(target_arch = "aarch64"))]
     {
@@ -2271,29 +2041,33 @@ fn main() {
         #[cfg(target_arch = "aarch64")]
         {
             if full_redraw || content_dirty || windows_dirty || mouse_moved_this_frame || cursor_dirty {
-                let _dirty_rect_snapshot = (dirty_x0, dirty_y0, dirty_x1, dirty_y1);
-                if mouse_moved_this_frame || cursor_dirty {
-                    compose_full_redraw(
-                        composite_buf,
-                        &mut fb,
-                        &mut shadow_fb,
-                        &bg_cache,
-                        &windows,
-                        focused_win,
-                        &clock_text,
-                        &mut ui_font,
+                let (cbuf, cw, ch): (&[u32], u32, u32) = if direct_mapped {
+                    (&[], 0, 0)
+                } else {
+                    (&composite_buf, screen_w as u32, screen_h as u32)
+                };
+                if full_redraw {
+                    let _ = graphics::virgl_composite_windows_rect(
+                        cbuf,
+                        cw,
+                        ch,
+                        1,
+                        0,
+                        0,
+                        screen_w as u32,
+                        screen_h as u32,
                     );
+                } else if content_dirty {
+                    let sw = screen_w as i32;
+                    let sh = screen_h as i32;
+                    let dx = dirty_x0.max(0) as u32;
+                    let dy = dirty_y0.max(0) as u32;
+                    let dw = (dirty_x1.min(sw) - dirty_x0.max(0)).max(0) as u32;
+                    let dh = (dirty_y1.min(sh) - dirty_y0.max(0)).max(0) as u32;
+                    let _ = graphics::virgl_composite_windows_rect(cbuf, cw, ch, 2, dx, dy, dw, dh);
+                } else if windows_dirty || mouse_moved_this_frame || cursor_dirty {
+                    let _ = graphics::virgl_composite_windows_rect(cbuf, cw, ch, 0, 0, 0, 0, 0);
                 }
-                blit_window_contents(composite_buf, screen_w, screen_h, &windows);
-                draw_software_cursor(
-                    composite_buf,
-                    screen_w,
-                    screen_h,
-                    mouse_x,
-                    mouse_y,
-                    active_cursor_shape,
-                );
-                let _ = graphics::virgl_composite(composite_buf, screen_w as u32, screen_h as u32);
                 full_redraw = false;
                 content_dirty = false;
                 windows_dirty = false;


### PR DESCRIPTION
## Summary
- Replace the rejected throttle/direct-scanout direction with the Linux-grounded present-fence model.
- Restore the op16 SUBMIT_3D compositor path with at most one compositor present in flight.
- Release client present waiters only after GPU present completion, preserving dirty state on failures.
- Add virtgpu present counters for submitted/completed/inflight/waiter release visibility.

## Proven fixed in this PR
- Complete lockup from the prior direct-scanout experiment is fixed.
- CPU0/BWM burn is eliminated in the validated core path; BWM is off the top CPU slot.
- Single-window Bounce remains in the known-good FPS class, roughly 180-220 FPS.
- Present accounting held with submitted == completed and inflight > 1 == 0.

## Known follow-up, intentionally separate
- Multi-window second-window virtio-gpu control-queue marshalling corruption is not fixed here.
- Evidence: VIRTGPU_FAIL / cmd=0xbf800000 and related payload-looking command words under the second-window path.
- That work continues on a new branch after this scoped core fix lands.

## Validation
- ARM64 kernel/userspace builds were clean in the validating turn.
- Default Parallels + Bounce path was clean with no panic/abort/soft-lockup/wait-timeout markers.

Co-authored-by: Ryan Breen <ryan@ryanbreen.com>
Co-authored-by: Claude Code <noreply@anthropic.com>