### PR TITLE
feat(bsshd): support publickey exec sessions

### DIFF
--- a/libs/libbreenix/src/ssh/channel.rs
+++ b/libs/libbreenix/src/ssh/channel.rs
@@ -37,6 +37,8 @@ pub struct Channel {
     pub pty_term: Option<String>,
     /// PTY dimensions (cols, rows).
     pub pty_size: (u32, u32),
+    /// Command from an SSH "exec" request, if this is a non-interactive session.
+    pub exec_command: Option<String>,
 }
 
 impl Channel {
@@ -52,6 +54,7 @@ impl Channel {
             closed: false,
             pty_term: None,
             pty_size: (80, 24),
+            exec_command: None,
         }
     }
 }
@@ -130,7 +133,15 @@ pub fn server_handle_channel_request(
                 send_channel_success(io, channel)?;
             }
         }
-        b"shell" | b"exec" => {
+        b"shell" => {
+            if want_reply {
+                send_channel_success(io, channel)?;
+            }
+        }
+        b"exec" => {
+            let command =
+                SshBuf::get_string(msg, &mut pos).ok_or(SshError::Protocol("bad exec command"))?;
+            channel.exec_command = Some(String::from_utf8_lossy(command).into_owned());
             if want_reply {
                 send_channel_success(io, channel)?;
             }

--- a/libs/libbreenix/src/ssh/transport.rs
+++ b/libs/libbreenix/src/ssh/transport.rs
@@ -257,6 +257,28 @@ impl ServerSession {
         }
     }
 
+    /// Take the command supplied by an SSH "exec" request, if any.
+    pub fn take_exec_command(&mut self) -> Option<String> {
+        self.channel
+            .as_mut()
+            .and_then(|channel| channel.exec_command.take())
+    }
+
+    /// Report an exec command's exit status to the SSH client.
+    pub fn send_exit_status(&mut self, status: i32) -> Result<(), SshError> {
+        if let Some(ref ch) = self.channel {
+            let mut msg = Vec::with_capacity(24);
+            msg.push(SSH_MSG_CHANNEL_REQUEST);
+            SshBuf::put_u32(&mut msg, ch.remote_id);
+            SshBuf::put_string(&mut msg, b"exit-status");
+            SshBuf::put_bool(&mut msg, false);
+            SshBuf::put_u32(&mut msg, status.max(0) as u32);
+            self.io.send_packet(&msg).map_err(|_| SshError::Io)
+        } else {
+            Err(SshError::ChannelNotFound)
+        }
+    }
+
     /// Receive a message from the client.
     ///
     /// Returns Some(data) for channel data, None for non-data messages

--- a/userspace/programs/src/bsshd.rs
+++ b/userspace/programs/src/bsshd.rs
@@ -6,6 +6,7 @@
 //! Usage: bsshd [port]
 //!   Default port: 2222
 
+use libbreenix::fs;
 use libbreenix::io;
 use libbreenix::process;
 use libbreenix::pty;
@@ -108,6 +109,13 @@ fn handle_connection(fd: Fd) {
         }
     };
 
