### PR TITLE
Make loopback sockets wake on delivery

### DIFF
--- a/kernel/src/ipc/poll.rs
+++ b/kernel/src/ipc/poll.rs
@@ -107,13 +107,13 @@ pub fn poll_fd(fd_entry: &FileDescriptor, events: i16) -> i16 {
                 revents |= events::POLLERR;
             }
         }
-        FdKind::UdpSocket(_socket) => {
-            // For UDP sockets: we don't implement poll properly yet
-            // Just mark as always writable for now
+        FdKind::UdpSocket(socket) => {
+            if (events & events::POLLIN) != 0 && socket.lock().has_data() {
+                revents |= events::POLLIN;
+            }
             if (events & events::POLLOUT) != 0 {
                 revents |= events::POLLOUT;
             }
-            // TODO: Check socket RX queue for POLLIN
         }
         FdKind::RegularFile(_file) => {
             // Regular files are always readable/writable (for now)

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -231,27 +231,40 @@ struct LoopbackPacket {
 
 static LOOPBACK_QUEUE: Mutex<Vec<LoopbackPacket>> = Mutex::new(Vec::new());
 
-/// Drain the loopback queue, delivering any pending packets
-/// Called after syscalls release their locks to avoid deadlock
+/// Drain the loopback queue, delivering any pending packets.
+///
+/// Called after syscalls release their locks to avoid deadlock. TCP loopback
+/// can enqueue deferred replies (SYN+ACK, ACK) while delivering an earlier
+/// packet, so drain bounded rounds until the local packet chain is quiescent.
 pub fn drain_loopback_queue() {
-    // Take all packets from the queue
-    let packets: Vec<LoopbackPacket> = {
-        let mut queue = LOOPBACK_QUEUE.lock();
-        core::mem::take(&mut *queue)
-    };
+    const MAX_DRAIN_ROUNDS: usize = 16;
 
-    // Deliver each packet
-    for packet in packets {
-        if let Some(parsed_ip) = ipv4::Ipv4Packet::parse(&packet.data) {
-            let src_mac = get_mac_address().unwrap_or([0; 6]);
-            let dummy_frame = ethernet::EthernetFrame {
-                src_mac,
-                dst_mac: src_mac,
-                ethertype: ethernet::ETHERTYPE_IPV4,
-                payload: &packet.data,
-            };
-            ipv4::handle_ipv4(&dummy_frame, &parsed_ip);
+    for _ in 0..MAX_DRAIN_ROUNDS {
+        // Take all packets from the queue
+        let packets: Vec<LoopbackPacket> = {
+            let mut queue = LOOPBACK_QUEUE.lock();
+            core::mem::take(&mut *queue)
+        };
+
+        if packets.is_empty() {
+            break;
         }
+
+        // Deliver each packet
+        for packet in packets {
+            if let Some(parsed_ip) = ipv4::Ipv4Packet::parse(&packet.data) {
+                let src_mac = get_mac_address().unwrap_or([0; 6]);
+                let dummy_frame = ethernet::EthernetFrame {
+                    src_mac,
+                    dst_mac: src_mac,
+                    ethertype: ethernet::ETHERTYPE_IPV4,
+                    payload: &packet.data,
+                };
+                ipv4::handle_ipv4(&dummy_frame, &parsed_ip);
+            }
+        }
+
+        tcp::drain_deferred_tx();
     }
 }
 

--- a/kernel/src/net/tcp.rs
+++ b/kernel/src/net/tcp.rs
@@ -44,7 +44,11 @@ pub fn drain_deferred_tx() {
     };
 
     for pkt in packets {
-        let result = if let Some(mac) = pkt.dst_mac {
+        let config = super::config();
+        let is_loopback = pkt.dst_ip == config.ip_addr || pkt.dst_ip[0] == 127;
+        let result = if is_loopback {
+            super::send_ipv4(pkt.dst_ip, PROTOCOL_TCP, &pkt.tcp_segment)
+        } else if let Some(mac) = pkt.dst_mac {
             // Send directly to the known MAC (bypasses ARP, which can't work
             // during process_rx since the re-entrancy guard is held).
             let ip_packet = super::ipv4::Ipv4Packet::build(

--- a/kernel/src/socket/udp.rs
+++ b/kernel/src/socket/udp.rs
@@ -140,8 +140,7 @@ impl UdpSocket {
         }
     }
 
-    /// Check if there are packets available to receive (part of API)
-    #[allow(dead_code)]
+    /// Check if there are packets available to receive.
     pub fn has_data(&self) -> bool {
         !self.rx_queue.lock().is_empty()
     }

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -433,6 +433,7 @@ pub fn sys_write(fd: u64, buf_ptr: u64, count: u64) -> SyscallResult {
             // Write to established TCP connection
             match crate::net::tcp::tcp_send(&conn_id, &buffer) {
                 Ok(n) => {
+                    crate::net::drain_loopback_queue();
                     log::debug!("sys_write: Wrote {} bytes to TCP connection", n);
                     SyscallResult::Ok(n as u64)
                 }
@@ -1191,18 +1192,12 @@ pub fn sys_read(fd: u64, buf_ptr: u64, count: u64) -> SyscallResult {
                 (fd_entry.status_flags & crate::ipc::fd::status_flags::O_NONBLOCK) != 0;
             drop(manager_guard);
 
-            // Drain loopback queue for localhost connections (127.x.x.x, own IP).
-            crate::net::drain_loopback_queue();
-
             let mut user_buf = alloc::vec![0u8; count as usize];
 
             // Read loop (may block if O_NONBLOCK not set)
             loop {
                 // Register as waiter FIRST to avoid race condition
                 crate::net::tcp::tcp_register_recv_waiter(&conn_id, thread_id);
-
-                // Drain loopback queue in case data arrived
-                crate::net::drain_loopback_queue();
 
                 // Try to receive
                 match crate::net::tcp::tcp_recv(&conn_id, &mut user_buf) {
@@ -1315,9 +1310,6 @@ pub fn sys_read(fd: u64, buf_ptr: u64, count: u64) -> SyscallResult {
 
                 // Unregister from wait queue (will re-register at top of loop)
                 crate::net::tcp::tcp_unregister_recv_waiter(&conn_id, thread_id);
-
-                // Drain loopback again before retrying
-                crate::net::drain_loopback_queue();
             }
         }
         FdKind::PtyMaster(pty_num) => {

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -520,8 +520,8 @@ pub fn sys_sendto(
 ///    This path runs in softirq context and wakes blocked threads.
 ///
 /// 2. **Loopback path**: `sendto()` → `drain_loopback_queue()` → `enqueue_packet()`
-///    This path runs synchronously in syscall context. We call `drain_loopback_queue()`
-///    at the start of recvfrom and after blocking to ensure loopback packets are delivered.
+///    This path runs synchronously in sender syscall context after locks are released,
+///    so receivers can block on socket waiters and wake on delivery.
 ///
 /// # Spurious Wakeups
 ///
@@ -543,10 +543,6 @@ pub fn sys_recvfrom(
         buf_ptr,
         len
     );
-
-    // Drain loopback queue for packets sent to ourselves (127.x.x.x, own IP).
-    // Hardware-received packets arrive via interrupt → softirq → process_rx().
-    crate::net::drain_loopback_queue();
 
     // Validate buffer pointer
     if buf_ptr == 0 {
@@ -606,9 +602,6 @@ pub fn sys_recvfrom(
         Cpu::without_interrupts(|| {
             socket_ref.lock().register_waiter(thread_id);
         });
-
-        // Drain loopback queue again in case packets arrived
-        crate::net::drain_loopback_queue();
 
         // Try to receive a packet
         // CRITICAL: Must disable interrupts to prevent deadlock with softirq.
@@ -783,10 +776,7 @@ pub fn sys_recvfrom(
             socket_ref.lock().unregister_waiter(thread_id);
         });
 
-        // Drain loopback again before retrying
-        crate::net::drain_loopback_queue();
-
-        // Loop back to try receiving again - we should have data now
+        // Loop back to try receiving again after a delivery wake or spurious wakeup.
     }
 }
 
@@ -927,9 +917,6 @@ enum ListenerType {
 pub fn sys_accept(fd: u64, addr_ptr: u64, addrlen_ptr: u64) -> SyscallResult {
     log::debug!("sys_accept: fd={}", fd);
 
-    // Drain loopback queue for localhost connections (127.x.x.x, own IP).
-    crate::net::drain_loopback_queue();
-
     // Get current thread ID for blocking
     let thread_id = match crate::per_cpu::current_thread() {
         Some(thread) => thread.id,
@@ -998,9 +985,6 @@ fn sys_accept_tcp(
     loop {
         // Register as waiter FIRST to avoid race condition
         crate::net::tcp::tcp_register_accept_waiter(port, thread_id);
-
-        // Drain loopback queue in case connections arrived
-        crate::net::drain_loopback_queue();
 
         // Try to accept a pending connection
         if let Some(conn_id) = crate::net::tcp::tcp_accept(port) {
@@ -1114,13 +1098,7 @@ fn sys_accept_tcp(
                 return SyscallResult::Err(e as u64);
             }
 
-            // Drain loopback queue - essential for single-threaded tests where
-            // no other thread processes packets. This may wake other threads'
-            // connections but that's OK - they'll re-check and re-block if needed.
-            crate::net::drain_loopback_queue();
-
-            // Check if we were woken by the drain (e.g., SYN arrived and woke us)
-            // IMPORTANT: Check BEFORE HLT to avoid unnecessary waiting
+            // Check if we were woken by TCP delivery before sleeping again.
             let still_blocked = crate::task::scheduler::with_scheduler(|sched| {
                 if let Some(thread) = sched.current_thread_mut() {
                     thread.state == crate::task::thread::ThreadState::Blocked
@@ -1153,9 +1131,6 @@ fn sys_accept_tcp(
 
         // Unregister from wait queue (will re-register at top of loop)
         crate::net::tcp::tcp_unregister_accept_waiter(port, thread_id);
-
-        // Drain loopback again before retrying
-        crate::net::drain_loopback_queue();
     }
 }
 
@@ -1473,6 +1448,11 @@ fn sys_connect_tcp(fd: u64, addr_ptr: u64, addrlen: u64) -> SyscallResult {
         // manager_guard dropped here
     };
 
+    // Deliver any loopback SYN/SYN+ACK/ACK chain now that PROCESS_MANAGER is
+    // released. The connection waiter below should sleep until TCP wakes it,
+    // not poll-drain localhost packets from the receive side.
+    crate::net::drain_loopback_queue();
+
     // For non-blocking sockets, return EINPROGRESS immediately
     // The connection is in progress but not yet established
     if is_nonblocking {
@@ -1512,14 +1492,9 @@ fn sys_connect_tcp(fd: u64, addr_ptr: u64, addrlen: u64) -> SyscallResult {
         // Register as waiter FIRST to avoid race condition
         crate::net::tcp::tcp_register_recv_waiter(&conn_id, thread_id);
 
-        // Drain loopback queue for localhost connections
-        crate::net::drain_loopback_queue();
-
         // Check if connected
         if crate::net::tcp::tcp_is_established(&conn_id) {
             crate::net::tcp::tcp_unregister_recv_waiter(&conn_id, thread_id);
-            // Drain loopback one more time to deliver the ACK to the server
-            crate::net::drain_loopback_queue();
             log::info!(
                 "TCP connect: thread={} - Connection established, returning success",
                 thread_id
@@ -1603,13 +1578,7 @@ fn sys_connect_tcp(fd: u64, addr_ptr: u64, addrlen: u64) -> SyscallResult {
                 return SyscallResult::Err(e as u64);
             }
 
-            // Drain loopback queue - essential for single-threaded tests where
-            // no other thread processes packets. This may wake other threads'
-            // connections but that's OK - they'll re-check and re-block if needed.
-            crate::net::drain_loopback_queue();
-
-            // Check if we were woken by the drain (e.g., SYN+ACK arrived and woke us)
-            // IMPORTANT: Check BEFORE HLT to avoid unnecessary waiting
+            // Check if we were woken by TCP delivery before sleeping again.
             let still_blocked = crate::task::scheduler::with_scheduler(|sched| {
                 if let Some(thread) = sched.current_thread_mut() {
                     thread.state == crate::task::thread::ThreadState::Blocked
@@ -1645,9 +1614,6 @@ fn sys_connect_tcp(fd: u64, addr_ptr: u64, addrlen: u64) -> SyscallResult {
 
         // Unregister from wait queue (will re-register at top of loop)
         crate::net::tcp::tcp_unregister_recv_waiter(&conn_id, thread_id);
-
-        // Drain loopback again before retrying
-        crate::net::drain_loopback_queue();
 
         log::info!(
             "TCP connect: thread={} looping back to check connection",


### PR DESCRIPTION
## Summary
- remove receiver-side loopback drain polling from blocking UDP recvfrom and TCP read/accept/connect loops
- drain loopback delivery from sender-side send/connect/write paths after locks are released
- route TCP deferred loopback replies back through send_ipv4 and report UDP POLLIN from socket queues

## Validation
- `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` with zero warning/error lines
- Parallels: `/bin/concurrent_recv_stress` passed; 4 children blocked in UDP `recvfrom()`, parent sent to `127.0.0.1`, all woke and verified payloads
- Parallels: `poll_test` passed, including TCP listener POLLIN after `127.0.0.1` connect
- Parallels: TCP socket data path verified client connect, accept, send, recv, data verified; binary still exits 1 on unrelated shutdown-write expectation
- Real NIC smoke: ping 2/2, SSH and telnet ports accepted

Artifacts are under `turn54-artifacts/` in the working directory.