### PR TITLE
feat(bssh): client exec channel + remote stdout relay

### DIFF
--- a/libs/libbreenix/src/ssh/channel.rs
+++ b/libs/libbreenix/src/ssh/channel.rs
@@ -6,8 +6,9 @@ use super::packet::PacketIo;
 use super::{SshBuf, SshError};
 use super::{
     SSH_MSG_CHANNEL_CLOSE, SSH_MSG_CHANNEL_DATA, SSH_MSG_CHANNEL_EOF, SSH_MSG_CHANNEL_FAILURE,
-    SSH_MSG_CHANNEL_OPEN, SSH_MSG_CHANNEL_OPEN_CONFIRMATION, SSH_MSG_CHANNEL_REQUEST,
-    SSH_MSG_CHANNEL_SUCCESS, SSH_MSG_CHANNEL_WINDOW_ADJUST,
+    SSH_MSG_CHANNEL_OPEN, SSH_MSG_CHANNEL_OPEN_CONFIRMATION, SSH_MSG_CHANNEL_OPEN_FAILURE,
+    SSH_MSG_CHANNEL_REQUEST, SSH_MSG_CHANNEL_SUCCESS, SSH_MSG_CHANNEL_WINDOW_ADJUST, SSH_MSG_DEBUG,
+    SSH_MSG_EXT_INFO, SSH_MSG_GLOBAL_REQUEST, SSH_MSG_IGNORE, SSH_MSG_REQUEST_FAILURE,
 };
 
 /// Default initial window size (1 MB).
