### PR TITLE
Wake current-on-CPU waiters with reschedule IPI

### DIFF
--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -181,7 +181,9 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
         CPU0_LAST_SYNC_ESR.store(esr, Ordering::Relaxed);
         CPU0_LAST_SYNC_FAR.store(far, Ordering::Relaxed);
         let elr: u64;
-        unsafe { core::arch::asm!("mrs {}, elr_el1", out(reg) elr, options(nomem, nostack)); }
+        unsafe {
+            core::arch::asm!("mrs {}, elr_el1", out(reg) elr, options(nomem, nostack));
+        }
         CPU0_LAST_SYNC_ELR.store(elr, Ordering::Relaxed);
     }
 
@@ -936,7 +938,11 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                                 raw_uart_str(" owner_pid=");
                                 raw_uart_dec(thread.owner_pid);
                                 raw_uart_str(" bis=");
-                                raw_uart_char(if thread.blocked_in_syscall { b'1' } else { b'0' });
+                                raw_uart_char(if thread.blocked_in_syscall {
+                                    b'1'
+                                } else {
+                                    b'0'
+                                });
                                 raw_uart_str(" saved_elr=");
                                 raw_uart_hex(thread.elr_el1);
                                 raw_uart_str(" saved_x30=");
@@ -1215,6 +1221,11 @@ fn dispatch_irq_action(irq_id: u32, frame: *const Aarch64ExceptionFrame) {
         0..=15 => {
             if irq_id == constants::SGI_RESCHEDULE {
                 // IPI reschedule: another CPU unblocked a thread and wants us to pick it up
+                crate::tracing::record_event(
+                    crate::tracing::TraceEventType::SCHED_RESCHED_IPI_RECV,
+                    0,
+                    irq_id,
+                );
                 crate::per_cpu_aarch64::set_need_resched(true);
             } else if irq_id == constants::SGI_TIMER_REARM {
                 // IPI timer re-arm: another CPU detected our timer is dead
@@ -1348,11 +1359,7 @@ pub extern "C" fn handle_irq(frame: *const Aarch64ExceptionFrame) {
             interrupted_context_had_irqs_unmasked(frame) && !gic::is_spi_level_triggered(irq_id);
         if reopen_nested_irq_window {
             unsafe {
-                core::arch::asm!(
-                    "msr daifclr, #3",
-                    "isb",
-                    options(nomem, nostack)
-                );
+                core::arch::asm!("msr daifclr, #3", "isb", options(nomem, nostack));
             }
         }
 
@@ -1360,11 +1367,7 @@ pub extern "C" fn handle_irq(frame: *const Aarch64ExceptionFrame) {
 
         if reopen_nested_irq_window {
             unsafe {
-                core::arch::asm!(
-                    "msr daifset, #3",
-                    "isb",
-                    options(nomem, nostack)
-                );
+                core::arch::asm!("msr daifset, #3", "isb", options(nomem, nostack));
             }
         }
 

--- a/kernel/src/fs/procfs/trace.rs
+++ b/kernel/src/fs/procfs/trace.rs
@@ -60,6 +60,18 @@ pub fn generate_events() -> String {
         (TraceEventType::SCHED_PICK, "scheduler pick"),
         (TraceEventType::SCHED_RESCHED, "reschedule"),
         (TraceEventType::SCHED_PREEMPT, "preemption"),
+        (
+            TraceEventType::SCHED_WAKE_CURRENT,
+            "wake thread current on another CPU",
+        ),
+        (
+            TraceEventType::SCHED_RESCHED_IPI_SEND,
+            "reschedule IPI send",
+        ),
+        (
+            TraceEventType::SCHED_RESCHED_IPI_RECV,
+            "reschedule IPI receive",
+        ),
         // Syscall events (0x03xx)
         (TraceEventType::SYSCALL_ENTRY, "syscall entry"),
         (TraceEventType::SYSCALL_EXIT, "syscall exit"),

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -1367,6 +1367,12 @@ impl Scheduler {
                 // same stack, leading to context corruption and crashes (ELR=0x0).
                 // The CPU running the thread will detect the state change (Blocked
                 // → Ready) when its WFI loop checks the thread state after waking.
+                #[cfg(target_arch = "aarch64")]
+                let current_cpu = (0..MAX_CPUS)
+                    .find(|&cpu| self.cpu_state[cpu].current_thread == Some(thread_id));
+                #[cfg(target_arch = "aarch64")]
+                let is_current_on_any_cpu = current_cpu.is_some();
+                #[cfg(not(target_arch = "aarch64"))]
                 let is_current_on_any_cpu =
                     (0..MAX_CPUS).any(|cpu| self.cpu_state[cpu].current_thread == Some(thread_id));
 
@@ -1401,11 +1407,25 @@ impl Scheduler {
                     self.send_resched_ipi();
                 } else if is_current_on_any_cpu || is_in_deferred {
                     ENQUEUE_DEFERRED.fetch_add(1, Ordering::Relaxed);
+                    #[cfg(target_arch = "aarch64")]
+                    if let Some(target) = current_cpu {
+                        self.trace_wake_current(thread_id, target);
+                        self.send_resched_ipi_to_cpu(target);
+                    }
                 } else if already_queued {
                     ENQUEUE_ALREADY_QUEUED_OK.fetch_add(1, Ordering::Relaxed);
                 }
             }
         }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn trace_wake_current(&self, thread_id: u64, target_cpu: usize) {
+        crate::tracing::record_event(
+            crate::tracing::TraceEventType::SCHED_WAKE_CURRENT,
+            0,
+            (((target_cpu as u32) & 0xFFFF) << 16) | ((thread_id as u32) & 0xFFFF),
+        );
     }
 
     /// Send reschedule IPIs (SGI 0) to all idle CPUs.
@@ -1457,6 +1477,12 @@ impl Scheduler {
         if target_cpu >= MAX_CPUS || target_cpu >= smp::cpus_online() as usize {
             return;
         }
+
+        crate::tracing::record_event(
+            crate::tracing::TraceEventType::SCHED_RESCHED_IPI_SEND,
+            0,
+            (((target_cpu as u32) & 0xFFFF) << 16) | ((Self::current_cpu_id() as u32) & 0xFFFF),
+        );
 
         crate::arch_impl::aarch64::gic::send_sgi(
             crate::arch_impl::aarch64::constants::SGI_RESCHEDULE as u8,
@@ -1833,10 +1859,16 @@ impl Scheduler {
 
     fn unblock_for_io_attributed(&mut self, tid: u64, from_isr_buffer: bool) {
         let wake = self.wake_io_thread_locked(tid, from_isr_buffer);
-        if wake.enqueued_target.is_some() {
-            #[cfg(target_arch = "aarch64")]
-            self.send_resched_ipi();
+        #[cfg(target_arch = "aarch64")]
+        if let Some(target) = wake.current_cpu {
+            self.trace_wake_current(tid, target);
         }
+        #[cfg(target_arch = "aarch64")]
+        if let Some(target) = wake.resched_target() {
+            self.send_resched_ipi_to_cpu(target);
+        }
+        #[cfg(not(target_arch = "aarch64"))]
+        let _ = wake.resched_target();
     }
 
     /// Immediate task-context waitqueue wake.
@@ -1846,6 +1878,10 @@ impl Scheduler {
     /// transition before the waitqueue wake returns.
     pub fn wake_waitqueue_thread(&mut self, tid: u64) {
         let wake = self.wake_io_thread_locked(tid, false);
+        #[cfg(target_arch = "aarch64")]
+        if let Some(target) = wake.current_cpu {
+            self.trace_wake_current(tid, target);
+        }
         #[cfg(target_arch = "aarch64")]
         if let Some(target) = wake.resched_target() {
             self.send_resched_ipi_to_cpu(target);
@@ -2214,8 +2250,8 @@ impl Scheduler {
             .unwrap_or(false);
         let is_queued = self.per_cpu_queues.iter().any(|q| q.contains(&previous));
         let is_current = (0..MAX_CPUS).any(|c| self.cpu_state[c].current_thread == Some(previous));
-        let is_other_deferred = (0..MAX_CPUS)
-            .any(|c| c != cpu && self.cpu_state[c].previous_thread == Some(previous));
+        let is_other_deferred =
+            (0..MAX_CPUS).any(|c| c != cpu && self.cpu_state[c].previous_thread == Some(previous));
 
         if is_ready && !is_idle && !is_queued && !is_current && !is_other_deferred {
             self.per_cpu_queues[cpu].push_back(previous);

--- a/kernel/src/tracing/core.rs
+++ b/kernel/src/tracing/core.rs
@@ -149,6 +149,9 @@ impl TraceEventType {
     pub const SCHED_PICK: u16 = 0x0200;
     pub const SCHED_RESCHED: u16 = 0x0201;
     pub const SCHED_PREEMPT: u16 = 0x0202;
+    pub const SCHED_WAKE_CURRENT: u16 = 0x0203;
+    pub const SCHED_RESCHED_IPI_SEND: u16 = 0x0204;
+    pub const SCHED_RESCHED_IPI_RECV: u16 = 0x0205;
     pub const SCHED_QUEUE_STATE: u16 = 0x0012;
 
     // Syscall events (0x03xx)

--- a/kernel/src/tracing/output.rs
+++ b/kernel/src/tracing/output.rs
@@ -266,6 +266,9 @@ pub fn event_type_name(event_type: u16) -> &'static str {
         TraceEventType::SCHED_PICK => "SCHED_PICK",
         TraceEventType::SCHED_RESCHED => "SCHED_RESCHED",
         TraceEventType::SCHED_PREEMPT => "SCHED_PREEMPT",
+        TraceEventType::SCHED_WAKE_CURRENT => "SCHED_WAKE_CURRENT",
+        TraceEventType::SCHED_RESCHED_IPI_SEND => "SCHED_RESCHED_IPI_SEND",
+        TraceEventType::SCHED_RESCHED_IPI_RECV => "SCHED_RESCHED_IPI_RECV",
 
         // Syscall events (0x03xx)
         TraceEventType::SYSCALL_ENTRY => "SYSCALL_ENTRY",
@@ -385,6 +388,9 @@ fn payload_description(event_type: u16) -> &'static str {
         TraceEventType::SCHED_PICK => "tid",
         TraceEventType::SCHED_RESCHED => "0",
         TraceEventType::SCHED_PREEMPT => "0",
+        TraceEventType::SCHED_WAKE_CURRENT => "target_cpu<<16|tid",
+        TraceEventType::SCHED_RESCHED_IPI_SEND => "target_cpu<<16|source_cpu",
+        TraceEventType::SCHED_RESCHED_IPI_RECV => "irq_id",
         TraceEventType::SYSCALL_ENTRY => "syscall_nr",
         TraceEventType::SYSCALL_EXIT => "result",
         TraceEventType::PAGE_FAULT => "error_code",


### PR DESCRIPTION
## Summary
- send a targeted ARM64 reschedule SGI when a wake makes a thread ready while it is still current on another CPU
- cover unblock, IO wake, and waitqueue wake paths without queueing the still-current thread on another CPU
- keep lock-free trace events for wake-current, targeted IPI send, and SGI receive diagnostics

## Proof
- build clean: `turn65-artifacts/build-aarch64-final.log` has no warning/error lines
- before-timer proof: `IDLE_WAKE_PROOF cpu=0 idle_wakes=319 recv_before_timer=314 resume_before_timer=0` in `turn65-artifacts/parallels-before-timer-proof.key-lines.txt` (98.4% recv-before-next-timer)
- final regression gate: `turn65-artifacts/parallels-final-candidate.key-lines.txt` shows bsshd/bounce startup and CPU0 ticks through 30000 with no DATA_ABORT/FATAL/SOFT_LOCKUP key lines

## Notes
- proof scaffolding was removed before commit; the final tree contains only the scheduler fix plus permanent lock-free trace metadata
- proof demonstrates CPU0, the harness target CPU; other CPUs use the same targeted SGI path by symmetry