### PR TITLE
Audit syscall user copies for CoW fault deadlocks

### DIFF
--- a/kernel/src/syscall/fs.rs
+++ b/kernel/src/syscall/fs.rs
@@ -3195,23 +3195,27 @@ pub fn sys_getcwd(buf: u64, size: u64) -> SyscallResult {
         }
     };
 
-    let manager_guard = crate::process::manager();
-    let process = match &*manager_guard {
-        Some(manager) => match manager.find_process_by_thread(thread_id) {
-            Some((_, p)) => p,
+    // Copy the CWD while holding PROCESS_MANAGER, then drop it before writing
+    // to userspace. The destination may be a CoW page, and the CoW handler
+    // also needs PROCESS_MANAGER.
+    let cwd = {
+        let manager_guard = crate::process::manager();
+        let process = match &*manager_guard {
+            Some(manager) => match manager.find_process_by_thread(thread_id) {
+                Some((_, p)) => p,
+                None => {
+                    log::error!("sys_getcwd: Process not found for thread {}", thread_id);
+                    return SyscallResult::Err(3); // ESRCH
+                }
+            },
             None => {
-                log::error!("sys_getcwd: Process not found for thread {}", thread_id);
+                log::error!("sys_getcwd: Process manager not initialized");
                 return SyscallResult::Err(3); // ESRCH
             }
-        },
-        None => {
-            log::error!("sys_getcwd: Process manager not initialized");
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
+        };
 
-    // Get the cwd from the process
-    let cwd = &process.cwd;
+        process.cwd.clone()
+    };
     let cwd_bytes = cwd.as_bytes();
     let required_size = cwd_bytes.len() + 1; // +1 for null terminator
 

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -1151,8 +1151,10 @@ pub fn sys_read(fd: u64, buf_ptr: u64, count: u64) -> SyscallResult {
         }
         FdKind::Device(device_type) => {
             // Read from devfs device (/dev/null, /dev/zero, /dev/console, /dev/tty)
+            let device_type = *device_type;
+            drop(manager_guard);
             let mut user_buf = alloc::vec![0u8; count as usize];
-            match crate::fs::devfs::device_read(*device_type, &mut user_buf) {
+            match crate::fs::devfs::device_read(device_type, &mut user_buf) {
                 Ok(n) => {
                     if n > 0 {
                         // Copy to userspace
@@ -1664,8 +1666,10 @@ pub fn sys_read(fd: u64, buf_ptr: u64, count: u64) -> SyscallResult {
             position,
         } => {
             // Read from procfs virtual file
-            let bytes = content.as_bytes();
+            let content = content.clone();
             let pos = *position;
+            drop(manager_guard);
+            let bytes = content.as_bytes();
             if pos >= bytes.len() {
                 return SyscallResult::Ok(0);
             }
@@ -1677,7 +1681,6 @@ pub fn sys_read(fd: u64, buf_ptr: u64, count: u64) -> SyscallResult {
                 }
             }
             // Update position - re-acquire the manager lock
-            drop(manager_guard);
             let mut mg = crate::process::manager();
             if let Some(manager) = &mut *mg {
                 if let Some((_pid, process)) = manager.find_process_by_thread_mut(thread_id) {

--- a/kernel/src/syscall/pipe.rs
+++ b/kernel/src/syscall/pipe.rs
@@ -8,6 +8,16 @@ use crate::ipc::fd::{flags, status_flags, FileDescriptor};
 use crate::ipc::{create_pipe, FdKind};
 use crate::process::manager;
 
+fn close_pipe_fds_for_thread(thread_id: u64, pipefd: [i32; 2]) {
+    let mut manager_guard = manager();
+    if let Some(manager) = &mut *manager_guard {
+        if let Some((_pid, process)) = manager.find_process_by_thread_mut(thread_id) {
+            let _ = process.fd_table.close(pipefd[0]);
+            let _ = process.fd_table.close(pipefd[1]);
+        }
+    }
+}
+
 /// sys_pipe - Create a pipe
 ///
 /// Creates a unidirectional data channel that can be used for inter-process communication.
@@ -39,57 +49,59 @@ pub fn sys_pipe(pipefd_ptr: u64) -> SyscallResult {
             return SyscallResult::Err(3); // ESRCH
         }
     };
-    let mut manager_guard = manager();
-    let process = match &mut *manager_guard {
-        Some(manager) => match manager.find_process_by_thread_mut(thread_id) {
-            Some((_pid, p)) => p,
+    let pipefd: [i32; 2] = {
+        let mut manager_guard = manager();
+        let process = match &mut *manager_guard {
+            Some(manager) => match manager.find_process_by_thread_mut(thread_id) {
+                Some((_pid, p)) => p,
+                None => {
+                    log::error!("sys_pipe: Process not found for thread {}", thread_id);
+                    return SyscallResult::Err(3); // ESRCH
+                }
+            },
             None => {
-                log::error!("sys_pipe: Process not found for thread {}", thread_id);
+                log::error!("sys_pipe: Process manager not initialized");
                 return SyscallResult::Err(3); // ESRCH
             }
-        },
-        None => {
-            log::error!("sys_pipe: Process manager not initialized");
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
+        };
 
-    // Create the pipe buffer (shared between read and write ends)
-    let (read_buffer, write_buffer) = create_pipe();
+        // Create the pipe buffer (shared between read and write ends)
+        let (read_buffer, write_buffer) = create_pipe();
 
-    // Allocate file descriptors for both ends
-    let read_fd = match process.fd_table.alloc(FdKind::PipeRead(read_buffer)) {
-        Ok(fd) => fd,
-        Err(e) => {
-            log::error!("sys_pipe: Failed to allocate read fd: {}", e);
-            return SyscallResult::Err(e as u64);
-        }
-    };
+        // Allocate file descriptors for both ends
+        let read_fd = match process.fd_table.alloc(FdKind::PipeRead(read_buffer)) {
+            Ok(fd) => fd,
+            Err(e) => {
+                log::error!("sys_pipe: Failed to allocate read fd: {}", e);
+                return SyscallResult::Err(e as u64);
+            }
+        };
 
-    let write_fd = match process.fd_table.alloc(FdKind::PipeWrite(write_buffer)) {
-        Ok(fd) => fd,
-        Err(e) => {
-            // Clean up read fd on failure
-            let _ = process.fd_table.close(read_fd);
-            log::error!("sys_pipe: Failed to allocate write fd: {}", e);
-            return SyscallResult::Err(e as u64);
-        }
+        let write_fd = match process.fd_table.alloc(FdKind::PipeWrite(write_buffer)) {
+            Ok(fd) => fd,
+            Err(e) => {
+                // Clean up read fd on failure
+                let _ = process.fd_table.close(read_fd);
+                log::error!("sys_pipe: Failed to allocate write fd: {}", e);
+                return SyscallResult::Err(e as u64);
+            }
+        };
+
+        [read_fd, write_fd]
     };
 
     // Write the file descriptors to user space
-    let pipefd: [i32; 2] = [read_fd, write_fd];
     if let Err(e) = copy_to_user(pipefd_ptr as *mut [i32; 2], &pipefd) {
         // Clean up on failure
-        let _ = process.fd_table.close(read_fd);
-        let _ = process.fd_table.close(write_fd);
+        close_pipe_fds_for_thread(thread_id, pipefd);
         log::error!("sys_pipe: Failed to copy fds to user: {}", e);
         return SyscallResult::Err(14); // EFAULT
     }
 
     log::info!(
         "sys_pipe: Created pipe with read_fd={}, write_fd={}",
-        read_fd,
-        write_fd
+        pipefd[0],
+        pipefd[1]
     );
 
     SyscallResult::Ok(0)
@@ -325,24 +337,6 @@ pub fn sys_pipe2(pipefd_ptr: u64, pipe_flags: u64) -> SyscallResult {
             return SyscallResult::Err(3); // ESRCH
         }
     };
-    let mut manager_guard = manager();
-    let process = match &mut *manager_guard {
-        Some(manager) => match manager.find_process_by_thread_mut(thread_id) {
-            Some((_pid, p)) => p,
-            None => {
-                log::error!("sys_pipe2: Process not found for thread {}", thread_id);
-                return SyscallResult::Err(3); // ESRCH
-            }
-        },
-        None => {
-            log::error!("sys_pipe2: Process manager not initialized");
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
-
-    // Create the pipe buffer (shared between read and write ends)
-    let (read_buffer, write_buffer) = create_pipe();
-
     // Determine fd_flags and status_flags based on pipe_flags argument
     let fd_flags = if (flags_u32 & status_flags::O_CLOEXEC) != 0 {
         flags::FD_CLOEXEC
@@ -355,45 +349,65 @@ pub fn sys_pipe2(pipefd_ptr: u64, pipe_flags: u64) -> SyscallResult {
         0
     };
 
-    // Create file descriptors with the appropriate flags
-    let read_fd_entry =
-        FileDescriptor::with_flags(FdKind::PipeRead(read_buffer), fd_flags, status_flags_val);
-    let write_fd_entry =
-        FileDescriptor::with_flags(FdKind::PipeWrite(write_buffer), fd_flags, status_flags_val);
+    let pipefd: [i32; 2] = {
+        let mut manager_guard = manager();
+        let process = match &mut *manager_guard {
+            Some(manager) => match manager.find_process_by_thread_mut(thread_id) {
+                Some((_pid, p)) => p,
+                None => {
+                    log::error!("sys_pipe2: Process not found for thread {}", thread_id);
+                    return SyscallResult::Err(3); // ESRCH
+                }
+            },
+            None => {
+                log::error!("sys_pipe2: Process manager not initialized");
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
 
-    // Allocate file descriptors for both ends using alloc_with_entry
-    let read_fd = match process.fd_table.alloc_with_entry(read_fd_entry.clone()) {
-        Ok(fd) => fd,
-        Err(e) => {
-            log::error!("sys_pipe2: Failed to allocate read fd: {}", e);
-            return SyscallResult::Err(e as u64);
-        }
-    };
+        // Create the pipe buffer (shared between read and write ends)
+        let (read_buffer, write_buffer) = create_pipe();
 
-    let write_fd = match process.fd_table.alloc_with_entry(write_fd_entry.clone()) {
-        Ok(fd) => fd,
-        Err(e) => {
-            // Clean up read fd on failure
-            let _ = process.fd_table.close(read_fd);
-            log::error!("sys_pipe2: Failed to allocate write fd: {}", e);
-            return SyscallResult::Err(e as u64);
-        }
+        // Create file descriptors with the appropriate flags
+        let read_fd_entry =
+            FileDescriptor::with_flags(FdKind::PipeRead(read_buffer), fd_flags, status_flags_val);
+        let write_fd_entry =
+            FileDescriptor::with_flags(FdKind::PipeWrite(write_buffer), fd_flags, status_flags_val);
+
+        // Allocate file descriptors for both ends using alloc_with_entry
+        let read_fd = match process.fd_table.alloc_with_entry(read_fd_entry) {
+            Ok(fd) => fd,
+            Err(e) => {
+                log::error!("sys_pipe2: Failed to allocate read fd: {}", e);
+                return SyscallResult::Err(e as u64);
+            }
+        };
+
+        let write_fd = match process.fd_table.alloc_with_entry(write_fd_entry) {
+            Ok(fd) => fd,
+            Err(e) => {
+                // Clean up read fd on failure
+                let _ = process.fd_table.close(read_fd);
+                log::error!("sys_pipe2: Failed to allocate write fd: {}", e);
+                return SyscallResult::Err(e as u64);
+            }
+        };
+
+        [read_fd, write_fd]
     };
 
     // Write the file descriptors to user space
-    let pipefd: [i32; 2] = [read_fd, write_fd];
     if let Err(e) = copy_to_user(pipefd_ptr as *mut [i32; 2], &pipefd) {
         // Clean up on failure
-        let _ = process.fd_table.close(read_fd);
-        let _ = process.fd_table.close(write_fd);
+        close_pipe_fds_for_thread(thread_id, pipefd);
         log::error!("sys_pipe2: Failed to copy fds to user: {}", e);
         return SyscallResult::Err(14); // EFAULT
     }
 
     log::info!(
         "sys_pipe2: Created pipe with read_fd={}, write_fd={}, flags={:#x}",
-        read_fd,
-        write_fd,
+        pipefd[0],
+        pipefd[1],
         flags_u32
     );
 

--- a/kernel/src/syscall/signal.rs
+++ b/kernel/src/syscall/signal.rs
@@ -492,51 +492,73 @@ pub fn sys_sigaction(sig: i32, new_act: u64, old_act: u64, sigsetsize: u64) -> S
         }
     };
 
-    let mut manager_guard = manager();
-    let manager = match manager_guard.as_mut() {
-        Some(m) => m,
-        None => {
-            log::error!("sys_sigaction: process manager not initialized");
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
-
-    let (_, process) = match manager.find_process_by_thread_mut(current_thread_id) {
-        Some(p) => p,
-        None => {
-            log::error!(
-                "sys_sigaction: process not found for thread {}",
-                current_thread_id
-            );
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
-
-    // Save old action if requested
-    if old_act != 0 {
-        let old_action = process.signals.get_handler(sig);
-        // Write the old action to userspace (with validation)
-        let ptr = old_act as *mut SignalAction;
-        if let Err(errno) = copy_to_user(ptr, old_action) {
-            return SyscallResult::Err(errno);
-        }
-    }
-
-    // Set new action if provided
-    if new_act != 0 {
-        // Read the new action from userspace (with validation)
+    let sanitized_action = if new_act != 0 {
         let ptr = new_act as *const SignalAction;
         let new_action = match copy_from_user(ptr) {
             Ok(action) => action,
             Err(errno) => return SyscallResult::Err(errno),
         };
 
-        // Sanitize the mask - cannot block SIGKILL or SIGSTOP
-        let sanitized_action = SignalAction {
+        Some(SignalAction {
             handler: new_action.handler,
             mask: new_action.mask & !UNCATCHABLE_SIGNALS,
             flags: new_action.flags,
             restorer: new_action.restorer,
+        })
+    } else {
+        None
+    };
+
+    if old_act != 0 {
+        let old_action = {
+            let manager_guard = manager();
+            let manager = match manager_guard.as_ref() {
+                Some(m) => m,
+                None => {
+                    log::error!("sys_sigaction: process manager not initialized");
+                    return SyscallResult::Err(3); // ESRCH
+                }
+            };
+
+            let (_, process) = match manager.find_process_by_thread(current_thread_id) {
+                Some(p) => p,
+                None => {
+                    log::error!(
+                        "sys_sigaction: process not found for thread {}",
+                        current_thread_id
+                    );
+                    return SyscallResult::Err(3); // ESRCH
+                }
+            };
+
+            *process.signals.get_handler(sig)
+        };
+
+        let ptr = old_act as *mut SignalAction;
+        if let Err(errno) = copy_to_user(ptr, &old_action) {
+            return SyscallResult::Err(errno);
+        }
+    }
+
+    if let Some(sanitized_action) = sanitized_action {
+        let mut manager_guard = manager();
+        let manager = match manager_guard.as_mut() {
+            Some(m) => m,
+            None => {
+                log::error!("sys_sigaction: process manager not initialized");
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
+
+        let (_, process) = match manager.find_process_by_thread_mut(current_thread_id) {
+            Some(p) => p,
+            None => {
+                log::error!(
+                    "sys_sigaction: process not found for thread {}",
+                    current_thread_id
+                );
+                return SyscallResult::Err(3); // ESRCH
+            }
         };
 
         process.signals.set_handler(sig, sanitized_action);
@@ -590,40 +612,66 @@ pub fn sys_sigprocmask(how: i32, new_set: u64, old_set: u64, sigsetsize: u64) ->
         }
     };
 
-    let mut manager_guard = manager();
-    let manager = match manager_guard.as_mut() {
-        Some(m) => m,
-        None => {
-            log::error!("sys_sigprocmask: process manager not initialized");
-            return SyscallResult::Err(3); // ESRCH
-        }
+    let new_mask = if new_set != 0 {
+        let ptr = new_set as *const u64;
+        Some(match copy_from_user(ptr) {
+            Ok(mask) => mask,
+            Err(errno) => return SyscallResult::Err(errno),
+        })
+    } else {
+        None
     };
 
-    let (_, process) = match manager.find_process_by_thread_mut(current_thread_id) {
-        Some(p) => p,
-        None => {
-            log::error!(
-                "sys_sigprocmask: process not found for thread {}",
-                current_thread_id
-            );
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
-
-    // Save old mask if requested
     if old_set != 0 {
+        let old_mask = {
+            let manager_guard = manager();
+            let manager = match manager_guard.as_ref() {
+                Some(m) => m,
+                None => {
+                    log::error!("sys_sigprocmask: process manager not initialized");
+                    return SyscallResult::Err(3); // ESRCH
+                }
+            };
+
+            let (_, process) = match manager.find_process_by_thread(current_thread_id) {
+                Some(p) => p,
+                None => {
+                    log::error!(
+                        "sys_sigprocmask: process not found for thread {}",
+                        current_thread_id
+                    );
+                    return SyscallResult::Err(3); // ESRCH
+                }
+            };
+
+            process.signals.blocked
+        };
+
         let ptr = old_set as *mut u64;
-        if let Err(errno) = copy_to_user(ptr, &process.signals.blocked) {
+        if let Err(errno) = copy_to_user(ptr, &old_mask) {
             return SyscallResult::Err(errno);
         }
     }
 
-    // Modify mask if new_set is provided
-    if new_set != 0 {
-        let ptr = new_set as *const u64;
-        let set = match copy_from_user(ptr) {
-            Ok(mask) => mask,
-            Err(errno) => return SyscallResult::Err(errno),
+    if let Some(set) = new_mask {
+        let mut manager_guard = manager();
+        let manager = match manager_guard.as_mut() {
+            Some(m) => m,
+            None => {
+                log::error!("sys_sigprocmask: process manager not initialized");
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
+
+        let (_, process) = match manager.find_process_by_thread_mut(current_thread_id) {
+            Some(p) => p,
+            None => {
+                log::error!(
+                    "sys_sigprocmask: process not found for thread {}",
+                    current_thread_id
+                );
+                return SyscallResult::Err(3); // ESRCH
+            }
         };
 
         match how {
@@ -1083,75 +1131,80 @@ pub fn sys_sigaltstack(ss: u64, old_ss: u64) -> SyscallResult {
         }
     };
 
-    let mut manager_guard = manager();
-    let manager_ref = match manager_guard.as_mut() {
-        Some(m) => m,
-        None => {
-            log::error!("sys_sigaltstack: process manager not initialized");
-            return SyscallResult::Err(3); // ESRCH
-        }
+    let new_stack = if ss != 0 {
+        let ptr = ss as *const StackT;
+        Some(match copy_from_user(ptr) {
+            Ok(s) => s,
+            Err(errno) => return SyscallResult::Err(errno),
+        })
+    } else {
+        None
     };
 
-    let (_, process) = match manager_ref.find_process_by_thread_mut(current_thread_id) {
-        Some(p) => p,
-        None => {
-            log::error!(
-                "sys_sigaltstack: process not found for thread {}",
-                current_thread_id
-            );
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
-
-    // If old_ss is provided, copy current alt stack info to it
-    if old_ss != 0 {
-        let alt = &process.signals.alt_stack;
-        let current_stack = StackT {
-            ss_sp: alt.base,
-            ss_flags: if alt.on_stack {
-                SS_ONSTACK as i32
-            } else if alt.flags & SS_DISABLE != 0 {
-                SS_DISABLE as i32
-            } else {
-                0
-            },
-            _pad: 0,
-            ss_size: alt.size,
+    let (current_stack, on_alt_stack) = {
+        let manager_guard = manager();
+        let manager_ref = match manager_guard.as_ref() {
+            Some(m) => m,
+            None => {
+                log::error!("sys_sigaltstack: process manager not initialized");
+                return SyscallResult::Err(3); // ESRCH
+            }
         };
 
+        let (_, process) = match manager_ref.find_process_by_thread(current_thread_id) {
+            Some(p) => p,
+            None => {
+                log::error!(
+                    "sys_sigaltstack: process not found for thread {}",
+                    current_thread_id
+                );
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
+
+        let alt = &process.signals.alt_stack;
+        (
+            StackT {
+                ss_sp: alt.base,
+                ss_flags: if alt.on_stack {
+                    SS_ONSTACK as i32
+                } else if alt.flags & SS_DISABLE != 0 {
+                    SS_DISABLE as i32
+                } else {
+                    0
+                },
+                _pad: 0,
+                ss_size: alt.size,
+            },
+            alt.on_stack,
+        )
+    };
+
+    if old_ss != 0 {
         let ptr = old_ss as *mut StackT;
         if let Err(errno) = copy_to_user(ptr, &current_stack) {
             return SyscallResult::Err(errno);
         }
     }
 
-    // If ss is provided, set new alt stack
-    if ss != 0 {
-        // Cannot change while executing on the alternate stack
-        if process.signals.alt_stack.on_stack {
+    if let Some(new_stack) = new_stack {
+        if on_alt_stack {
             log::warn!("sys_sigaltstack: cannot change while on alternate stack");
             return SyscallResult::Err(1); // EPERM
         }
 
-        // Read the new stack configuration from userspace
-        let ptr = ss as *const StackT;
-        let new_stack = match copy_from_user(ptr) {
-            Ok(s) => s,
-            Err(errno) => return SyscallResult::Err(errno),
-        };
-
         // Check if disabling the alternate stack
-        if (new_stack.ss_flags as u32 & SS_DISABLE) != 0 {
-            process.signals.alt_stack = crate::signal::types::AltStack {
-                base: 0,
-                size: 0,
-                flags: SS_DISABLE,
-                on_stack: false,
-            };
+        let next_alt_stack = if (new_stack.ss_flags as u32 & SS_DISABLE) != 0 {
             log::debug!(
                 "sigaltstack: disabled alternate stack for thread {}",
                 current_thread_id
             );
+            crate::signal::types::AltStack {
+                base: 0,
+                size: 0,
+                flags: SS_DISABLE,
+                on_stack: false,
+            }
         } else {
             // Validate the new stack configuration
             // ss_sp must not be NULL
@@ -1190,20 +1243,41 @@ pub fn sys_sigaltstack(ss: u64, old_ss: u64) -> SyscallResult {
                 return SyscallResult::Err(14); // EFAULT
             }
 
-            // Set the new alternate stack
-            process.signals.alt_stack = crate::signal::types::AltStack {
-                base: new_stack.ss_sp,
-                size: new_stack.ss_size,
-                flags: 0, // Enabled (not SS_DISABLE)
-                on_stack: false,
-            };
             log::debug!(
                 "sigaltstack: set alternate stack for thread {}: base={:#x}, size={}",
                 current_thread_id,
                 new_stack.ss_sp,
                 new_stack.ss_size
             );
-        }
+            crate::signal::types::AltStack {
+                base: new_stack.ss_sp,
+                size: new_stack.ss_size,
+                flags: 0, // Enabled (not SS_DISABLE)
+                on_stack: false,
+            }
+        };
+
+        let mut manager_guard = manager();
+        let manager_ref = match manager_guard.as_mut() {
+            Some(m) => m,
+            None => {
+                log::error!("sys_sigaltstack: process manager not initialized");
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
+
+        let (_, process) = match manager_ref.find_process_by_thread_mut(current_thread_id) {
+            Some(p) => p,
+            None => {
+                log::error!(
+                    "sys_sigaltstack: process not found for thread {}",
+                    current_thread_id
+                );
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
+
+        process.signals.alt_stack = next_alt_stack;
     }
 
     SyscallResult::Ok(0)
@@ -1547,28 +1621,29 @@ pub fn sys_getitimer(which: i32, curr_value: u64) -> SyscallResult {
         }
     };
 
-    let manager_guard = manager();
-    let manager_ref = match manager_guard.as_ref() {
-        Some(m) => m,
-        None => {
-            log::error!("sys_getitimer: process manager not initialized");
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
+    let value = {
+        let manager_guard = manager();
+        let manager_ref = match manager_guard.as_ref() {
+            Some(m) => m,
+            None => {
+                log::error!("sys_getitimer: process manager not initialized");
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
 
-    let (_, process) = match manager_ref.find_process_by_thread(current_thread_id) {
-        Some(p) => p,
-        None => {
-            log::error!(
-                "sys_getitimer: process not found for thread {}",
-                current_thread_id
-            );
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
+        let (_, process) = match manager_ref.find_process_by_thread(current_thread_id) {
+            Some(p) => p,
+            None => {
+                log::error!(
+                    "sys_getitimer: process not found for thread {}",
+                    current_thread_id
+                );
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
 
-    // Get current timer value
-    let value = process.itimers.real.get_value();
+        process.itimers.real.get_value()
+    };
 
     // Write to userspace
     if curr_value != 0 {
@@ -1628,27 +1703,6 @@ pub fn sys_setitimer(which: i32, new_value: u64, old_value: u64) -> SyscallResul
         }
     };
 
-    let mut manager_guard = manager();
-    let manager_ref = match manager_guard.as_mut() {
-        Some(m) => m,
-        None => {
-            log::error!("sys_setitimer: process manager not initialized");
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
-
-    let (pid, process) = match manager_ref.find_process_by_thread_mut(current_thread_id) {
-        Some(p) => p,
-        None => {
-            log::error!(
-                "sys_setitimer: process not found for thread {}",
-                current_thread_id
-            );
-            return SyscallResult::Err(3); // ESRCH
-        }
-    };
-
-    // Read new value from userspace (if provided)
     let new_itimerval = if new_value != 0 {
         let ptr = new_value as *const Itimerval;
         match copy_from_user(ptr) {
@@ -1659,7 +1713,6 @@ pub fn sys_setitimer(which: i32, new_value: u64, old_value: u64) -> SyscallResul
         None
     };
 
-    // Validate timer values if provided
     if let Some(ref val) = new_itimerval {
         // tv_usec must be < 1,000,000
         if val.it_value.tv_usec >= 1_000_000 || val.it_value.tv_usec < 0 {
@@ -1683,29 +1736,53 @@ pub fn sys_setitimer(which: i32, new_value: u64, old_value: u64) -> SyscallResul
         }
     }
 
-    // Get old value before modifying
-    let old_itimerval = process.itimers.real.get_value();
+    let old_itimerval = {
+        let mut manager_guard = manager();
+        let manager_ref = match manager_guard.as_mut() {
+            Some(m) => m,
+            None => {
+                log::error!("sys_setitimer: process manager not initialized");
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
 
-    // Set new value if provided
-    if let Some(new_val) = new_itimerval {
-        process.itimers.real.set_value(&new_val);
+        let (pid, process) = match manager_ref.find_process_by_thread_mut(current_thread_id) {
+            Some(p) => p,
+            None => {
+                log::error!(
+                    "sys_setitimer: process not found for thread {}",
+                    current_thread_id
+                );
+                return SyscallResult::Err(3); // ESRCH
+            }
+        };
 
-        if new_val.it_value.is_zero() {
-            log::debug!(
-                "sys_setitimer: disabled ITIMER_REAL for process {}",
-                pid.as_u64()
-            );
-        } else {
-            log::debug!(
-                "sys_setitimer: set ITIMER_REAL for process {}: value={}.{:06}s, interval={}.{:06}s",
-                pid.as_u64(),
-                new_val.it_value.tv_sec,
-                new_val.it_value.tv_usec,
-                new_val.it_interval.tv_sec,
-                new_val.it_interval.tv_usec
-            );
+        // Get old value before modifying
+        let old_itimerval = process.itimers.real.get_value();
+
+        // Set new value if provided
+        if let Some(new_val) = new_itimerval {
+            process.itimers.real.set_value(&new_val);
+
+            if new_val.it_value.is_zero() {
+                log::debug!(
+                    "sys_setitimer: disabled ITIMER_REAL for process {}",
+                    pid.as_u64()
+                );
+            } else {
+                log::debug!(
+                    "sys_setitimer: set ITIMER_REAL for process {}: value={}.{:06}s, interval={}.{:06}s",
+                    pid.as_u64(),
+                    new_val.it_value.tv_sec,
+                    new_val.it_value.tv_usec,
+                    new_val.it_interval.tv_sec,
+                    new_val.it_interval.tv_usec
+                );
+            }
         }
-    }
+
+        old_itimerval
+    };
 
     // Write old value to userspace (if requested)
     if old_value != 0 {

--- a/kernel/src/syscall/socket.rs
+++ b/kernel/src/syscall/socket.rs
@@ -30,6 +30,16 @@ fn reset_quantum() {
     crate::arch_impl::aarch64::timer_interrupt::reset_quantum();
 }
 
+fn close_fds_for_thread(thread_id: u64, fds: [i32; 2]) {
+    let mut manager_guard = crate::process::manager();
+    if let Some(ref mut manager) = *manager_guard {
+        if let Some((_pid, process)) = manager.find_process_by_thread_mut(thread_id) {
+            let _ = process.fd_table.close(fds[0]);
+            let _ = process.fd_table.close(fds[1]);
+        }
+    }
+}
+
 /// Test hook to verify reset_quantum wiring on ARM64.
 #[cfg(feature = "boot_tests")]
 pub fn test_reset_quantum_hook() {
@@ -169,6 +179,11 @@ pub fn sys_socket(domain: u64, sock_type: u64, _protocol: u64) -> SyscallResult 
 ///
 /// Returns: 0 on success, negative errno on error
 pub fn sys_bind(fd: u64, addr_ptr: u64, addrlen: u64) -> SyscallResult {
+    enum BindAddress {
+        Inet(SockAddrIn),
+        Unix(alloc::vec::Vec<u8>),
+    }
+
     // Validate address pointer
     if addr_ptr == 0 {
         return SyscallResult::Err(EFAULT as u64);
@@ -183,6 +198,56 @@ pub fn sys_bind(fd: u64, addr_ptr: u64, addrlen: u64) -> SyscallResult {
     let family = unsafe {
         let family_bytes = core::slice::from_raw_parts(addr_ptr as *const u8, 2);
         u16::from_ne_bytes([family_bytes[0], family_bytes[1]])
+    };
+
+    let bind_addr = match family {
+        AF_INET => {
+            // Validate address length for IPv4
+            if addrlen < 16 {
+                return SyscallResult::Err(EINVAL as u64);
+            }
+
+            // Read full IPv4 address from userspace
+            let addr = unsafe {
+                let addr_bytes = core::slice::from_raw_parts(addr_ptr as *const u8, 16);
+                match SockAddrIn::from_bytes(addr_bytes) {
+                    Some(a) => a,
+                    None => return SyscallResult::Err(EINVAL as u64),
+                }
+            };
+
+            BindAddress::Inet(addr)
+        }
+        AF_UNIX => {
+            // Validate address length for Unix (need at least family + 1 byte path)
+            if addrlen < 3 {
+                return SyscallResult::Err(EINVAL as u64);
+            }
+
+            // Read Unix socket address from userspace
+            let addr = unsafe {
+                let addr_len = (addrlen as usize).min(110); // family (2) + path (108)
+                let addr_bytes = core::slice::from_raw_parts(addr_ptr as *const u8, addr_len);
+                match SockAddrUn::from_bytes(addr_bytes) {
+                    Some(a) => a,
+                    None => return SyscallResult::Err(EINVAL as u64),
+                }
+            };
+
+            // For now, only support abstract sockets (path starts with '\0')
+            if !addr.is_abstract() {
+                log::debug!(
+                    "sys_bind: Only abstract Unix sockets supported (path must start with \\0)"
+                );
+                return SyscallResult::Err(EINVAL as u64);
+            }
+
+            BindAddress::Unix(addr.path_bytes().to_vec())
+        }
+        _ => {
+            log::debug!("sys_bind: unsupported address family {}", family);
+            return SyscallResult::Err(EAFNOSUPPORT as u64);
+        }
     };
 
     // Get current thread and process
@@ -220,22 +285,8 @@ pub fn sys_bind(fd: u64, addr_ptr: u64, addrlen: u64) -> SyscallResult {
     };
 
     // Handle bind based on address family
-    match family {
-        AF_INET => {
-            // Validate address length for IPv4
-            if addrlen < 16 {
-                return SyscallResult::Err(EINVAL as u64);
-            }
-
-            // Read full IPv4 address from userspace
-            let addr = unsafe {
-                let addr_bytes = core::slice::from_raw_parts(addr_ptr as *const u8, 16);
-                match SockAddrIn::from_bytes(addr_bytes) {
-                    Some(a) => a,
-                    None => return SyscallResult::Err(EINVAL as u64),
-                }
-            };
-
+    match bind_addr {
+        BindAddress::Inet(addr) => {
             // Handle bind based on socket type
             match &fd_entry.kind {
                 FdKind::UdpSocket(s) => {
@@ -285,33 +336,7 @@ pub fn sys_bind(fd: u64, addr_ptr: u64, addrlen: u64) -> SyscallResult {
                 _ => SyscallResult::Err(ENOTSOCK as u64),
             }
         }
-        AF_UNIX => {
-            // Validate address length for Unix (need at least family + 1 byte path)
-            if addrlen < 3 {
-                return SyscallResult::Err(EINVAL as u64);
-            }
-
-            // Read Unix socket address from userspace
-            let addr = unsafe {
-                let addr_len = (addrlen as usize).min(110); // family (2) + path (108)
-                let addr_bytes = core::slice::from_raw_parts(addr_ptr as *const u8, addr_len);
-                match SockAddrUn::from_bytes(addr_bytes) {
-                    Some(a) => a,
-                    None => return SyscallResult::Err(EINVAL as u64),
-                }
-            };
-
-            // For now, only support abstract sockets (path starts with '\0')
-            if !addr.is_abstract() {
-                log::debug!(
-                    "sys_bind: Only abstract Unix sockets supported (path must start with \\0)"
-                );
-                return SyscallResult::Err(EINVAL as u64);
-            }
-
-            // Get the path bytes
-            let path = addr.path_bytes().to_vec();
-
+        BindAddress::Unix(path) => {
             // Handle bind based on socket type
             match &fd_entry.kind {
                 FdKind::UnixSocket(s) => {
@@ -336,10 +361,6 @@ pub fn sys_bind(fd: u64, addr_ptr: u64, addrlen: u64) -> SyscallResult {
                     SyscallResult::Err(EINVAL as u64)
                 }
             }
-        }
-        _ => {
-            log::debug!("sys_bind: unsupported address family {}", family);
-            SyscallResult::Err(EAFNOSUPPORT as u64)
         }
     }
 }
@@ -1854,78 +1875,81 @@ pub fn sys_socketpair(domain: u64, sock_type: u64, protocol: u64, sv_ptr: u64) -
         }
     };
 
-    let mut manager_guard = crate::process::manager();
-    let manager = match *manager_guard {
-        Some(ref mut m) => m,
-        None => {
-            log::error!("sys_socketpair: No process manager!");
-            return SyscallResult::Err(ErrorCode::NoSuchProcess as u64);
-        }
+    // Validate pointer is in valid userspace range (code/data, mmap, or stack)
+    if !crate::memory::layout::is_valid_user_address(sv_ptr) {
+        return SyscallResult::Err(EFAULT as u64);
+    }
+
+    let sv: [i32; 2] = {
+        let mut manager_guard = crate::process::manager();
+        let manager = match *manager_guard {
+            Some(ref mut m) => m,
+            None => {
+                log::error!("sys_socketpair: No process manager!");
+                return SyscallResult::Err(ErrorCode::NoSuchProcess as u64);
+            }
+        };
+
+        let (_pid, process) = match manager.find_process_by_thread_mut(current_thread_id) {
+            Some(p) => p,
+            None => {
+                log::error!(
+                    "sys_socketpair: No process found for thread_id={}",
+                    current_thread_id
+                );
+                return SyscallResult::Err(ErrorCode::NoSuchProcess as u64);
+            }
+        };
+
+        // Create the socket pair
+        let (socket_a, socket_b) = UnixStreamSocket::new_pair(nonblocking);
+
+        // Create file descriptor entries with appropriate flags
+        let fd_flags = if cloexec { flags::FD_CLOEXEC } else { 0 };
+        let fd_status_flags = if nonblocking {
+            status_flags::O_NONBLOCK
+        } else {
+            0
+        };
+
+        let fd_entry_a =
+            FileDescriptor::with_flags(FdKind::UnixStream(socket_a), fd_flags, fd_status_flags);
+        let fd_entry_b =
+            FileDescriptor::with_flags(FdKind::UnixStream(socket_b), fd_flags, fd_status_flags);
+
+        // Allocate file descriptors
+        let fd_a = match process.fd_table.alloc_with_entry(fd_entry_a) {
+            Ok(fd) => fd,
+            Err(e) => {
+                log::error!("sys_socketpair: Failed to allocate fd_a: {}", e);
+                return SyscallResult::Err(e as u64);
+            }
+        };
+
+        let fd_b = match process.fd_table.alloc_with_entry(fd_entry_b) {
+            Ok(fd) => fd,
+            Err(e) => {
+                // Clean up fd_a on failure
+                let _ = process.fd_table.close(fd_a);
+                log::error!("sys_socketpair: Failed to allocate fd_b: {}", e);
+                return SyscallResult::Err(e as u64);
+            }
+        };
+
+        [fd_a, fd_b]
     };
 
-    let (_pid, process) = match manager.find_process_by_thread_mut(current_thread_id) {
-        Some(p) => p,
-        None => {
-            log::error!(
-                "sys_socketpair: No process found for thread_id={}",
-                current_thread_id
-            );
-            return SyscallResult::Err(ErrorCode::NoSuchProcess as u64);
-        }
-    };
-
-    // Create the socket pair
-    let (socket_a, socket_b) = UnixStreamSocket::new_pair(nonblocking);
-
-    // Create file descriptor entries with appropriate flags
-    let fd_flags = if cloexec { flags::FD_CLOEXEC } else { 0 };
-    let fd_status_flags = if nonblocking {
-        status_flags::O_NONBLOCK
-    } else {
-        0
-    };
-
-    let fd_entry_a =
-        FileDescriptor::with_flags(FdKind::UnixStream(socket_a), fd_flags, fd_status_flags);
-    let fd_entry_b =
-        FileDescriptor::with_flags(FdKind::UnixStream(socket_b), fd_flags, fd_status_flags);
-
-    // Allocate file descriptors
-    let fd_a = match process.fd_table.alloc_with_entry(fd_entry_a) {
-        Ok(fd) => fd,
-        Err(e) => {
-            log::error!("sys_socketpair: Failed to allocate fd_a: {}", e);
-            return SyscallResult::Err(e as u64);
-        }
-    };
-
-    let fd_b = match process.fd_table.alloc_with_entry(fd_entry_b) {
-        Ok(fd) => fd,
-        Err(e) => {
-            // Clean up fd_a on failure
-            let _ = process.fd_table.close(fd_a);
-            log::error!("sys_socketpair: Failed to allocate fd_b: {}", e);
-            return SyscallResult::Err(e as u64);
-        }
-    };
-
-    // Write the file descriptors to userspace sv[0], sv[1]
-    let sv: [i32; 2] = [fd_a, fd_b];
-    unsafe {
-        let sv_user = sv_ptr as *mut [i32; 2];
-        // Validate pointer is in valid userspace range (code/data, mmap, or stack)
-        if !crate::memory::layout::is_valid_user_address(sv_ptr) {
-            let _ = process.fd_table.close(fd_a);
-            let _ = process.fd_table.close(fd_b);
-            return SyscallResult::Err(EFAULT as u64);
-        }
-        core::ptr::write_volatile(sv_user, sv);
+    // Write the file descriptors to userspace sv[0], sv[1] after dropping
+    // PROCESS_MANAGER; sv may point at a CoW page.
+    if let Err(errno) = super::userptr::copy_to_user(sv_ptr as *mut [i32; 2], &sv) {
+        close_fds_for_thread(current_thread_id, sv);
+        return SyscallResult::Err(errno);
     }
 
     log::info!(
         "sys_socketpair: Created Unix socket pair sv=[{}, {}] nonblocking={} cloexec={}",
-        fd_a,
-        fd_b,
+        sv[0],
+        sv[1],
         nonblocking,
         cloexec
     );


### PR DESCRIPTION
## Summary

This audits syscall paths that could hold process/fd state locks while touching faultable userspace memory, matching the deadlock class fixed for NB-13 in `sys_ptsname`. The patch snapshots or allocates kernel-side state under the lock, releases the lock, and then performs the `copy_to_user` / `copy_from_user` operation so an ARM64 CoW fault cannot re-enter the same process-manager path.

Changed files:
- `kernel/src/syscall/fs.rs`: `getcwd` snapshots cwd before copying to the caller buffer.
- `kernel/src/syscall/handlers.rs`: `read` devfs/procfs paths drop the process-manager guard before copying data to userspace.
- `kernel/src/syscall/pipe.rs`: `pipe` / `pipe2` allocate fds under lock, copy the fd array after releasing it, and clean up by reacquiring only on copy failure.
- `kernel/src/syscall/signal.rs`: signal action/mask/altstack/timer APIs separate state snapshots/updates from faultable user copies.
- `kernel/src/syscall/socket.rs`: `bind` captures the user address before process state work, and `socketpair` copies returned fds after releasing `PROCESS_MANAGER` with cleanup on failure.

## Validation

Validation was completed before the wrap directive; no extra boots/tests were run after that directive.

- `turn59-artifacts/build-aarch64-final.log`: release build finished cleanly, no warnings/errors.
- `turn59-artifacts/build-x86_64.log`: kernel + breenix release build finished cleanly, no warnings/errors.
- `turn59-artifacts/parallels-test-120.serial.log`: 120s Parallels run stayed alive; heartbeats continued to roughly `uptime_ms=155595`; validation notes reported `VIRTGPU_FAIL=0`.
- `turn59-artifacts/parallels-autolaunch-terminal.serial.log`: NB-13 reproducer remained fixed; BWM discovered `Terminal` and `bterm` spawned both child processes (`pid=9`, `pid=10`).

## Soft-lockup note

The 120s Parallels run contains about 85 `SOFT LOCKUP DETECTED` dumps. I am not hiding that. These are the separate pre-existing recurring scheduler/VirtGPU issue already flagged since TURN 55/57, not introduced by this syscall copy-path audit: this patch does not touch scheduler/VirtGPU paths, the system stayed alive with heartbeats continuing, and validation reported `VIRTGPU_FAIL=0`.

🤖 Generated with [Codex](https://openai.com/codex)