### PR TITLE
epoll CoW-fault-deadlock round-2: lock-drop before user copies

### DIFF
--- a/kernel/src/syscall/epoll.rs
+++ b/kernel/src/syscall/epoll.rs
@@ -214,7 +214,11 @@ pub fn sys_epoll_ctl(epfd: i32, op: i32, fd: i32, event_ptr: u64) -> SyscallResu
         }
     }
 
-    // Read the event structure from userspace (not needed for DEL)
+    // Drop manager guard before any faultable user copy or EPOLL_INSTANCES access.
+    drop(manager_guard);
+
+    // Read the event structure from userspace after dropping the process-manager
+    // lock. A userspace page fault here may need that lock.
     let (events, data) = if op != EPOLL_CTL_DEL {
         if event_ptr == 0 {
             return SyscallResult::Err(errno::EFAULT as u64);
@@ -228,9 +232,6 @@ pub fn sys_epoll_ctl(epfd: i32, op: i32, fd: i32, event_ptr: u64) -> SyscallResu
     } else {
         (0, 0)
     };
-
-    // Drop manager guard before accessing EPOLL_INSTANCES to avoid lock ordering issues
-    drop(manager_guard);
 
     let result = match op {
         EPOLL_CTL_ADD => with_instance(epoll_id, |inst| inst.add(fd, events, data)),
@@ -364,10 +365,10 @@ pub fn sys_epoll_pwait(
         // If events are ready, copy to userspace and return
         if !ready_events.is_empty() {
             let count = ready_events.len();
-            unsafe {
-                let dst = events_ptr as *mut EpollEvent;
-                for (i, event) in ready_events.iter().enumerate() {
-                    core::ptr::write(dst.add(i), *event);
+            let dst = events_ptr as *mut EpollEvent;
+            for (i, event) in ready_events.iter().enumerate() {
+                if let Err(errno) = super::userptr::copy_to_user(dst.wrapping_add(i), event) {
+                    return SyscallResult::Err(errno);
                 }
             }
             return SyscallResult::Ok(count as u64);

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -147,6 +147,10 @@ name = "select_test"
 path = "src/select_test.rs"
 
 [[bin]]
+name = "epoll_test"
+path = "src/epoll_test.rs"
+
+[[bin]]
 name = "nonblock_test"
 path = "src/nonblock_test.rs"
 

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -127,6 +127,7 @@ STD_BINARIES=(
     "fcntl_test"
     "poll_test"
     "select_test"
+    "epoll_test"
     "nonblock_test"
     "brk_test"
     "signal_handler_test"

--- a/userspace/programs/src/bcheck.rs
+++ b/userspace/programs/src/bcheck.rs
@@ -68,6 +68,7 @@ fn make_tests() -> Vec<TestDef> {
         (b"/usr/local/test/bin/pipe2_test\0",        "pipe2",            "ipc"),
         (b"/usr/local/test/bin/dup_test\0",          "dup",              "ipc"),
         (b"/usr/local/test/bin/fcntl_test\0",        "fcntl",            "ipc"),
+        (b"/usr/local/test/bin/epoll_test\0",        "epoll",            "ipc"),
         // Process
         (b"/usr/local/test/bin/fork_test\0",         "fork",             "proc"),
         (b"/usr/local/test/bin/waitpid_test\0",      "waitpid",          "proc"),

--- a/userspace/programs/src/epoll_test.rs
+++ b/userspace/programs/src/epoll_test.rs
@@ -1,0 +1,187 @@
+//! Epoll syscall test program.
+//!
+//! Covers basic epoll_create1/epoll_ctl/epoll_wait behavior and a fork/CoW
+//! case where epoll_wait writes into a child stack buffer inherited from the
+//! parent.
+
+use libbreenix::io;
+use libbreenix::process::{fork, waitpid, wexitstatus, wifexited, ForkResult};
+use libbreenix::syscall::{nr, raw};
+use std::process;
+
+const EPOLLIN: u32 = 0x001;
+const EPOLL_CTL_ADD: i32 = 1;
+
+#[repr(C)]
+#[cfg_attr(target_arch = "x86_64", repr(packed))]
+#[derive(Clone, Copy, Default)]
+struct EpollEvent {
+    events: u32,
+    data: u64,
+}
+
+impl EpollEvent {
+    fn events(&self) -> u32 {
+        unsafe { core::ptr::addr_of!(self.events).read_unaligned() }
+    }
+
+    fn data(&self) -> u64 {
+        unsafe { core::ptr::addr_of!(self.data).read_unaligned() }
+    }
+
+    fn zero_unaligned(&mut self) {
+        unsafe {
+            core::ptr::addr_of_mut!(self.events).write_unaligned(0);
+            core::ptr::addr_of_mut!(self.data).write_unaligned(0);
+        }
+    }
+}
+
+fn fail(msg: &str) -> ! {
+    println!("USERSPACE EPOLL: FAIL - {}", msg);
+    process::exit(1);
+}
+
+fn syscall_i32(ret: u64, name: &str) -> i32 {
+    let signed = ret as i64;
+    if signed < 0 {
+        println!("  {} returned errno {}", name, -signed);
+        fail(name);
+    }
+    signed as i32
+}
+
+fn epoll_create1(flags: i32) -> i32 {
+    let ret = unsafe { raw::syscall1(nr::EPOLL_CREATE1, flags as u64) };
+    syscall_i32(ret, "epoll_create1")
+}
+
+fn epoll_ctl(epfd: i32, op: i32, fd: i32, event: &mut EpollEvent) {
+    let ret = unsafe {
+        raw::syscall4(
+            nr::EPOLL_CTL,
+            epfd as u64,
+            op as u64,
+            fd as u64,
+            event as *mut EpollEvent as u64,
+        )
+    };
+    let _ = syscall_i32(ret, "epoll_ctl");
+}
+
+fn epoll_wait(epfd: i32, events: &mut [EpollEvent], timeout_ms: i32) -> i32 {
+    let ret = unsafe {
+        raw::syscall6(
+            nr::EPOLL_PWAIT,
+            epfd as u64,
+            events.as_mut_ptr() as u64,
+            events.len() as u64,
+            timeout_ms as u64,
+            0,
+            0,
+        )
+    };
+    syscall_i32(ret, "epoll_wait")
+}
+
+fn expect_ready(epfd: i32, expected_data: u64, label: &str) {
+    let mut events = [EpollEvent::default(); 1];
+    let count = epoll_wait(epfd, &mut events, 0);
+    println!(
+        "  {}: epoll_wait returned {}, events={:#x}, data={:#x}",
+        label,
+        count,
+        events[0].events(),
+        events[0].data()
+    );
+
+    if count != 1 {
+        fail("epoll_wait should return one ready event");
+    }
+    if events[0].events() & EPOLLIN == 0 {
+        fail("ready event should include EPOLLIN");
+    }
+    if events[0].data() != expected_data {
+        fail("ready event data mismatch");
+    }
+}
+
+fn create_ready_epoll(data: u64) -> (i32, libbreenix::types::Fd, libbreenix::types::Fd) {
+    let (read_fd, write_fd) = io::pipe().unwrap_or_else(|_| fail("pipe failed"));
+    let epfd = epoll_create1(0);
+
+    let mut event = EpollEvent {
+        events: EPOLLIN,
+        data,
+    };
+    epoll_ctl(epfd, EPOLL_CTL_ADD, read_fd.raw() as i32, &mut event);
+
+    let written = io::write(write_fd, b"x").unwrap_or_else(|_| fail("pipe write failed"));
+    if written != 1 {
+        fail("pipe write returned short count");
+    }
+
+    (epfd, read_fd, write_fd)
+}
+
+fn test_basic_ready_pipe() {
+    println!("Phase 1: basic epoll ready pipe");
+    let (epfd, read_fd, write_fd) = create_ready_epoll(0xE901_0001);
+    expect_ready(epfd, 0xE901_0001, "basic");
+    let _ = io::close(read_fd);
+    let _ = io::close(write_fd);
+    println!("  EPOLL_BASIC_READY_PASS");
+}
+
+fn test_fork_cow_wait_buffer() {
+    println!("Phase 2: fork child epoll_wait into CoW stack buffer");
+    let (epfd, read_fd, write_fd) = create_ready_epoll(0xC0FF_EE68);
+
+    let mut child_events = [EpollEvent::default(); 1];
+    child_events[0].zero_unaligned();
+
+    match fork() {
+        Ok(ForkResult::Child) => {
+            let count = epoll_wait(epfd, &mut child_events, 0);
+            println!(
+                "[CHILD] epoll_wait returned {}, events={:#x}, data={:#x}",
+                count,
+                child_events[0].events(),
+                child_events[0].data()
+            );
+            if count == 1
+                && child_events[0].events() & EPOLLIN != 0
+                && child_events[0].data() == 0xC0FF_EE68
+            {
+                println!("EPOLL_COW_WAIT_CHILD_PASS");
+                process::exit(0);
+            }
+            println!("EPOLL_COW_WAIT_CHILD_FAIL");
+            process::exit(1);
+        }
+        Ok(ForkResult::Parent(child_pid)) => {
+            let mut status = 0i32;
+            match waitpid(child_pid.raw() as i32, &mut status, 0) {
+                Ok(pid) if pid.raw() == child_pid.raw() => {}
+                _ => fail("waitpid failed for epoll CoW child"),
+            }
+            if !wifexited(status) || wexitstatus(status) != 0 {
+                fail("epoll CoW child failed");
+            }
+        }
+        Err(_) => fail("fork failed for epoll CoW test"),
+    }
+
+    let _ = io::close(read_fd);
+    let _ = io::close(write_fd);
+    println!("  EPOLL_COW_WAIT_PASS");
+}
+
+fn main() {
+    println!("=== Epoll Test Program ===");
+    test_basic_ready_pipe();
+    test_fork_cow_wait_buffer();
+    println!("USERSPACE EPOLL: ALL TESTS PASSED");
+    println!("EPOLL_TEST_PASSED");
+    process::exit(0);
+}


### PR DESCRIPTION
## Summary
- Fixes the epoll CoW-fault-deadlock round-2 sites by dropping the process-manager lock before faultable user copies.
- Converts `epoll_wait` ready-event writes from raw `ptr::write` to fault-safe `copy_to_user`.
- Adds `/usr/local/test/bin/epoll_test` and wires it into `bcheck`; the test covers basic ready-pipe delivery plus a forked child waiting into a CoW stack buffer.

## Offending sites / fix
- `kernel/src/syscall/epoll.rs`: `sys_epoll_ctl` now drops the process-manager guard before `copy_from_user(event_ptr)`.
- `kernel/src/syscall/epoll.rs`: `sys_epoll_pwait` snapshots state before readiness checks, then uses `copy_to_user` for ready events so user faults are handled outside the dangerous lock path.

## Proof
- Prior runtime proof captured in `turn68-artifacts/`: `EPOLL_COW_WAIT_CHILD_PASS` and `EPOLL_TEST_PASSED`.
- Candidate-alone regression boot was clean per the Turn 68 artifacts.
- Final compile gates run after the commit-only cleanup:
  - `turn68-artifacts/build-aarch64-final-codex.log`: ARM64 kernel build clean.
  - `turn68-artifacts/build-userspace-final-codex.log`: userspace build clean and installs `epoll_test.elf`.

## Note
The only code adjustment during this finalize turn was a literal compile fix in `epoll_test.rs`: the x86_64 test struct is packed, so test logging/checking now reads fields through unaligned-safe helpers instead of creating references to packed fields.
