### PR TITLE
fix(pty): drop process-manager lock before copying ptsname to userspace (NB-13 total lockup)

### DIFF
--- a/kernel/src/syscall/pty.rs
+++ b/kernel/src/syscall/pty.rs
@@ -3,7 +3,7 @@
 //! Implements the POSIX PTY syscalls: posix_openpt, grantpt, unlockpt, ptsname
 
 use super::errno::ENOTTY;
-use super::userptr::validate_user_buffer;
+use super::userptr::{copy_to_user, validate_user_buffer};
 use super::SyscallResult;
 use crate::ipc::fd::{flags, FdKind, FileDescriptor};
 use crate::process::manager;
@@ -274,7 +274,10 @@ pub fn sys_ptsname(fd: u64, buf: u64, buflen: u64) -> SyscallResult {
         return SyscallResult::Err(e);
     }
 
-    // Get current process
+    // Get current process and validate the fd while holding the process-manager
+    // lock, but do not copy to userspace until after the lock is dropped.
+    // A ptsname() buffer can live on a CoW stack after fork(); writing it while
+    // holding the PM lock can deadlock the CoW fault handler.
     let thread_id = match crate::task::scheduler::current_thread_id() {
         Some(id) => id,
         None => {
@@ -282,73 +285,68 @@ pub fn sys_ptsname(fd: u64, buf: u64, buflen: u64) -> SyscallResult {
             return SyscallResult::Err(3); // ESRCH
         }
     };
-    let manager_guard = manager();
-    let process = match &*manager_guard {
-        Some(manager) => match manager.find_process_by_thread(thread_id) {
-            Some((_pid, p)) => p,
+    let pty_num = {
+        let manager_guard = manager();
+        let process = match &*manager_guard {
+            Some(manager) => match manager.find_process_by_thread(thread_id) {
+                Some((_pid, p)) => p,
+                None => {
+                    log::error!("sys_ptsname: Process not found for thread {}", thread_id);
+                    return SyscallResult::Err(3); // ESRCH
+                }
+            },
             None => {
-                log::error!("sys_ptsname: Process not found for thread {}", thread_id);
+                log::error!("sys_ptsname: Process manager not initialized");
                 return SyscallResult::Err(3); // ESRCH
             }
-        },
-        None => {
-            log::error!("sys_ptsname: Process manager not initialized");
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
+        };
 
-    // Get fd entry
-    let fd_entry = match process.fd_table.get(fd_i32) {
-        Some(entry) => entry,
-        None => {
-            log::error!("sys_ptsname: Bad file descriptor {}", fd_i32);
-            return SyscallResult::Err(9); // EBADF
-        }
-    };
-
-    // Verify it's a PTY master and get the slave path
-    match &fd_entry.kind {
-        FdKind::PtyMaster(pty_num) => {
-            // Get the PTY pair
-            match pty::get(*pty_num) {
-                Some(pair) => {
-                    let path = pair.slave_path();
-                    let path_bytes = path.as_bytes();
-
-                    // Check if buffer is large enough (need space for null terminator)
-                    if path_bytes.len() + 1 > buflen as usize {
-                        log::error!(
-                            "sys_ptsname: buffer too small ({} < {})",
-                            buflen,
-                            path_bytes.len() + 1
-                        );
-                        return SyscallResult::Err(34); // ERANGE
-                    }
-
-                    // Copy path to user buffer
-                    let buf_ptr = buf as *mut u8;
-                    unsafe {
-                        core::ptr::copy_nonoverlapping(
-                            path_bytes.as_ptr(),
-                            buf_ptr,
-                            path_bytes.len(),
-                        );
-                        // Write null terminator
-                        core::ptr::write_volatile(buf_ptr.add(path_bytes.len()), 0);
-                    }
-
-                    log::debug!("sys_ptsname: fd {} -> '{}' (pty {})", fd_i32, path, pty_num);
-                    SyscallResult::Ok(0)
+        match process.fd_table.get(fd_i32) {
+            Some(entry) => match &entry.kind {
+                FdKind::PtyMaster(pty_num) => *pty_num,
+                _ => {
+                    log::error!("sys_ptsname: fd {} is not a PTY master", fd_i32);
+                    return SyscallResult::Err(ENOTTY as u64);
                 }
-                None => {
-                    log::error!("sys_ptsname: PTY {} not found", pty_num);
-                    SyscallResult::Err(5) // EIO
-                }
+            },
+            None => {
+                log::error!("sys_ptsname: Bad file descriptor {}", fd_i32);
+                return SyscallResult::Err(9); // EBADF
             }
         }
-        _ => {
-            log::error!("sys_ptsname: fd {} is not a PTY master", fd_i32);
-            SyscallResult::Err(ENOTTY as u64)
+    };
+
+    let pair = match pty::get(pty_num) {
+        Some(pair) => pair,
+        None => {
+            log::error!("sys_ptsname: PTY {} not found", pty_num);
+            return SyscallResult::Err(5); // EIO
+        }
+    };
+    let path = pair.slave_path();
+    let path_bytes = path.as_bytes();
+
+    // Check if buffer is large enough (need space for null terminator)
+    if path_bytes.len() + 1 > buflen as usize {
+        log::error!(
+            "sys_ptsname: buffer too small ({} < {})",
+            buflen,
+            path_bytes.len() + 1
+        );
+        return SyscallResult::Err(34); // ERANGE
+    }
+
+    let buf_ptr = buf as *mut u8;
+    for (idx, byte) in path_bytes.iter().copied().enumerate() {
+        if let Err(errno) = copy_to_user(buf_ptr.wrapping_add(idx), &byte) {
+            return SyscallResult::Err(errno);
         }
     }
+    let nul = 0u8;
+    if let Err(errno) = copy_to_user(buf_ptr.wrapping_add(path_bytes.len()), &nul) {
+        return SyscallResult::Err(errno);
+    }
+
+    log::debug!("sys_ptsname: fd {} -> '{}' (pty {})", fd_i32, path, pty_num);
+    SyscallResult::Ok(0)
 }


### PR DESCRIPTION
## Summary
Fixes the operator-reported **NB-13 total lockup** when loading Terminal from the launcher.

`sys_ptsname()` held the process-manager lock while copying the `/dev/pts/N` path into the caller's buffer. When that buffer lives on a copy-on-write stack page — exactly the case when `bterm` opens a **second** PTY for its shell tab after `fork()` — the kernel write faults on the CoW page, and the ARM64 CoW fault handler tries to acquire the **same** process-manager lock → self-deadlock. The stuck thread holds the PM lock, every thread needing it stalls, the ready queue drains, and the whole system freezes (timer + network dead).

## Fix
Extract and validate the PTY fd under the PM lock in a scoped block, **drop the lock**, then copy the slave path to userspace via fault-safe `copy_to_user` byte writes. The "never hold a lock across a faultable userspace access" pattern. Single file, non-prohibited.

## Validation (deterministic reproducer)
Reproduced via a temporary `blauncher --autolaunch-terminal` harness (programmatic `launch_app(Terminal)`, **removed before commit**):
- **Before:** ping 0/3 (100% loss), SSH dead, serial stops after the second PTY unlock → total freeze.
- **After:** Terminal launches (BWM window id=3, both bterm children spawn), heartbeat/FPS continue to ~260s uptime, ping 3/3, fresh SSH shell connects+exits, Bounce window unaffected. Clean ARM64 build, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)