### PR TITLE
Fix bssh client KEX negotiation with OpenSSH

### DIFF
--- a/libs/libbreenix/src/ssh/auth.rs
+++ b/libs/libbreenix/src/ssh/auth.rs
@@ -7,6 +7,7 @@
 use super::keys;
 use super::packet::PacketIo;
 use super::{SshBuf, SshError};
+use super::{SSH_MSG_DEBUG, SSH_MSG_EXT_INFO, SSH_MSG_IGNORE};
 use super::{SSH_MSG_SERVICE_ACCEPT, SSH_MSG_SERVICE_REQUEST};
 use super::{SSH_MSG_USERAUTH_FAILURE, SSH_MSG_USERAUTH_REQUEST, SSH_MSG_USERAUTH_SUCCESS};
 
@@ -188,7 +189,7 @@ pub fn client_request_service(io: &mut PacketIo) -> Result<(), SshError> {
     SshBuf::put_string(&mut req, b"ssh-userauth");
     io.send_packet(&req).map_err(|_| SshError::Io)?;
 
-    let reply = io.recv_packet().map_err(|_| SshError::Io)?;
+    let reply = recv_client_reply(io)?;
     if reply.is_empty() || reply[0] != SSH_MSG_SERVICE_ACCEPT {
         return Err(SshError::Protocol("service request rejected"));
     }
@@ -211,7 +212,7 @@ pub fn client_auth_password(
     SshBuf::put_string(&mut req, password.as_bytes());
     io.send_packet(&req).map_err(|_| SshError::Io)?;
 
-    let reply = io.recv_packet().map_err(|_| SshError::Io)?;
+    let reply = recv_client_reply(io)?;
     if reply.is_empty() {
         return Err(SshError::Protocol("empty auth response"));
     }
@@ -220,5 +221,18 @@ pub fn client_auth_password(
         SSH_MSG_USERAUTH_SUCCESS => Ok(()),
         SSH_MSG_USERAUTH_FAILURE => Err(SshError::Auth),
         _ => Err(SshError::Protocol("unexpected auth response")),
+    }
+}
+
+fn recv_client_reply(io: &mut PacketIo) -> Result<Vec<u8>, SshError> {
+    loop {
+        let reply = io.recv_packet().map_err(|_| SshError::Io)?;
+        if reply.is_empty() {
+            return Ok(reply);
+        }
+        match reply[0] {
+            SSH_MSG_IGNORE | SSH_MSG_DEBUG | SSH_MSG_EXT_INFO => continue,
+            _ => return Ok(reply),
+        }
     }
 }

--- a/libs/libbreenix/src/ssh/kex.rs
+++ b/libs/libbreenix/src/ssh/kex.rs
@@ -18,6 +18,12 @@ use super::*;
 /// Algorithms offered by BSSH.
 // ext-info-s tells clients we'll send SSH_MSG_EXT_INFO after NEWKEYS (RFC 8308)
 pub const KEX_ALGORITHMS: &str = "mlkem768x25519-sha256,curve25519-sha256,ext-info-s";
+/// Algorithms offered by the BSSH client.
+///
+/// Keep this in sync with the client-side key exchange implementation. The
+/// client currently implements Curve25519 only; advertising ML-KEM here causes
+/// OpenSSH servers to negotiate a hybrid exchange that the client cannot speak.
+pub const CLIENT_KEX_ALGORITHMS: &str = "curve25519-sha256,ext-info-c";
 pub const HOST_KEY_ALGORITHMS: &str = "rsa-sha2-256,ssh-rsa";
 pub const CIPHERS: &str = "aes128-ctr";
 pub const MACS: &str = "hmac-sha2-256";
@@ -45,6 +51,15 @@ impl KexState {
 
 /// Build a KEXINIT message payload.
 pub fn build_kexinit(rng: &mut Csprng) -> Vec<u8> {
+    build_kexinit_with_algorithms(rng, KEX_ALGORITHMS)
+}
+
+/// Build a client-side KEXINIT message payload.
+pub fn build_client_kexinit(rng: &mut Csprng) -> Vec<u8> {
+    build_kexinit_with_algorithms(rng, CLIENT_KEX_ALGORITHMS)
+}
+
+fn build_kexinit_with_algorithms(rng: &mut Csprng, kex_algorithms: &str) -> Vec<u8> {
     let mut payload = Vec::with_capacity(256);
 
     // Message type
@@ -56,7 +71,7 @@ pub fn build_kexinit(rng: &mut Csprng) -> Vec<u8> {
     payload.extend_from_slice(&cookie);
 
     // Algorithm name-lists (10 of them)
-    SshBuf::put_string(&mut payload, KEX_ALGORITHMS.as_bytes());
+    SshBuf::put_string(&mut payload, kex_algorithms.as_bytes());
     SshBuf::put_string(&mut payload, HOST_KEY_ALGORITHMS.as_bytes());
     SshBuf::put_string(&mut payload, CIPHERS.as_bytes()); // encryption C->S
     SshBuf::put_string(&mut payload, CIPHERS.as_bytes()); // encryption S->C

--- a/libs/libbreenix/src/ssh/mod.rs
+++ b/libs/libbreenix/src/ssh/mod.rs
@@ -22,6 +22,7 @@ pub const SSH_MSG_UNIMPLEMENTED: u8 = 3;
 pub const SSH_MSG_DEBUG: u8 = 4;
 pub const SSH_MSG_SERVICE_REQUEST: u8 = 5;
 pub const SSH_MSG_SERVICE_ACCEPT: u8 = 6;
+pub const SSH_MSG_EXT_INFO: u8 = 7;
 pub const SSH_MSG_KEXINIT: u8 = 20;
 pub const SSH_MSG_NEWKEYS: u8 = 21;
 pub const SSH_MSG_KEX_ECDH_INIT: u8 = 30;

--- a/libs/libbreenix/src/ssh/transport.rs
+++ b/libs/libbreenix/src/ssh/transport.rs
@@ -367,7 +367,7 @@ impl ClientSession {
 
         // 2. Key exchange
         let mut rng = Csprng::new();
-        let my_kexinit = kex::build_kexinit(&mut rng);
+        let my_kexinit = kex::build_client_kexinit(&mut rng);
         self.kex.my_kexinit = my_kexinit.clone();
         self.io.send_packet(&my_kexinit).map_err(|_| SshError::Io)?;
 

--- a/userspace/programs/src/bssh.rs
+++ b/userspace/programs/src/bssh.rs
@@ -67,7 +67,11 @@ fn main() {
 
     // SSH handshake + auth
     if let Err(e) = session.handshake(username, password) {
-        eprintln!("bssh: handshake failed: {:?}", e);
+        if matches!(e, libbreenix::ssh::SshError::Auth) {
+            eprintln!("bssh: authentication failed");
+        } else {
+            eprintln!("bssh: handshake failed: {:?}", e);
+        }
         std::process::exit(1);
     }
     println!("bssh: authenticated as '{}'", username);


### PR DESCRIPTION
## Summary
- use a client-specific SSH KEXINIT so bssh no longer advertises unsupported ML-KEM client support
- advertise ext-info-c from the client side and skip OpenSSH EXT_INFO packets before service/auth replies
- report password auth failures separately from transport handshake failures in bssh

## Validation
- ARM64 userspace + kernel builds: empty warning/error grep in turn49-artifacts/build-aarch64-warning-error-grep.txt
- x86 qemu-uefi build: empty warning/error grep in turn49-artifacts/build-x86-warning-error-grep.txt
- Linux ground truth to 10.0.1.210 with bssh-compatible algorithms reaches NEWKEYS and SERVICE_ACCEPT
- Breenix probe before fix: receives server KEXINIT then fails during ECDH with Io
- Breenix probe after fix: ECDH completes, NEWKEYS is received/sent, userauth service is requested, then the test password fails with Auth instead of Io
- Production Parallels boot: Boot script completed, bsshd started, BWM discovered Bounce, heartbeats and bwm-fps continued through ~45s; no bssh probe marker in production serial