### PR TITLE
feat(bssh): verify known host keys

### DIFF
--- a/libs/libbreenix/src/ssh/kex.rs
+++ b/libs/libbreenix/src/ssh/kex.rs
@@ -10,7 +10,7 @@ use crate::crypto::sha256::sha256;
 use crate::crypto::x25519::{x25519, x25519_basepoint};
 
 use super::cipher::SshCipher;
-use super::keys::HostKey;
+use super::keys::{HostKey, ServerHostKeyInfo};
 use super::packet::PacketIo;
 use super::SshBuf;
 use super::*;
@@ -259,7 +259,7 @@ pub fn client_kex_ecdh(
     kex: &mut KexState,
     client_version: &str,
     server_version: &str,
-) -> Result<(Vec<u8>, Vec<u8>, Vec<u8>), SshError> {
+) -> Result<(Vec<u8>, Vec<u8>, ServerHostKeyInfo), SshError> {
     // Generate client's ephemeral key pair
     let mut rng = Csprng::new();
     let mut client_secret = [0u8; 32];
@@ -322,7 +322,10 @@ pub fn client_kex_ecdh(
         return Err(SshError::Protocol("host key signature verification failed"));
     }
 
-    Ok((h, shared_secret.to_vec(), host_key_blob))
+    let host_key = ServerHostKeyInfo::from_parts(host_key_blob, signature)
+        .ok_or(SshError::Protocol("bad server host key identity"))?;
+
+    Ok((h, shared_secret.to_vec(), host_key))
 }
 
 /// Compute the exchange hash H per RFC 8731.

--- a/libs/libbreenix/src/ssh/keys.rs
+++ b/libs/libbreenix/src/ssh/keys.rs
@@ -7,7 +7,10 @@
 //! - Host key fingerprint for client-side known_hosts verification
 
 use crate::crypto::bignum::BigNum;
-use crate::crypto::rsa::{rsa_sign_pkcs1_sha256, rsa_verify_pkcs1_sha256, rsa_verify_pkcs1_sha512, RsaPrivateKey, RsaPublicKey};
+use crate::crypto::rsa::{
+    rsa_sign_pkcs1_sha256, rsa_verify_pkcs1_sha256, rsa_verify_pkcs1_sha512, RsaPrivateKey,
+    RsaPublicKey,
+};
 use crate::crypto::sha256::sha256;
 use crate::crypto::sha512::sha512;
 
@@ -168,6 +171,48 @@ impl HostKey {
     }
 }
 
+/// Server host-key identity observed during client key exchange.
+#[derive(Debug, Clone)]
+pub struct ServerHostKeyInfo {
+    /// Raw SSH public-key blob from KEX_ECDH_REPLY.
+    pub key_blob: Vec<u8>,
+    /// Key type stored inside the key blob, e.g. "ssh-rsa".
+    pub key_type: String,
+    /// Signature/host-key algorithm used in KEX, e.g. "rsa-sha2-256".
+    pub algorithm: String,
+    /// SHA-256 fingerprint of `key_blob`.
+    pub fingerprint: [u8; 32],
+}
+
+impl ServerHostKeyInfo {
+    pub fn from_parts(key_blob: Vec<u8>, signature_blob: &[u8]) -> Option<Self> {
+        let key_type = key_type_from_blob(&key_blob)?;
+        let algorithm = signature_algorithm(signature_blob)?;
+        let fingerprint = sha256(&key_blob);
+
+        Some(Self {
+            key_blob,
+            key_type,
+            algorithm,
+            fingerprint,
+        })
+    }
+}
+
+/// Parse the key type string from an SSH public-key blob.
+pub fn key_type_from_blob(blob: &[u8]) -> Option<String> {
+    let mut pos = 0;
+    let key_type = SshBuf::get_string(blob, &mut pos)?;
+    Some(String::from_utf8_lossy(key_type).into_owned())
+}
+
+/// Parse the algorithm string from an SSH signature blob.
+pub fn signature_algorithm(signature_blob: &[u8]) -> Option<String> {
+    let mut pos = 0;
+    let algorithm = SshBuf::get_string(signature_blob, &mut pos)?;
+    Some(String::from_utf8_lossy(algorithm).into_owned())
+}
+
 // ==========================================================================
 // Authorized key operations
 // ==========================================================================
