### PR TITLE
Fix CoW user copies under process-manager lock

### DIFF
--- a/kernel/src/syscall/clone.rs
+++ b/kernel/src/syscall/clone.rs
@@ -219,15 +219,13 @@ pub fn sys_clone(
         child_process.clear_child_tid = Some(child_tidptr);
     }
 
-    // Write child TID to child_tidptr (CLONE_CHILD_SETTID)
-    if flags & CLONE_CHILD_SETTID != 0 && child_tidptr != 0 {
-        unsafe {
-            let ptr = child_tidptr as *mut u32;
-            if !ptr.is_null() && (child_tidptr as usize) < 0x7FFF_FFFF_FFFF {
-                core::ptr::write_volatile(ptr, child_thread_id as u32);
-            }
-        }
-    }
+    // Write child TID to child_tidptr (CLONE_CHILD_SETTID), but only after
+    // PROCESS_MANAGER is dropped. The pointer may reference a CoW page.
+    let child_tid_write = if flags & CLONE_CHILD_SETTID != 0 && child_tidptr != 0 {
+        Some((child_tidptr as *mut u32, child_thread_id as u32))
+    } else {
+        None
+    };
 
     // Write child TID to parent's tidptr (CLONE_PARENT_SETTID)
     // (handled by caller since we return the tid)
@@ -255,6 +253,10 @@ pub fn sys_clone(
     };
 
     drop(manager_guard);
+
+    if let Some((ptr, tid)) = child_tid_write {
+        let _ = super::userptr::copy_to_user(ptr, &tid);
+    }
 
     // Add thread to scheduler
     if let Some(thread_box) = scheduler_thread {

--- a/kernel/src/syscall/graphics.rs
+++ b/kernel/src/syscall/graphics.rs
@@ -2055,10 +2055,12 @@ fn handle_resize_window_buffer(cmd: &FbDrawCmd) -> SyscallResult {
         new_addr
     );
 
-    // Write new mmap address to userspace
+    // Write new mmap address to userspace after dropping PROCESS_MANAGER;
+    // out_ptr may reference a CoW page.
+    drop(manager_guard);
     if out_ptr != 0 && out_ptr < USER_SPACE_MAX {
-        unsafe {
-            core::ptr::write(out_ptr as *mut u64, new_addr);
+        if crate::syscall::userptr::copy_to_user(out_ptr as *mut u64, &new_addr).is_err() {
+            return SyscallResult::Err(super::ErrorCode::Fault as u64);
         }
     }
 
@@ -2160,9 +2162,11 @@ fn handle_map_window_buffer(cmd: &FbDrawCmd) -> SyscallResult {
         num_pages
     );
 
-    // Write mapped address to userspace
-    unsafe {
-        core::ptr::write(out_ptr as *mut u64, new_addr);
+    // Write mapped address to userspace after dropping PROCESS_MANAGER;
+    // out_ptr may reference a CoW page.
+    drop(manager_guard);
+    if crate::syscall::userptr::copy_to_user(out_ptr as *mut u64, &new_addr).is_err() {
+        return SyscallResult::Err(super::ErrorCode::Fault as u64);
     }
 
     // Return packed dimensions
@@ -2263,9 +2267,11 @@ fn handle_map_compositor_texture(cmd: &FbDrawCmd) -> SyscallResult {
         new_addr, tex_w, tex_h, num_pages, crate::graphics::compositor_backend()
     );
 
-    // Write mapped address to userspace
-    unsafe {
-        core::ptr::write(out_ptr as *mut u64, new_addr);
+    // Write mapped address to userspace after dropping PROCESS_MANAGER;
+    // out_ptr may reference a CoW page.
+    drop(manager_guard);
+    if crate::syscall::userptr::copy_to_user(out_ptr as *mut u64, &new_addr).is_err() {
+        return SyscallResult::Err(super::ErrorCode::Fault as u64);
     }
 
     // Return packed dimensions

--- a/kernel/src/syscall/handlers.rs
+++ b/kernel/src/syscall/handlers.rs
@@ -138,27 +138,31 @@ pub fn sys_exit(exit_code: i32) -> SyscallResult {
         log::debug!("sys_exit: Current thread ID from scheduler: {}", thread_id);
         crate::tracing::providers::process::trace_thread_exit(thread_id as u16, exit_code as u16);
 
-        // Handle clear_child_tid for clone threads (CLONE_CHILD_CLEARTID)
-        // Write 0 to the tid address and futex-wake any joiners
-        {
+        // Handle clear_child_tid for clone threads (CLONE_CHILD_CLEARTID).
+        // Snapshot under PROCESS_MANAGER, then write to userspace after the
+        // lock is dropped because the tid address may reference a CoW page.
+        let clear_child_tid = {
             let manager_guard = crate::process::manager();
             if let Some(ref manager) = *manager_guard {
                 if let Some((_pid, process)) = manager.find_process_by_thread(thread_id) {
                     if let Some(tid_addr) = process.clear_child_tid {
                         let tg_id = process.thread_group_id.unwrap_or(_pid.as_u64());
-                        // Write 0 to the tid address
-                        unsafe {
-                            let ptr = tid_addr as *mut u32;
-                            if !ptr.is_null() && tid_addr < 0x7FFF_FFFF_FFFF {
-                                core::ptr::write_volatile(ptr, 0);
-                            }
-                        }
-                        // Futex-wake any threads waiting on this address
-                        drop(manager_guard);
-                        super::futex::futex_wake_for_thread_group(tg_id, tid_addr, u32::MAX);
+                        Some((tg_id, tid_addr))
+                    } else {
+                        None
                     }
+                } else {
+                    None
                 }
+            } else {
+                None
             }
+        };
+
+        if let Some((tg_id, tid_addr)) = clear_child_tid {
+            let zero = 0u32;
+            let _ = super::userptr::copy_to_user(tid_addr as *mut u32, &zero);
+            super::futex::futex_wake_for_thread_group(tg_id, tid_addr, u32::MAX);
         }
 
         // Handle thread exit through ProcessScheduler


### PR DESCRIPTION
## Summary
- drop PROCESS_MANAGER before CLONE_CHILD_SETTID child tid copy_to_user
- drop PROCESS_MANAGER before graphics mmap-address copy_to_user writes
- snapshot clear_child_tid under PROCESS_MANAGER, then copy_to_user and futex-wake after dropping it

## Cleanup
- reverted the project-wide cargo fmt churn from this branch
- confirmed gold-master context_switch.rs and timer_interrupt.rs are pristine
- final diff is limited to clone.rs, graphics.rs, and handlers.rs

## Validation
- cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64
- build log had no lines matching ^(warning|error)
- git diff --check