@@ -64,14 +65,13 @@ pub fn server_handle_channel_open(
     local_id: u32,
 ) -> Result<Channel, SshError> {
     let mut pos = 1; // skip message type
-    let channel_type = SshBuf::get_string(msg, &mut pos)
-        .ok_or(SshError::Protocol("bad channel type"))?;
-    let sender_channel = SshBuf::get_u32(msg, &mut pos)
-        .ok_or(SshError::Protocol("bad sender channel"))?;
-    let initial_window = SshBuf::get_u32(msg, &mut pos)
-        .ok_or(SshError::Protocol("bad initial window"))?;
-    let max_packet = SshBuf::get_u32(msg, &mut pos)
-        .ok_or(SshError::Protocol("bad max packet"))?;
+    let channel_type =
+        SshBuf::get_string(msg, &mut pos).ok_or(SshError::Protocol("bad channel type"))?;
+    let sender_channel =
+        SshBuf::get_u32(msg, &mut pos).ok_or(SshError::Protocol("bad sender channel"))?;
+    let initial_window =
+        SshBuf::get_u32(msg, &mut pos).ok_or(SshError::Protocol("bad initial window"))?;
+    let max_packet = SshBuf::get_u32(msg, &mut pos).ok_or(SshError::Protocol("bad max packet"))?;
 
     if channel_type != b"session" {
         // Send channel open failure
@@ -109,12 +109,11 @@ pub fn server_handle_channel_request(
     channel: &mut Channel,
 ) -> Result<String, SshError> {
     let mut pos = 1;
-    let _recipient = SshBuf::get_u32(msg, &mut pos)
-        .ok_or(SshError::Protocol("bad channel id in request"))?;
-    let request_type = SshBuf::get_string(msg, &mut pos)
-        .ok_or(SshError::Protocol("bad request type"))?;
-    let want_reply = SshBuf::get_bool(msg, &mut pos)
-        .ok_or(SshError::Protocol("bad want_reply"))?;
+    let _recipient =
+        SshBuf::get_u32(msg, &mut pos).ok_or(SshError::Protocol("bad channel id in request"))?;
+    let request_type =
+        SshBuf::get_string(msg, &mut pos).ok_or(SshError::Protocol("bad request type"))?;
+    let want_reply = SshBuf::get_bool(msg, &mut pos).ok_or(SshError::Protocol("bad want_reply"))?;
 
     let req_name = String::from_utf8_lossy(request_type).into_owned();
 
@@ -253,15 +252,21 @@ pub fn client_open_session(io: &mut PacketIo) -> Result<Channel, SshError> {
     io.send_packet(&msg).map_err(|_| SshError::Io)?;
 
     // Wait for confirmation
-    let reply = io.recv_packet().map_err(|_| SshError::Io)?;
-    if reply.is_empty() || reply[0] != SSH_MSG_CHANNEL_OPEN_CONFIRMATION {
+    let reply = recv_client_control_packet(io)?;
+    if reply.is_empty() {
+        return Err(SshError::Protocol("empty channel open response"));
+    }
+    if reply[0] == SSH_MSG_CHANNEL_OPEN_FAILURE {
+        return Err(SshError::Protocol("channel open rejected"));
+    }
+    if reply[0] != SSH_MSG_CHANNEL_OPEN_CONFIRMATION {
         return Err(SshError::Protocol("channel open failed"));
     }
 
     let mut pos = 1;
     let _recipient = SshBuf::get_u32(&reply, &mut pos);
-    let sender = SshBuf::get_u32(&reply, &mut pos)
-        .ok_or(SshError::Protocol("bad channel confirmation"))?;
+    let sender =
+        SshBuf::get_u32(&reply, &mut pos).ok_or(SshError::Protocol("bad channel confirmation"))?;
     let initial_window = SshBuf::get_u32(&reply, &mut pos).unwrap_or(INITIAL_WINDOW_SIZE);
     let max_packet = SshBuf::get_u32(&reply, &mut pos).unwrap_or(MAX_PACKET_SIZE);
 
@@ -289,7 +294,7 @@ pub fn client_request_pty(
     SshBuf::put_string(&mut msg, &[]); // terminal modes (empty)
     io.send_packet(&msg).map_err(|_| SshError::Io)?;
 
-    let reply = io.recv_packet().map_err(|_| SshError::Io)?;
+    let reply = recv_client_control_packet(io)?;
     if reply.is_empty() || reply[0] != SSH_MSG_CHANNEL_SUCCESS {
         return Err(SshError::Protocol("pty request failed"));
     }
@@ -306,9 +311,65 @@ pub fn client_request_shell(io: &mut PacketIo, channel: &Channel) -> Result<(), 
     SshBuf::put_bool(&mut msg, true); // want reply
     io.send_packet(&msg).map_err(|_| SshError::Io)?;
 
-    let reply = io.recv_packet().map_err(|_| SshError::Io)?;
+    let reply = recv_client_control_packet(io)?;
     if reply.is_empty() || reply[0] != SSH_MSG_CHANNEL_SUCCESS {
         return Err(SshError::Protocol("shell request failed"));
+    }
+
+    Ok(())
+}
+
+/// Request execution of a command (client side).
+pub fn client_request_exec(
+    io: &mut PacketIo,
+    channel: &Channel,
+    command: &str,
+) -> Result<(), SshError> {
+    let mut msg = Vec::with_capacity(24 + command.len());
+    msg.push(SSH_MSG_CHANNEL_REQUEST);
+    SshBuf::put_u32(&mut msg, channel.remote_id);
+    SshBuf::put_string(&mut msg, b"exec");
+    SshBuf::put_bool(&mut msg, true); // want reply
+    SshBuf::put_string(&mut msg, command.as_bytes());
+    io.send_packet(&msg).map_err(|_| SshError::Io)?;
+
+    let reply = recv_client_control_packet(io)?;
+    if reply.is_empty() || reply[0] != SSH_MSG_CHANNEL_SUCCESS {
+        return Err(SshError::Protocol("exec request failed"));
+    }
+
+    Ok(())
+}
+
+fn recv_client_control_packet(io: &mut PacketIo) -> Result<Vec<u8>, SshError> {
+    loop {
+        let msg = io.recv_packet().map_err(|_| SshError::Io)?;
+        if msg.is_empty() {
+            return Ok(msg);
+        }
+
+        match msg[0] {
+            SSH_MSG_IGNORE | SSH_MSG_DEBUG | SSH_MSG_EXT_INFO => continue,
+            SSH_MSG_CHANNEL_WINDOW_ADJUST => continue,
+            SSH_MSG_GLOBAL_REQUEST => {
+                handle_client_global_request(io, &msg)?;
+                continue;
+            }
+            _ => return Ok(msg),
+        }
+    }
+}
+
+fn handle_client_global_request(io: &mut PacketIo, msg: &[u8]) -> Result<(), SshError> {
+    let mut pos = 1;
+    let _request_name =
+        SshBuf::get_string(msg, &mut pos).ok_or(SshError::Protocol("bad global request name"))?;
+    let want_reply = SshBuf::get_bool(msg, &mut pos)
+        .ok_or(SshError::Protocol("bad global request want_reply"))?;
+
+    if want_reply {
+        io.send_packet(&[SSH_MSG_REQUEST_FAILURE])
+            .map_err(|_| SshError::Io)?;
     }
 
     Ok(())

--- a/libs/libbreenix/src/ssh/transport.rs
+++ b/libs/libbreenix/src/ssh/transport.rs
@@ -16,8 +16,8 @@ use super::packet::PacketIo;
 use super::{SshBuf, SshError, BSSH_VERSION};
 use super::{
     SSH_MSG_CHANNEL_CLOSE, SSH_MSG_CHANNEL_DATA, SSH_MSG_CHANNEL_EOF, SSH_MSG_CHANNEL_OPEN,
-    SSH_MSG_CHANNEL_REQUEST, SSH_MSG_CHANNEL_WINDOW_ADJUST, SSH_MSG_DISCONNECT,
-    SSH_MSG_GLOBAL_REQUEST, SSH_MSG_IGNORE, SSH_MSG_KEXINIT, SSH_MSG_NEWKEYS,
+    SSH_MSG_CHANNEL_REQUEST, SSH_MSG_CHANNEL_SUCCESS, SSH_MSG_CHANNEL_WINDOW_ADJUST,
+    SSH_MSG_DISCONNECT, SSH_MSG_GLOBAL_REQUEST, SSH_MSG_IGNORE, SSH_MSG_KEXINIT, SSH_MSG_NEWKEYS,
     SSH_MSG_UNIMPLEMENTED,
 };
 
@@ -342,6 +342,7 @@ pub struct ClientSession {
     kex: KexState,
     server_version: String,
     channel: Option<Channel>,
+    exit_status: Option<i32>,
 }
 
 /// Authentication method for SSH client handshakes.
@@ -358,6 +359,7 @@ impl ClientSession {
             kex: KexState::new(),
             server_version: String::new(),
             channel: None,
+            exit_status: None,
         }
     }
 
@@ -447,6 +449,17 @@ impl ClientSession {
         Ok(())
     }
 
+    /// Open a session channel and execute a command.
+    pub fn open_exec(&mut self, command: &str) -> Result<(), SshError> {
+        let ch = channel::client_open_session(&mut self.io)?;
+        self.channel = Some(ch);
+
+        let ch = self.channel.as_ref().unwrap();
+        channel::client_request_exec(&mut self.io, ch, command)?;
+
+        Ok(())
+    }
+
     /// Send data on the channel.
     pub fn send_data(&mut self, data: &[u8]) -> Result<(), SshError> {
         if let Some(ref mut ch) = self.channel {
@@ -488,11 +501,46 @@ impl ClientSession {
                 }
                 Ok(None)
             }
-            SSH_MSG_CHANNEL_EOF | SSH_MSG_CHANNEL_CLOSE => Err(SshError::Disconnected),
+            SSH_MSG_CHANNEL_EOF => {
+                if let Some(ref mut ch) = self.channel {
+                    ch.eof_received = true;
+                }
+                Ok(None)
+            }
+            SSH_MSG_CHANNEL_CLOSE => Err(SshError::Disconnected),
             SSH_MSG_DISCONNECT => Err(SshError::Disconnected),
             SSH_MSG_IGNORE | SSH_MSG_UNIMPLEMENTED => Ok(None),
+            SSH_MSG_CHANNEL_REQUEST => {
+                let mut pos = 1;
+                let _recipient = SshBuf::get_u32(&msg, &mut pos);
+                let request_type = SshBuf::get_string(&msg, &mut pos)
+                    .ok_or(SshError::Protocol("bad channel request type"))?;
+                let want_reply = SshBuf::get_bool(&msg, &mut pos)
+                    .ok_or(SshError::Protocol("bad channel request want_reply"))?;
+
+                if request_type == b"exit-status" {
+                    let status = SshBuf::get_u32(&msg, &mut pos)
+                        .ok_or(SshError::Protocol("bad exit-status"))?;
+                    self.exit_status = Some(status as i32);
+                }
+
+                if want_reply {
+                    if let Some(ref ch) = self.channel {
+                        let mut reply = Vec::with_capacity(5);
+                        reply.push(SSH_MSG_CHANNEL_SUCCESS);
+                        SshBuf::put_u32(&mut reply, ch.remote_id);
+                        self.io.send_packet(&reply).map_err(|_| SshError::Io)?;
+                    }
+                }
+                Ok(None)
+            }
             _ => Ok(None),
         }
+    }
+
+    /// Last exit status reported by the remote exec channel.
+    pub fn exit_status(&self) -> Option<i32> {
+        self.exit_status
     }
 
     /// Close the session.

--- a/scripts/create_ext2_disk.sh
+++ b/scripts/create_ext2_disk.sh
@@ -88,6 +88,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
         -v "$PROJECT_ROOT/fonts:/fonts:ro" \
         -e "OUTPUT_FILENAME=$OUTPUT_FILENAME" \
         -e "BREENIX_WAIT_STRESS=${BREENIX_WAIT_STRESS:-0}" \
+        -e "BREENIX_BSSH_AUTORUN=${BREENIX_BSSH_AUTORUN:-0}" \
         alpine:latest \
         sh -c '
             set -e
@@ -220,6 +221,10 @@ BSHRC
             if [ "${BREENIX_WAIT_STRESS:-0}" = "1" ]; then
                 touch /mnt/ext2/etc/wait_stress.enabled
                 echo "  Enabled wait_stress init gate"
+            fi
+            if [ "${BREENIX_BSSH_AUTORUN:-0}" = "1" ]; then
+                touch /mnt/ext2/etc/bssh_autorun.enabled
+                echo "  Enabled bssh autorun init gate"
             fi
 
             # Create /home for user data (Gus Kit saves, etc.)
@@ -496,6 +501,10 @@ BSHRC
     if [ "${BREENIX_WAIT_STRESS:-0}" = "1" ]; then
         touch "$MOUNT_DIR/etc/wait_stress.enabled"
         echo "  Enabled wait_stress init gate"
+    fi
+    if [ "${BREENIX_BSSH_AUTORUN:-0}" = "1" ]; then
+        touch "$MOUNT_DIR/etc/bssh_autorun.enabled"
+        echo "  Enabled bssh autorun init gate"
     fi
 
     # Create /home for user data (Gus Kit saves, etc.)

--- a/userspace/programs/src/bssh.rs
+++ b/userspace/programs/src/bssh.rs
@@ -2,7 +2,7 @@
 //!
 //! Connects to a remote SSH server and opens an interactive shell session.
 //!
-//! Usage: bssh <host> [port] [username] [password|--publickey|--publickey-wrong] [--smoke]
+//! Usage: bssh <host> [port] [username] [password|--publickey|--publickey-wrong] [--smoke] [--exec command]
 //!   Default port: 22
 //!   Default username: root
 //!   Default password: (prompted)
@@ -26,19 +26,18 @@ fn main() {
     }
 
     let host = &args[1];
-    let port: u16 = args
-        .get(2)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(22);
-    let username = args
-        .get(3)
-        .map(|s| s.as_str())
-        .unwrap_or("root");
-    let auth_arg = args
-        .get(4)
-        .map(|s| s.as_str())
-        .unwrap_or("breenix");
+    let port: u16 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(22);
+    let username = args.get(3).map(|s| s.as_str()).unwrap_or("root");
+    let auth_arg = args.get(4).map(|s| s.as_str()).unwrap_or("breenix");
     let smoke = args.iter().any(|arg| arg == "--smoke");
+    let exec_command = args.iter().position(|arg| arg == "--exec").and_then(|idx| {
+        let parts = args.get(idx + 1..)?;
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join(" "))
+        }
+    });
     let auth_choice = match auth_arg {
         "--publickey" | "publickey" => AuthChoice::PublicKey { wrong_key: false },
         "--publickey-wrong" | "publickey-wrong" => AuthChoice::PublicKey { wrong_key: true },
@@ -60,8 +59,10 @@ fn main() {
         }
     };
 
-    println!("bssh: connecting to {}.{}.{}.{}:{}",
-        addr_bytes[0], addr_bytes[1], addr_bytes[2], addr_bytes[3], port);
+    println!(
+        "bssh: connecting to {}.{}.{}.{}:{}",
+        addr_bytes[0], addr_bytes[1], addr_bytes[2], addr_bytes[3], port
+    );
 
     // Connect
     let addr = SockAddrIn::new(addr_bytes, port);
@@ -90,6 +91,19 @@ fn main() {
         std::process::exit(1);
     }
     println!("bssh: authenticated as '{}'", username);
+
+    if let Some(command) = exec_command {
+        if let Err(e) = session.open_exec(&command) {
+            eprintln!("bssh: exec request failed: {:?}", e);
+            std::process::exit(1);
+        }
+
+        println!("BSSH_EXEC_BEGIN host={} command={}", host, command);
+        let rc = drain_exec_output(&mut session);
+        println!("BSSH_EXEC_END host={} rc={}", host, rc);
+        session.close();
+        std::process::exit(rc);
+    }
 
     // Open channel + PTY + shell
     if let Err(e) = session.open_shell() {
@@ -181,6 +195,50 @@ fn main() {
     }
 
     session.close();
+}
+
+fn drain_exec_output(session: &mut ClientSession) -> i32 {
+    let stdout_fd = Fd::from_raw(1);
+    let ssh_fd = session.io().fd();
+    let mut idle_ticks = 0u32;
+
+    loop {
+        let mut fds = [io::PollFd::new(ssh_fd, io::poll_events::POLLIN)];
+        match io::poll(&mut fds, 100) {
+            Ok(0) => {
+                idle_ticks += 1;
+                if idle_ticks >= 300 {
+                    eprintln!("bssh: exec timed out waiting for remote output/close");
+                    return 124;
+                }
+                continue;
+            }
+            Ok(_) => {
+                idle_ticks = 0;
+            }
+            Err(_) => return 1,
+        }
+
+        if fds[0].revents & io::poll_events::POLLIN != 0 {
+            match session.recv_data() {
+                Ok(Some(data)) => {
+                    let _ = io::write(stdout_fd, &data);
+                }
+                Ok(None) => {}
+                Err(libbreenix::ssh::SshError::Disconnected) => {
+                    return session.exit_status().unwrap_or(0);
+                }
+                Err(e) => {
+                    eprintln!("bssh: exec receive failed: {:?}", e);
+                    return 1;
+                }
+            }
+        }
+
+        if fds[0].revents & io::poll_events::POLLHUP != 0 {
+            return session.exit_status().unwrap_or(0);
+        }
+    }
 }
 
 /// Parse an IPv4 address string into 4 bytes.

--- a/userspace/programs/src/init.rs
+++ b/userspace/programs/src/init.rs
@@ -19,6 +19,8 @@ fn main() {
     start_bsshd();
     #[cfg(target_arch = "aarch64")]
     start_bounce();
+    #[cfg(target_arch = "aarch64")]
+    run_bssh_autorun_if_enabled();
 
     // Reap zombies forever
     let mut status: i32 = 0;
@@ -69,6 +71,69 @@ fn run_wait_stress_if_enabled() {
         }
         Err(e) => {
             print!("[init] Warning: failed to start wait_stress: {}\n", e);
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn run_bssh_autorun_if_enabled() {
+    let build_enabled = option_env!("BREENIX_BSSH_AUTORUN") == Some("1");
+    if !build_enabled || fs::access("/etc/bssh_autorun.enabled", fs::F_OK).is_err() {
+        return;
+    }
+
+    print!("[init] bssh autorun enabled by build environment and /etc gate\n");
+
+    let ts = libbreenix::types::Timespec {
+        tv_sec: 15,
+        tv_nsec: 0,
+    };
+    let _ = libbreenix::time::nanosleep(&ts);
+
+    run_bssh_exec_autorun("10.0.1.210");
+    run_bssh_exec_autorun("10.211.55.2");
+}
+
+#[cfg(target_arch = "aarch64")]
+fn run_bssh_exec_autorun(host: &str) {
+    let path = b"/bin/bssh\0";
+    let arg0 = b"bssh\0";
+    let port = b"22\0";
+    let user = b"wrb\0";
+    let auth = b"--publickey\0";
+    let exec = b"--exec\0";
+    let command = b"uname\0";
+
+    let mut host_buf = [0u8; 32];
+    let host_bytes = host.as_bytes();
+    if host_bytes.len() + 1 > host_buf.len() {
+        print!("[init] bssh autorun host too long: {}\n", host);
+        return;
+    }
+    host_buf[..host_bytes.len()].copy_from_slice(host_bytes);
+
+    let argv = [
+        arg0.as_ptr(),
+        host_buf.as_ptr(),
+        port.as_ptr(),
+        user.as_ptr(),
+        auth.as_ptr(),
+        exec.as_ptr(),
+        command.as_ptr(),
+        core::ptr::null(),
+    ];
+
+    print!("[init] bssh autorun starting host={}\n", host);
+    match spawnv(path, argv.as_ptr()) {
+        Ok(child_pid) => {
+            print!(
+                "[init] bssh autorun spawned host={} pid={}\n",
+                host,
+                child_pid.raw()
+            );
+        }
+        Err(e) => {
+            print!("[init] Warning: failed to start bssh autorun: {}\n", e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add client-side SSH exec channel support for `bssh <host> [port] <user> --publickey --exec <cmd>`.
- Relay remote stdout from `CHANNEL_DATA` and return the remote `exit-status`.
- Keep the serial autorun proof hook gated off by default: it requires both `BREENIX_BSSH_AUTORUN=1` at build time and `/etc/bssh_autorun.enabled` in the disk image.

## Proof
Cold Parallels serial autorun proved the operator target `10.0.1.210` returns real remote stdout:

```text
bssh: authenticated as 'wrb'
BSSH_EXEC_BEGIN host=10.0.1.210 command=uname
Darwin
BSSH_EXEC_END host=10.0.1.210 rc=0
[init] Process 8 exited (code 0)
```

Artifact: `/Users/wrb/Downloads/Ralph/breenix-interrupt-io-roadmap-1780056222/turn84-artifacts/serial-autorun/parallels-serial-autorun-independent.serial.log` lines 527-532.

## Validation
- `env -u BREENIX_BSSH_AUTORUN userspace/programs/build.sh --arch aarch64` exited `0`.
- Warning/error grep artifact is empty: `/Users/wrb/Downloads/Ralph/breenix-interrupt-io-roadmap-1780056222/turn85-artifacts/normal-userspace-build-warning-error-grep.txt`.
- `git diff --cached --check` passed before commit.

## Known follow-ups
- `10.211.55.2` cold same-subnet direct-ARP resolution stall remains a separate Breenix net-stack follow-up, not a bssh channel blocker.
- A late `!!! SOFT LOCKUP DETECTED !!!` dump was observed after the accepted `10.0.1.210` proof in `parallels-serial-autorun-independent.serial.log`; treat as observed-but-unrelated and investigate separately.