@@ -237,11 +282,7 @@ pub fn parse_rsa_pubkey_blob(blob: &[u8]) -> Option<RsaPublicKey> {
 ///
 /// The signature is in SSH wire format: string algorithm || string sig_blob
 /// The data is hashed with SHA-256 before PKCS#1 v1.5 verification.
-pub fn verify_rsa_signature(
-    pubkey_blob: &[u8],
-    signature_blob: &[u8],
-    data: &[u8],
-) -> bool {
+pub fn verify_rsa_signature(pubkey_blob: &[u8], signature_blob: &[u8], data: &[u8]) -> bool {
     // Parse the public key
     let pubkey = match parse_rsa_pubkey_blob(pubkey_blob) {
         Some(k) => k,

--- a/libs/libbreenix/src/ssh/transport.rs
+++ b/libs/libbreenix/src/ssh/transport.rs
@@ -11,7 +11,7 @@ use crate::types::Fd;
 use super::auth;
 use super::channel::{self, Channel};
 use super::kex::{self, KexState};
-use super::keys::HostKey;
+use super::keys::{HostKey, ServerHostKeyInfo};
 use super::packet::PacketIo;
 use super::{SshBuf, SshError, BSSH_VERSION};
 use super::{
@@ -396,6 +396,19 @@ impl ClientSession {
         username: &str,
         auth_method: ClientAuthMethod<'_>,
     ) -> Result<(), SshError> {
+        self.handshake_with_auth_and_host_key(username, auth_method, |_| Ok(()))
+    }
+
+    /// Perform the full SSH handshake with caller-supplied host-key verification.
+    pub fn handshake_with_auth_and_host_key<F>(
+        &mut self,
+        username: &str,
+        auth_method: ClientAuthMethod<'_>,
+        verify_host_key: F,
+    ) -> Result<(), SshError>
+    where
+        F: FnOnce(&ServerHostKeyInfo) -> Result<(), SshError>,
+    {
         // 1. Version exchange
         self.io.write_line(BSSH_VERSION).map_err(|_| SshError::Io)?;
         self.server_version = self.io.read_line().map_err(|_| SshError::Io)?;
@@ -418,12 +431,13 @@ impl ClientSession {
         self.kex.peer_kexinit = peer_kexinit;
 
         // Perform client-side DH
-        let (exchange_hash, shared_secret, _host_key_blob) = kex::client_kex_ecdh(
+        let (exchange_hash, shared_secret, host_key) = kex::client_kex_ecdh(
             &mut self.io,
             &mut self.kex,
             BSSH_VERSION,
             &self.server_version,
         )?;
+        verify_host_key(&host_key)?;
 
         // Receive server's NEWKEYS
         let newkeys = self.io.recv_packet().map_err(|_| SshError::Io)?;

--- a/userspace/programs/src/bssh.rs
+++ b/userspace/programs/src/bssh.rs
@@ -7,52 +7,52 @@
 //!   Default username: root
 //!   Default password: (prompted)
 
+use libbreenix::fs;
 use libbreenix::io;
 use libbreenix::socket::{SockAddrIn, TcpStream};
+use libbreenix::ssh::keys::ServerHostKeyInfo;
 use libbreenix::ssh::transport::{ClientAuthMethod, ClientSession};
 use libbreenix::termios;
 use libbreenix::types::Fd;
 
-enum AuthChoice<'a> {
-    Password(&'a str),
+const DEFAULT_KNOWN_HOSTS: &str = "/tmp/bssh_known_hosts";
+
+enum AuthChoice {
+    Password(String),
     PublicKey { wrong_key: bool },
+}
+
+struct Options {
+    host: String,
+    port: u16,
+    username: String,
+    auth_choice: AuthChoice,
+    smoke: bool,
+    exec_command: Option<String>,
+    known_hosts_path: String,
+    host_key_alias: Option<String>,
 }
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: bssh <host> [port] [username] [password|--publickey|--publickey-wrong] [--smoke]");
-        std::process::exit(1);
-    }
-
-    let host = &args[1];
-    let port: u16 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(22);
-    let username = args.get(3).map(|s| s.as_str()).unwrap_or("root");
-    let auth_arg = args.get(4).map(|s| s.as_str()).unwrap_or("breenix");
-    let smoke = args.iter().any(|arg| arg == "--smoke");
-    let exec_command = args.iter().position(|arg| arg == "--exec").and_then(|idx| {
-        let parts = args.get(idx + 1..)?;
-        if parts.is_empty() {
-            None
-        } else {
-            Some(parts.join(" "))
+    let opts = match parse_options(&args) {
+        Ok(opts) => opts,
+        Err(message) => {
+            eprintln!("{}", message);
+            usage();
+            std::process::exit(1);
         }
-    });
-    let auth_choice = match auth_arg {
-        "--publickey" | "publickey" => AuthChoice::PublicKey { wrong_key: false },
-        "--publickey-wrong" | "publickey-wrong" => AuthChoice::PublicKey { wrong_key: true },
-        password => AuthChoice::Password(password),
     };
 
     // Parse host as IPv4 address
-    let addr_bytes = match parse_ipv4(host) {
+    let addr_bytes = match parse_ipv4(&opts.host) {
         Some(b) => b,
         None => {
             // Try DNS resolution
-            match libbreenix::dns::resolve_auto(host) {
+            match libbreenix::dns::resolve_auto(&opts.host) {
                 Ok(result) => result.addr,
                 Err(e) => {
-                    eprintln!("bssh: cannot resolve '{}': {:?}", host, e);
+                    eprintln!("bssh: cannot resolve '{}': {:?}", opts.host, e);
                     std::process::exit(1);
                 }
             }
@@ -61,11 +61,11 @@ fn main() {
 
     println!(
         "bssh: connecting to {}.{}.{}.{}:{}",
-        addr_bytes[0], addr_bytes[1], addr_bytes[2], addr_bytes[3], port
+        addr_bytes[0], addr_bytes[1], addr_bytes[2], addr_bytes[3], opts.port
     );
 
     // Connect
-    let addr = SockAddrIn::new(addr_bytes, port);
+    let addr = SockAddrIn::new(addr_bytes, opts.port);
     let stream = match TcpStream::connect(&addr) {
         Ok(s) => s,
         Err(e) => {
@@ -76,13 +76,20 @@ fn main() {
 
     let fd = stream.into_raw_fd();
     let mut session = ClientSession::new(fd);
+    let known_host_id = known_host_id(&opts.host, opts.port, opts.host_key_alias.as_deref());
 
     // SSH handshake + auth
-    let auth_method = match auth_choice {
+    let auth_method = match &opts.auth_choice {
         AuthChoice::Password(password) => ClientAuthMethod::Password(password),
-        AuthChoice::PublicKey { wrong_key } => ClientAuthMethod::PublicKey { wrong_key },
+        AuthChoice::PublicKey { wrong_key } => ClientAuthMethod::PublicKey {
+            wrong_key: *wrong_key,
+        },
     };
-    if let Err(e) = session.handshake_with_auth(username, auth_method) {
+    if let Err(e) =
+        session.handshake_with_auth_and_host_key(&opts.username, auth_method, |host_key| {
+            verify_or_pin_known_host(&opts.known_hosts_path, &known_host_id, host_key)
+        })
+    {
         if matches!(e, libbreenix::ssh::SshError::Auth) {
             eprintln!("bssh: authentication failed");
         } else {
@@ -90,17 +97,17 @@ fn main() {
         }
         std::process::exit(1);
     }
-    println!("bssh: authenticated as '{}'", username);
+    println!("bssh: authenticated as '{}'", opts.username);
 
-    if let Some(command) = exec_command {
+    if let Some(command) = opts.exec_command {
         if let Err(e) = session.open_exec(&command) {
             eprintln!("bssh: exec request failed: {:?}", e);
             std::process::exit(1);
         }
 
-        println!("BSSH_EXEC_BEGIN host={} command={}", host, command);
+        println!("BSSH_EXEC_BEGIN host={} command={}", opts.host, command);
         let rc = drain_exec_output(&mut session);
-        println!("BSSH_EXEC_END host={} rc={}", host, rc);
+        println!("BSSH_EXEC_END host={} rc={}", opts.host, rc);
         session.close();
         std::process::exit(rc);
     }
@@ -111,7 +118,7 @@ fn main() {
         std::process::exit(1);
     }
     println!("bssh: shell opened");
-    if smoke {
+    if opts.smoke {
         println!("bssh: smoke success");
         session.close();
         std::process::exit(0);
@@ -195,6 +202,250 @@ fn main() {
     }
 
     session.close();
+}
+
+fn usage() {
+    eprintln!(
+        "Usage: bssh <host> [port] [username] [password|--publickey|--publickey-wrong] [--known-hosts path] [--host-key-alias id] [--smoke] [--exec command]"
+    );
+}
+
+fn parse_options(args: &[String]) -> Result<Options, String> {
+    if args.len() < 2 {
+        return Err("bssh: missing host".to_string());
+    }
+
+    let host = args[1].clone();
+    let mut idx = 2;
+
+    let port = if let Some(arg) = args.get(idx) {
+        if !arg.starts_with("--") {
+            if let Ok(port) = arg.parse::<u16>() {
+                idx += 1;
+                port
+            } else {
+                22
+            }
+        } else {
+            22
+        }
+    } else {
+        22
+    };
+
+    let username = if let Some(arg) = args.get(idx) {
+        if !arg.starts_with("--") {
+            idx += 1;
+            arg.clone()
+        } else {
+            "root".to_string()
+        }
+    } else {
+        "root".to_string()
+    };
+
+    let mut auth_choice = AuthChoice::Password("breenix".to_string());
+    if let Some(arg) = args.get(idx) {
+        if arg == "--publickey" || arg == "publickey" {
+            auth_choice = AuthChoice::PublicKey { wrong_key: false };
+            idx += 1;
+        } else if arg == "--publickey-wrong" || arg == "publickey-wrong" {
+            auth_choice = AuthChoice::PublicKey { wrong_key: true };
+            idx += 1;
+        } else if !arg.starts_with("--") {
+            auth_choice = AuthChoice::Password(arg.clone());
+            idx += 1;
+        }
+    }
+
+    let mut smoke = false;
+    let mut exec_command = None;
+    let mut known_hosts_path = DEFAULT_KNOWN_HOSTS.to_string();
+    let mut host_key_alias = None;
+
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--smoke" => {
+                smoke = true;
+                idx += 1;
+            }
+            "--publickey" | "publickey" => {
+                auth_choice = AuthChoice::PublicKey { wrong_key: false };
+                idx += 1;
+            }
+            "--publickey-wrong" | "publickey-wrong" => {
+                auth_choice = AuthChoice::PublicKey { wrong_key: true };
+                idx += 1;
+            }
+            "--known-hosts" => {
+                let path = args
+                    .get(idx + 1)
+                    .ok_or_else(|| "bssh: --known-hosts requires a path".to_string())?;
+                known_hosts_path = path.clone();
+                idx += 2;
+            }
+            "--host-key-alias" => {
+                let alias = args
+                    .get(idx + 1)
+                    .ok_or_else(|| "bssh: --host-key-alias requires an id".to_string())?;
+                host_key_alias = Some(alias.clone());
+                idx += 2;
+            }
+            "--exec" => {
+                let parts = args
+                    .get(idx + 1..)
+                    .ok_or_else(|| "bssh: --exec requires a command".to_string())?;
+                if parts.is_empty() {
+                    return Err("bssh: --exec requires a command".to_string());
+                }
+                exec_command = Some(parts.join(" "));
+                break;
+            }
+            other => return Err(format!("bssh: unknown option '{}'", other)),
+        }
+    }
+
+    Ok(Options {
+        host,
+        port,
+        username,
+        auth_choice,
+        smoke,
+        exec_command,
+        known_hosts_path,
+        host_key_alias,
+    })
+}
+
+fn known_host_id(host: &str, port: u16, alias: Option<&str>) -> String {
+    if let Some(alias) = alias {
+        return alias.to_string();
+    }
+
+    format!("[{}]:{}", host, port)
+}
+
+fn verify_or_pin_known_host(
+    path: &str,
+    host_id: &str,
+    host_key: &ServerHostKeyInfo,
+) -> Result<(), libbreenix::ssh::SshError> {
+    let fingerprint = fingerprint_hex(&host_key.fingerprint);
+
+    if let Some(entry) = find_known_host(path, host_id) {
+        if entry.key_type == host_key.key_type && entry.fingerprint == host_key.fingerprint {
+            return Ok(());
+        }
+
+        eprintln!(
+            "bssh: host key verification failed for {}: expected {} SHA256:{}, got {} SHA256:{}",
+            host_id,
+            entry.key_type,
+            fingerprint_hex(&entry.fingerprint),
+            host_key.key_type,
+            fingerprint
+        );
+        return Err(libbreenix::ssh::SshError::Protocol(
+            "host key verification failed",
+        ));
+    }
+
+    let line = format!(
+        "{} {} SHA256:{} {}\n",
+        host_id, host_key.key_type, fingerprint, host_key.algorithm
+    );
+    let fd = match fs::open_with_mode(path, fs::O_WRONLY | fs::O_CREAT | fs::O_APPEND, 0o644) {
+        Ok(fd) => fd,
+        Err(e) => {
+            eprintln!("bssh: failed to open known_hosts '{}': {:?}", path, e);
+            return Err(libbreenix::ssh::SshError::Io);
+        }
+    };
+
+    let result = fs::write(fd, line.as_bytes());
+    let _ = fs::close(fd);
+    if let Err(e) = result {
+        eprintln!("bssh: failed to write known_hosts '{}': {:?}", path, e);
+        return Err(libbreenix::ssh::SshError::Io);
+    }
+
+    println!(
+        "bssh: pinned host key {} algorithm={} fingerprint=SHA256:{}",
+        host_id, host_key.algorithm, fingerprint
+    );
+    Ok(())
+}
+
+struct KnownHostEntry {
+    key_type: String,
+    fingerprint: [u8; 32],
+}
+
+fn find_known_host(path: &str, host_id: &str) -> Option<KnownHostEntry> {
+    let content = read_file(path)?;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let mut parts = trimmed.split_whitespace();
+        let hosts = parts.next()?;
+        let key_type = parts.next()?;
+        let fingerprint = parts.next()?;
+
+        if hosts.split(',').any(|candidate| candidate == host_id) {
+            let fingerprint = parse_fingerprint(fingerprint)?;
+            return Some(KnownHostEntry {
+                key_type: key_type.to_string(),
+                fingerprint,
+            });
+        }
+    }
+
+    None
+}
+
+fn read_file(path: &str) -> Option<String> {
+    let fd = fs::open(path, fs::O_RDONLY).ok()?;
+    let mut bytes = Vec::new();
+    let mut buf = [0u8; 512];
+    loop {
+        match fs::read(fd, &mut buf) {
+            Ok(0) => break,
+            Ok(n) => bytes.extend_from_slice(&buf[..n]),
+            Err(_) => {
+                let _ = fs::close(fd);
+                return None;
+            }
+        }
+    }
+    let _ = fs::close(fd);
+    String::from_utf8(bytes).ok()
+}
+
+fn parse_fingerprint(value: &str) -> Option<[u8; 32]> {
+    let hex = value.strip_prefix("SHA256:")?;
+    if hex.len() != 64 {
+        return None;
+    }
+
+    let mut out = [0u8; 32];
+    for i in 0..32 {
+        let byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).ok()?;
+        out[i] = byte;
+    }
+    Some(out)
+}
+
+fn fingerprint_hex(fingerprint: &[u8; 32]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(64);
+    for byte in fingerprint {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
 }
 
 fn drain_exec_output(session: &mut ClientSession) -> i32 {


### PR DESCRIPTION
## Summary
- exposes server host-key identity from client KEX
- adds bssh known_hosts-style verification at /tmp/bssh_known_hosts by default, with --known-hosts override
- TOFU-pins unknown hosts, silently accepts matching pinned hosts, and refuses mismatched pins before auth/channel setup

## Validation
- cargo check --manifest-path libs/libbreenix/Cargo.toml --features std
- userspace/programs/build.sh --arch aarch64
- cargo build --release --features testing,external_test_bins --bin qemu-uefi (warning scan empty)
- Parallels proof via Breenix bsshd exec into bssh targeting operator Mac sshd 10.0.1.210:22:
  - Case A first connect: empty known_hosts, pinned [10.0.1.210]:22, returned Darwin, exit 0
  - Case B strict reverify: reused the pinned key without re-pinning, returned Darwin, exit 0
  - Case C tampered pin: wrong Breenix key pinned for [10.0.1.210]:22, bssh refused with host key verification failed, no BSSH_EXEC_BEGIN, exit 1

Artifacts: /Users/wrb/Downloads/Ralph/breenix-interrupt-io-roadmap-1780056222/turn93-artifacts