+    if let Some(command) = session.take_exec_command() {
+        let status = run_exec_command(&mut session, &command);
+        let _ = session.send_exit_status(status);
+        session.close();
+        return;
+    }
+
     // Allocate PTY if requested
     let (master_fd, slave_path) = if pty_requested {
         match pty::openpty() {
@@ -142,10 +150,7 @@ fn handle_connection(fd: Fd) {
                 // Open the slave PTY
                 let path_bytes = pty::slave_path_bytes(&slave_path);
                 let path_str = core::str::from_utf8(path_bytes).unwrap_or("/dev/pts/0");
-                let slave_fd = match libbreenix::fs::open(
-                    path_str,
-                    libbreenix::fs::O_RDWR,
-                ) {
+                let slave_fd = match libbreenix::fs::open(path_str, libbreenix::fs::O_RDWR) {
                     Ok(fd) => fd,
                     Err(_) => process::exit(1),
                 };
@@ -153,8 +158,8 @@ fn handle_connection(fd: Fd) {
                 // Set PTY to translate \n → \r\n (ONLCR) for SSH terminals
                 let mut tio: libbreenix::termios::Termios = unsafe { core::mem::zeroed() };
                 let _ = libbreenix::termios::tcgetattr(slave_fd, &mut tio);
-                tio.c_oflag |= libbreenix::termios::oflag::OPOST
-                    | libbreenix::termios::oflag::ONLCR;
+                tio.c_oflag |=
+                    libbreenix::termios::oflag::OPOST | libbreenix::termios::oflag::ONLCR;
                 tio.c_iflag |= libbreenix::termios::iflag::ICRNL;
                 let _ = libbreenix::termios::tcsetattr(slave_fd, 0, &tio);
 
@@ -178,7 +183,11 @@ fn handle_connection(fd: Fd) {
         }
         Ok(process::ForkResult::Parent(child_pid)) => {
             // Parent: shuttle data between SSH channel and PTY master
-            println!("bsshd: shell started (pid {}) for user '{}'", child_pid.raw(), username);
+            println!(
+                "bsshd: shell started (pid {}) for user '{}'",
+                child_pid.raw(),
+                username
+            );
             data_shuttle(&mut session, master_fd);
             println!("bsshd: session ended for user '{}'", username);
 
@@ -193,6 +202,127 @@ fn handle_connection(fd: Fd) {
     }
 
     session.close();
+}
+
+fn run_exec_command(session: &mut ServerSession, command: &str) -> i32 {
+    println!("bsshd: exec request '{}'", command);
+
+    let mut last_status = 0;
+    for part in command.split("&&") {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+
+        last_status = run_single_exec_command(session, part);
+        if last_status != 0 {
+            break;
+        }
+    }
+
+    last_status
+}
+
+fn run_single_exec_command(session: &mut ServerSession, command: &str) -> i32 {
+    let args: Vec<&str> = command.split_whitespace().collect();
+    if args.is_empty() {
+        return 0;
+    }
+
+    let Some(path) = resolve_exec_path(args[0]) else {
+        let msg = format!("{}: command not found\n", args[0]);
+        let _ = session.send_data(msg.as_bytes());
+        return 127;
+    };
+
+    let (read_fd, write_fd) = match io::pipe() {
+        Ok(pipe) => pipe,
+        Err(e) => {
+            let msg = format!("bsshd: pipe failed: {:?}\n", e);
+            let _ = session.send_data(msg.as_bytes());
+            return 1;
+        }
+    };
+
+    match process::fork() {
+        Ok(process::ForkResult::Child) => {
+            let _ = io::close(read_fd);
+            let _ = io::dup2(write_fd, Fd::from_raw(1));
+            let _ = io::dup2(write_fd, Fd::from_raw(2));
+            if write_fd.raw() > 2 {
+                let _ = io::close(write_fd);
+            }
+
+            let path_c = c_string(&path);
+            let arg_storage: Vec<Vec<u8>> = args.iter().map(|arg| c_string(arg)).collect();
+            let mut argv: Vec<*const u8> = arg_storage.iter().map(|arg| arg.as_ptr()).collect();
+            argv.push(core::ptr::null());
+            let _ = process::execv(&path_c, argv.as_ptr());
+            process::exit(127);
+        }
+        Ok(process::ForkResult::Parent(child_pid)) => {
+            let _ = io::close(write_fd);
+            let mut buf = [0u8; 4096];
+            loop {
+                match io::read(read_fd, &mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if session.send_data(&buf[..n]).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            let _ = io::close(read_fd);
+
+            let mut status = 0i32;
+            match process::waitpid(child_pid.raw() as i32, &mut status as *mut i32, 0) {
+                Ok(_) if process::wifexited(status) => process::wexitstatus(status),
+                Ok(_) if process::wifsignaled(status) => 128 + process::wtermsig(status),
+                Ok(_) => 1,
+                Err(_) => 1,
+            }
+        }
+        Err(e) => {
+            let _ = io::close(read_fd);
+            let _ = io::close(write_fd);
+            let msg = format!("bsshd: fork failed: {:?}\n", e);
+            let _ = session.send_data(msg.as_bytes());
+            1
+        }
+    }
+}
+
+fn resolve_exec_path(command: &str) -> Option<String> {
+    if command.contains('/') {
+        return executable_path(command);
+    }
+
+    let candidates = [
+        format!("/bin/{}", command),
+        format!("/sbin/{}", command),
+        format!("/usr/local/cbin/{}", command),
+        format!("/usr/local/cbin/{}_musl_test", command),
+    ];
+
+    candidates
+        .iter()
+        .find_map(|candidate| executable_path(candidate))
+}
+
+fn executable_path(path: &str) -> Option<String> {
+    fs::access(path, fs::X_OK).ok().map(|_| path.to_string())
+}
+
+fn c_string(value: &str) -> Vec<u8> {
+    let mut bytes: Vec<u8> = value
+        .as_bytes()
+        .iter()
+        .map(|byte| if *byte == 0 { b'?' } else { *byte })
+        .collect();
+    bytes.push(0);
+    bytes
 }
 
 /// Shuttle data between the SSH channel and the PTY master fd.


### PR DESCRIPTION
## Summary
- records SSH exec requests in the server channel state
- runs non-interactive bsshd exec commands with stdout/stderr relayed over the SSH channel
- sends SSH exit-status before closing the channel

## Validation
- cargo check --manifest-path libs/libbreenix/Cargo.toml --features std
- userspace/programs/build.sh --arch aarch64
- cargo build --release --features testing,external_test_bins --bin qemu-uefi (warning scan empty)
- macOS OpenSSH publickey-only proof with StrictHostKeyChecking=yes and UserKnownHostsFile=turn92-artifacts/known_hosts:
  - Authenticated using /Users/wrb/.ssh/id_rsa publickey
  - exec request accepted
  - stdout included BREEMARK and Breenix uname output
  - SSH exit status 0

Artifacts: /Users/wrb/Downloads/Ralph/breenix-interrupt-io-roadmap-1780056222/turn92-artifacts