### PR TITLE
Fix bssh auth against macOS sshd

### DIFF
--- a/docs/planning/bssh-client-key-security.md
+++ b/docs/planning/bssh-client-key-security.md
@@ -2,8 +2,9 @@
 
 ## Current state
 
-`bssh --publickey` currently uses the compiled-in Breenix RSA keypair as its
-SSH user-authentication identity.
+`bssh --identity <path>` uses a caller-supplied RSA identity for SSH
+user-authentication. The older `bssh --publickey` path still uses the
+compiled-in Breenix RSA keypair as a development/test fallback.
 
 The key flow is:
 
@@ -15,23 +16,24 @@ The key flow is:
 - `libs/libbreenix/src/ssh/keys.rs` implements both helpers by loading
   `HostKey::load()`, whose private exponent is compiled from `HOST_KEY_D`.
 
-That means the current publickey identity is not a private user identity. It is
-repository key material and must not be authorized for login to real external
-accounts.
+That fallback identity is not a private user identity. It is repository key
+material and must not be authorized for login to real external accounts.
 
 ## Required production fix
 
-`bssh` should support a caller-supplied client identity, for example:
+Use a caller-supplied client identity for real hosts:
 
 ```text
-bssh user@host --identity /path/to/id_rsa --publickey
+bssh user@host --identity /path/to/id_rsa
 ```
 
-The client should parse an OpenSSH-compatible private key or a constrained
-Breenix key format from the filesystem, derive the matching public key blob,
-and sign USERAUTH data with that private key. The embedded repo key can remain
-only as a local development/test identity, and `bssh` should label it as such in
-the CLI.
+The first implemented identity format is unencrypted PKCS#1 PEM RSA. Generate
+compatible proof keys with:
 
-Until that exists, real-host publickey proofs must not rely on adding the
-embedded Breenix key to a real account's `authorized_keys`.
+```text
+ssh-keygen -t rsa -b 3072 -m PEM -f id_rsa -N ''
+```
+
+Future work can add OpenSSH private-key format parsing and encrypted-key
+passphrases. Real-host publickey proofs must not rely on adding the embedded
+Breenix key to a real account's `authorized_keys`.

--- a/docs/planning/bssh-client-key-security.md
+++ b/docs/planning/bssh-client-key-security.md
@@ -1,0 +1,37 @@
+# bssh Client Key Security
+
+## Current state
+
+`bssh --publickey` currently uses the compiled-in Breenix RSA keypair as its
+SSH user-authentication identity.
+
+The key flow is:
+
+- `userspace/programs/src/bssh.rs` selects `ClientAuthMethod::PublicKey`.
+- `libs/libbreenix/src/ssh/transport.rs` calls `auth::client_auth_publickey`.
+- `libs/libbreenix/src/ssh/auth.rs` gets the public key from
+  `keys::embedded_client_public_key_blob()` and signs with
+  `keys::sign_with_embedded_client_key()`.
+- `libs/libbreenix/src/ssh/keys.rs` implements both helpers by loading
+  `HostKey::load()`, whose private exponent is compiled from `HOST_KEY_D`.
+
+That means the current publickey identity is not a private user identity. It is
+repository key material and must not be authorized for login to real external
+accounts.
+
+## Required production fix
+
+`bssh` should support a caller-supplied client identity, for example:
+
+```text
+bssh user@host --identity /path/to/id_rsa --publickey
+```
+
+The client should parse an OpenSSH-compatible private key or a constrained
+Breenix key format from the filesystem, derive the matching public key blob,
+and sign USERAUTH data with that private key. The embedded repo key can remain
+only as a local development/test identity, and `bssh` should label it as such in
+the CLI.
+
+Until that exists, real-host publickey proofs must not rely on adding the
+embedded Breenix key to a real account's `authorized_keys`.

--- a/libs/libbreenix/src/ssh/auth.rs
+++ b/libs/libbreenix/src/ssh/auth.rs
@@ -9,10 +9,16 @@ use super::packet::PacketIo;
 use super::{SshBuf, SshError};
 use super::{SSH_MSG_DEBUG, SSH_MSG_EXT_INFO, SSH_MSG_IGNORE};
 use super::{SSH_MSG_SERVICE_ACCEPT, SSH_MSG_SERVICE_REQUEST};
-use super::{SSH_MSG_USERAUTH_FAILURE, SSH_MSG_USERAUTH_REQUEST, SSH_MSG_USERAUTH_SUCCESS};
+use super::{
+    SSH_MSG_USERAUTH_BANNER, SSH_MSG_USERAUTH_FAILURE, SSH_MSG_USERAUTH_REQUEST,
+    SSH_MSG_USERAUTH_SUCCESS,
+};
 
 /// SSH_MSG_USERAUTH_PK_OK (RFC 4252 §7)
 const SSH_MSG_USERAUTH_PK_OK: u8 = 60;
+/// SSH_MSG_USERAUTH_INFO_REQUEST / INFO_RESPONSE (RFC 4256 §3)
+const SSH_MSG_USERAUTH_INFO_REQUEST: u8 = 60;
+const SSH_MSG_USERAUTH_INFO_RESPONSE: u8 = 61;
 
 /// Handle the "ssh-userauth" service request (server side).
 ///
@@ -22,7 +28,9 @@ pub fn server_accept_service(io: &mut PacketIo) -> Result<(), SshError> {
     let msg = loop {
         let pkt = io.recv_packet().map_err(|_| SshError::Io)?;
         if pkt.is_empty() {
-            return Err(SshError::Protocol("empty packet waiting for SERVICE_REQUEST"));
+            return Err(SshError::Protocol(
+                "empty packet waiting for SERVICE_REQUEST",
+            ));
         }
         // Skip informational messages that arrive before SERVICE_REQUEST
         match pkt[0] {
@@ -35,8 +43,8 @@ pub fn server_accept_service(io: &mut PacketIo) -> Result<(), SshError> {
     }
 
     let mut pos = 1;
-    let service = SshBuf::get_string(&msg, &mut pos)
-        .ok_or(SshError::Protocol("bad SERVICE_REQUEST"))?;
+    let service =
+        SshBuf::get_string(&msg, &mut pos).ok_or(SshError::Protocol("bad SERVICE_REQUEST"))?;
 
     if service != b"ssh-userauth" {
         return Err(SshError::Protocol("unknown service requested"));
@@ -57,10 +65,7 @@ pub fn server_accept_service(io: &mut PacketIo) -> Result<(), SshError> {
 /// 2. **password** — accepts password "breenix" (development fallback)
 ///
 /// The `session_id` is required for public key signature verification.
-pub fn server_authenticate(
-    io: &mut PacketIo,
-    session_id: &[u8],
-) -> Result<String, SshError> {
+pub fn server_authenticate(io: &mut PacketIo, session_id: &[u8]) -> Result<String, SshError> {
     loop {
         let msg = io.recv_packet().map_err(|_| SshError::Io)?;
         if msg.is_empty() {
@@ -72,12 +77,11 @@ pub fn server_authenticate(
         }
 
         let mut pos = 1;
-        let username = SshBuf::get_string(&msg, &mut pos)
-            .ok_or(SshError::Protocol("bad username"))?;
-        let service = SshBuf::get_string(&msg, &mut pos)
-            .ok_or(SshError::Protocol("bad service"))?;
-        let method = SshBuf::get_string(&msg, &mut pos)
-            .ok_or(SshError::Protocol("bad method"))?;
+        let username =
+            SshBuf::get_string(&msg, &mut pos).ok_or(SshError::Protocol("bad username"))?;
+        let service =
+            SshBuf::get_string(&msg, &mut pos).ok_or(SshError::Protocol("bad service"))?;
+        let method = SshBuf::get_string(&msg, &mut pos).ok_or(SshError::Protocol("bad method"))?;
 
         if service != b"ssh-connection" {
             return Err(SshError::Protocol("unsupported service"));
@@ -93,8 +97,12 @@ pub fn server_authenticate(
             let key_blob = SshBuf::get_string(&msg, &mut pos)
                 .ok_or(SshError::Protocol("bad publickey blob"))?;
 
-            println!("bsshd: pubkey auth: algo={} blob_len={} has_sig={}",
-                String::from_utf8_lossy(algo), key_blob.len(), has_signature);
+            println!(
+                "bsshd: pubkey auth: algo={} blob_len={} has_sig={}",
+                String::from_utf8_lossy(algo),
+                key_blob.len(),
+                has_signature
+            );
 
             // Check if this key is in our authorized_keys
             if !keys::is_authorized_key(key_blob) {
@@ -202,6 +210,8 @@ pub fn client_auth_password(
     username: &str,
     password: &str,
 ) -> Result<(), SshError> {
+    println!("bssh: userauth request method=password user='{}'", username);
+
     let mut req = Vec::with_capacity(64);
     req.push(SSH_MSG_USERAUTH_REQUEST);
     SshBuf::put_string(&mut req, username.as_bytes());
@@ -218,9 +228,83 @@ pub fn client_auth_password(
 
     match reply[0] {
         SSH_MSG_USERAUTH_SUCCESS => Ok(()),
-        SSH_MSG_USERAUTH_FAILURE => Err(SshError::Auth),
+        SSH_MSG_USERAUTH_FAILURE => {
+            let failure = parse_auth_failure(&reply)?;
+            println!(
+                "bssh: userauth failure methods='{}' partial={}",
+                failure.methods, failure.partial_success
+            );
+            if failure.method_allowed("keyboard-interactive") {
+                println!("bssh: retrying auth with keyboard-interactive");
+                client_auth_keyboard_interactive(io, username, password)
+            } else {
+                Err(SshError::Auth)
+            }
+        }
         _ => Err(SshError::Protocol("unexpected auth response")),
     }
+}
+
+/// Authenticate with keyboard-interactive using the supplied password for prompts.
+pub fn client_auth_keyboard_interactive(
+    io: &mut PacketIo,
+    username: &str,
+    password: &str,
+) -> Result<(), SshError> {
+    println!(
+        "bssh: userauth request method=keyboard-interactive user='{}'",
+        username
+    );
+
+    let mut req = Vec::with_capacity(96);
+    req.push(SSH_MSG_USERAUTH_REQUEST);
+    SshBuf::put_string(&mut req, username.as_bytes());
+    SshBuf::put_string(&mut req, b"ssh-connection");
+    SshBuf::put_string(&mut req, b"keyboard-interactive");
+    SshBuf::put_string(&mut req, b"");
+    SshBuf::put_string(&mut req, b"");
+    io.send_packet(&req).map_err(|_| SshError::Io)?;
+
+    for _ in 0..8 {
+        let reply = recv_client_reply(io)?;
+        if reply.is_empty() {
+            return Err(SshError::Protocol("empty keyboard-interactive response"));
+        }
+
+        match reply[0] {
+            SSH_MSG_USERAUTH_SUCCESS => return Ok(()),
+            SSH_MSG_USERAUTH_FAILURE => {
+                let failure = parse_auth_failure(&reply)?;
+                println!(
+                    "bssh: userauth failure methods='{}' partial={}",
+                    failure.methods, failure.partial_success
+                );
+                return Err(SshError::Auth);
+            }
+            SSH_MSG_USERAUTH_INFO_REQUEST => {
+                let prompt_count = parse_keyboard_interactive_request(&reply)?;
+                println!(
+                    "bssh: keyboard-interactive info-request prompts={}",
+                    prompt_count
+                );
+
+                let mut response = Vec::with_capacity(16 + password.len() * prompt_count);
+                response.push(SSH_MSG_USERAUTH_INFO_RESPONSE);
+                SshBuf::put_u32(&mut response, prompt_count as u32);
+                for _ in 0..prompt_count {
+                    SshBuf::put_string(&mut response, password.as_bytes());
+                }
+                io.send_packet(&response).map_err(|_| SshError::Io)?;
+            }
+            _ => {
+                return Err(SshError::Protocol(
+                    "unexpected keyboard-interactive response",
+                ))
+            }
+        }
+    }
+
+    Err(SshError::Protocol("too many keyboard-interactive rounds"))
 }
 
 /// Authenticate with the SSH publickey method using the embedded bssh key.
@@ -238,6 +322,13 @@ pub fn client_auth_publickey(
         }
     }
 
+    println!(
+        "bssh: userauth request method=publickey user='{}' algo={} has_signature=false key_blob_len={}",
+        username,
+        String::from_utf8_lossy(algo),
+        key_blob.len()
+    );
+
     let mut query = Vec::with_capacity(128 + key_blob.len());
     query.push(SSH_MSG_USERAUTH_REQUEST);
     SshBuf::put_string(&mut query, username.as_bytes());
@@ -254,7 +345,14 @@ pub fn client_auth_publickey(
     }
     match reply[0] {
         SSH_MSG_USERAUTH_PK_OK => {}
-        SSH_MSG_USERAUTH_FAILURE => return Err(SshError::Auth),
+        SSH_MSG_USERAUTH_FAILURE => {
+            let failure = parse_auth_failure(&reply)?;
+            println!(
+                "bssh: userauth failure methods='{}' partial={}",
+                failure.methods, failure.partial_success
+            );
+            return Err(SshError::Auth);
+        }
         _ => return Err(SshError::Protocol("unexpected publickey query response")),
     }
 
@@ -278,6 +376,13 @@ pub fn client_auth_publickey(
     SshBuf::put_string(&mut signed_data, &key_blob);
     let signature = keys::sign_with_embedded_client_key(&signed_data);
 
+    println!(
+        "bssh: userauth request method=publickey user='{}' algo={} has_signature=true signature_len={}",
+        username,
+        String::from_utf8_lossy(algo),
+        signature.len()
+    );
+
     let mut req = Vec::with_capacity(128 + key_blob.len() + signature.len());
     req.push(SSH_MSG_USERAUTH_REQUEST);
     SshBuf::put_string(&mut req, username.as_bytes());
@@ -296,9 +401,61 @@ pub fn client_auth_publickey(
 
     match reply[0] {
         SSH_MSG_USERAUTH_SUCCESS => Ok(()),
-        SSH_MSG_USERAUTH_FAILURE => Err(SshError::Auth),
+        SSH_MSG_USERAUTH_FAILURE => {
+            let failure = parse_auth_failure(&reply)?;
+            println!(
+                "bssh: userauth failure methods='{}' partial={}",
+                failure.methods, failure.partial_success
+            );
+            Err(SshError::Auth)
+        }
         _ => Err(SshError::Protocol("unexpected publickey auth response")),
     }
+}
+
+struct AuthFailure {
+    methods: String,
+    partial_success: bool,
+}
+
+impl AuthFailure {
+    fn method_allowed(&self, method: &str) -> bool {
+        self.methods.split(',').any(|candidate| candidate == method)
+    }
+}
+
+fn parse_auth_failure(reply: &[u8]) -> Result<AuthFailure, SshError> {
+    let mut pos = 1;
+    let methods = SshBuf::get_string(reply, &mut pos)
+        .ok_or(SshError::Protocol("bad userauth failure methods"))?;
+    let partial_success = SshBuf::get_bool(reply, &mut pos)
+        .ok_or(SshError::Protocol("bad userauth failure partial flag"))?;
+    Ok(AuthFailure {
+        methods: String::from_utf8_lossy(methods).into_owned(),
+        partial_success,
+    })
+}
+
+fn parse_keyboard_interactive_request(reply: &[u8]) -> Result<usize, SshError> {
+    let mut pos = 1;
+    let _name = SshBuf::get_string(reply, &mut pos)
+        .ok_or(SshError::Protocol("bad keyboard-interactive name"))?;
+    let _instruction = SshBuf::get_string(reply, &mut pos)
+        .ok_or(SshError::Protocol("bad keyboard-interactive instruction"))?;
+    let _language = SshBuf::get_string(reply, &mut pos)
+        .ok_or(SshError::Protocol("bad keyboard-interactive language"))?;
+    let prompt_count = SshBuf::get_u32(reply, &mut pos)
+        .ok_or(SshError::Protocol("bad keyboard-interactive prompt count"))?
+        as usize;
+
+    for _ in 0..prompt_count {
+        let _prompt = SshBuf::get_string(reply, &mut pos)
+            .ok_or(SshError::Protocol("bad keyboard-interactive prompt"))?;
+        let _echo = SshBuf::get_bool(reply, &mut pos)
+            .ok_or(SshError::Protocol("bad keyboard-interactive echo flag"))?;
+    }
+
+    Ok(prompt_count)
 }
 
 fn recv_client_reply(io: &mut PacketIo) -> Result<Vec<u8>, SshError> {
@@ -308,7 +465,7 @@ fn recv_client_reply(io: &mut PacketIo) -> Result<Vec<u8>, SshError> {
             return Ok(reply);
         }
         match reply[0] {
-            SSH_MSG_IGNORE | SSH_MSG_DEBUG | SSH_MSG_EXT_INFO => continue,
+            SSH_MSG_IGNORE | SSH_MSG_DEBUG | SSH_MSG_EXT_INFO | SSH_MSG_USERAUTH_BANNER => continue,
             _ => return Ok(reply),
         }
     }

--- a/libs/libbreenix/src/ssh/auth.rs
+++ b/libs/libbreenix/src/ssh/auth.rs
@@ -314,14 +314,41 @@ pub fn client_auth_publickey(
     session_id: &[u8],
     wrong_key: bool,
 ) -> Result<(), SshError> {
-    let algo = b"rsa-sha2-256";
     let mut key_blob = keys::embedded_client_public_key_blob();
     if wrong_key {
         if let Some(last) = key_blob.last_mut() {
             *last ^= 0x01;
         }
     }
+    client_auth_publickey_with_signer(io, username, session_id, key_blob, |data| {
+        keys::sign_with_embedded_client_key(data)
+    })
+}
 
+/// Authenticate with the SSH publickey method using a caller-supplied identity.
+pub fn client_auth_publickey_identity(
+    io: &mut PacketIo,
+    username: &str,
+    session_id: &[u8],
+    identity: &keys::RsaIdentity,
+) -> Result<(), SshError> {
+    let key_blob = identity.public_key_blob();
+    client_auth_publickey_with_signer(io, username, session_id, key_blob, |data| {
+        identity.sign(data)
+    })
+}
+
+fn client_auth_publickey_with_signer<F>(
+    io: &mut PacketIo,
+    username: &str,
+    session_id: &[u8],
+    key_blob: Vec<u8>,
+    sign: F,
+) -> Result<(), SshError>
+where
+    F: FnOnce(&[u8]) -> Vec<u8>,
+{
+    let algo = b"rsa-sha2-256";
     println!(
         "bssh: userauth request method=publickey user='{}' algo={} has_signature=false key_blob_len={}",
         username,
@@ -374,7 +401,7 @@ pub fn client_auth_publickey(
     SshBuf::put_bool(&mut signed_data, true);
     SshBuf::put_string(&mut signed_data, algo);
     SshBuf::put_string(&mut signed_data, &key_blob);
-    let signature = keys::sign_with_embedded_client_key(&signed_data);
+    let signature = sign(&signed_data);
 
     println!(
         "bssh: userauth request method=publickey user='{}' algo={} has_signature=true signature_len={}",

--- a/libs/libbreenix/src/ssh/keys.rs
+++ b/libs/libbreenix/src/ssh/keys.rs
@@ -171,6 +171,50 @@ impl HostKey {
     }
 }
 
+/// Caller-supplied RSA identity for SSH publickey client authentication.
+pub struct RsaIdentity {
+    key: RsaPrivateKey,
+}
+
+impl RsaIdentity {
+    /// Load an unencrypted PKCS#1 PEM RSA private key.
+    pub fn from_pkcs1_pem(pem: &str) -> Result<Self, &'static str> {
+        let der = decode_pem_block(
+            pem,
+            "-----BEGIN RSA PRIVATE KEY-----",
+            "-----END RSA PRIVATE KEY-----",
+        )?;
+        let (n, e, d) = parse_pkcs1_rsa_private_key(&der)?;
+        Ok(Self {
+            key: RsaPrivateKey {
+                n: BigNum::from_be_bytes(n),
+                e: BigNum::from_be_bytes(e),
+                d: BigNum::from_be_bytes(d),
+            },
+        })
+    }
+
+    /// Encode this identity's public key in SSH wire format.
+    pub fn public_key_blob(&self) -> Vec<u8> {
+        let mut blob = Vec::with_capacity(4 + 7 + 4 + 4 + 4 + 384);
+        SshBuf::put_string(&mut blob, b"ssh-rsa");
+        SshBuf::put_mpint(&mut blob, &self.key.e.to_be_bytes());
+        SshBuf::put_mpint(&mut blob, &self.key.n.to_be_bytes());
+        blob
+    }
+
+    /// Sign data with rsa-sha2-256, returning an SSH signature blob.
+    pub fn sign(&self, data: &[u8]) -> Vec<u8> {
+        let hash = sha256(data);
+        let sig_bytes = rsa_sign_pkcs1_sha256(&self.key, &hash);
+
+        let mut sig = Vec::with_capacity(4 + 12 + 4 + sig_bytes.len());
+        SshBuf::put_string(&mut sig, b"rsa-sha2-256");
+        SshBuf::put_string(&mut sig, &sig_bytes);
+        sig
+    }
+}
+
 /// Server host-key identity observed during client key exchange.
 #[derive(Debug, Clone)]
 pub struct ServerHostKeyInfo {
@@ -255,6 +299,164 @@ pub fn embedded_client_public_key_blob() -> Vec<u8> {
 /// Sign publickey-auth data with the embedded bssh client identity.
 pub fn sign_with_embedded_client_key(data: &[u8]) -> Vec<u8> {
     HostKey::load().sign(data)
+}
+
+fn decode_pem_block(
+    pem: &str,
+    begin_marker: &str,
+    end_marker: &str,
+) -> Result<Vec<u8>, &'static str> {
+    let begin = pem.find(begin_marker).ok_or("missing PEM begin marker")?;
+    let body_start = begin + begin_marker.len();
+    let end = pem[body_start..]
+        .find(end_marker)
+        .ok_or("missing PEM end marker")?
+        + body_start;
+
+    let mut b64 = Vec::new();
+    for byte in pem[body_start..end].bytes() {
+        if byte == b'\r' || byte == b'\n' || byte == b'\t' || byte == b' ' {
+            continue;
+        }
+        b64.push(byte);
+    }
+
+    base64_decode(&b64)
+}
+
+fn base64_decode(input: &[u8]) -> Result<Vec<u8>, &'static str> {
+    let mut out = Vec::with_capacity(input.len() * 3 / 4);
+    let mut chunk = [0u8; 4];
+    let mut chunk_len = 0usize;
+
+    for &byte in input {
+        let value = match byte {
+            b'A'..=b'Z' => byte - b'A',
+            b'a'..=b'z' => byte - b'a' + 26,
+            b'0'..=b'9' => byte - b'0' + 52,
+            b'+' => 62,
+            b'/' => 63,
+            b'=' => 64,
+            _ => return Err("invalid base64 character"),
+        };
+
+        chunk[chunk_len] = value;
+        chunk_len += 1;
+        if chunk_len != 4 {
+            continue;
+        }
+
+        if chunk[0] == 64 || chunk[1] == 64 {
+            return Err("invalid base64 padding");
+        }
+
+        out.push((chunk[0] << 2) | (chunk[1] >> 4));
+        if chunk[2] != 64 {
+            out.push((chunk[1] << 4) | (chunk[2] >> 2));
+        }
+        if chunk[3] != 64 {
+            out.push((chunk[2] << 6) | chunk[3]);
+        }
+
+        chunk_len = 0;
+    }
+
+    if chunk_len != 0 {
+        return Err("truncated base64 data");
+    }
+
+    Ok(out)
+}
+
+fn parse_pkcs1_rsa_private_key(der: &[u8]) -> Result<(&[u8], &[u8], &[u8]), &'static str> {
+    let mut reader = DerReader::new(der);
+    let seq = reader.read_constructed(0x30)?;
+    if !reader.is_empty() {
+        return Err("trailing data after private key");
+    }
+
+    let mut seq_reader = DerReader::new(seq);
+    let _version = seq_reader.read_integer()?;
+    let n = seq_reader.read_integer()?;
+    let e = seq_reader.read_integer()?;
+    let d = seq_reader.read_integer()?;
+    Ok((n, e, d))
+}
+
+struct DerReader<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> DerReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pos == self.data.len()
+    }
+
+    fn read_constructed(&mut self, tag: u8) -> Result<&'a [u8], &'static str> {
+        self.read_tlv(tag)
+    }
+
+    fn read_integer(&mut self) -> Result<&'a [u8], &'static str> {
+        let value = self.read_tlv(0x02)?;
+        Ok(strip_der_integer_prefix(value))
+    }
+
+    fn read_tlv(&mut self, expected_tag: u8) -> Result<&'a [u8], &'static str> {
+        if self.pos >= self.data.len() {
+            return Err("unexpected end of DER");
+        }
+        let tag = self.data[self.pos];
+        self.pos += 1;
+        if tag != expected_tag {
+            return Err("unexpected DER tag");
+        }
+
+        let len = self.read_len()?;
+        if self.pos + len > self.data.len() {
+            return Err("DER length exceeds input");
+        }
+        let start = self.pos;
+        self.pos += len;
+        Ok(&self.data[start..start + len])
+    }
+
+    fn read_len(&mut self) -> Result<usize, &'static str> {
+        if self.pos >= self.data.len() {
+            return Err("missing DER length");
+        }
+        let first = self.data[self.pos];
+        self.pos += 1;
+
+        if first & 0x80 == 0 {
+            return Ok(first as usize);
+        }
+
+        let count = (first & 0x7f) as usize;
+        if count == 0 || count > core::mem::size_of::<usize>() || self.pos + count > self.data.len()
+        {
+            return Err("invalid DER length");
+        }
+
+        let mut len = 0usize;
+        for _ in 0..count {
+            len = (len << 8) | self.data[self.pos] as usize;
+            self.pos += 1;
+        }
+        Ok(len)
+    }
+}
+
+fn strip_der_integer_prefix(value: &[u8]) -> &[u8] {
+    if value.len() > 1 && value[0] == 0 {
+        &value[1..]
+    } else {
+        value
+    }
 }
 
 /// Parse an SSH RSA public key blob and extract the public key components.

--- a/libs/libbreenix/src/ssh/transport.rs
+++ b/libs/libbreenix/src/ssh/transport.rs
@@ -11,7 +11,7 @@ use crate::types::Fd;
 use super::auth;
 use super::channel::{self, Channel};
 use super::kex::{self, KexState};
-use super::keys::{HostKey, ServerHostKeyInfo};
+use super::keys::{HostKey, RsaIdentity, ServerHostKeyInfo};
 use super::packet::PacketIo;
 use super::{SshBuf, SshError, BSSH_VERSION};
 use super::{
@@ -371,6 +371,7 @@ pub struct ClientSession {
 pub enum ClientAuthMethod<'a> {
     Password(&'a str),
     PublicKey { wrong_key: bool },
+    PublicKeyIdentity(&'a RsaIdentity),
 }
 
 impl ClientSession {
@@ -465,6 +466,9 @@ impl ClientSession {
             }
             ClientAuthMethod::PublicKey { wrong_key } => {
                 auth::client_auth_publickey(&mut self.io, username, session_id, wrong_key)?;
+            }
+            ClientAuthMethod::PublicKeyIdentity(identity) => {
+                auth::client_auth_publickey_identity(&mut self.io, username, session_id, identity)?;
             }
         }
 

--- a/userspace/programs/src/bssh.rs
+++ b/userspace/programs/src/bssh.rs
@@ -10,7 +10,7 @@
 use libbreenix::fs;
 use libbreenix::io;
 use libbreenix::socket::{SockAddrIn, TcpStream};
-use libbreenix::ssh::keys::ServerHostKeyInfo;
+use libbreenix::ssh::keys::{RsaIdentity, ServerHostKeyInfo};
 use libbreenix::ssh::transport::{ClientAuthMethod, ClientSession};
 use libbreenix::termios;
 use libbreenix::types::Fd;
@@ -27,6 +27,7 @@ struct Options {
     port: u16,
     username: String,
     auth_choice: AuthChoice,
+    identity_path: Option<String>,
     smoke: bool,
     exec_command: Option<String>,
     known_hosts_path: String,
@@ -79,9 +80,17 @@ fn main() {
     let known_host_id = known_host_id(&opts.host, opts.port, opts.host_key_alias.as_deref());
 
     // SSH handshake + auth
-    let auth_method = match &opts.auth_choice {
-        AuthChoice::Password(password) => ClientAuthMethod::Password(password),
-        AuthChoice::PublicKey { wrong_key } => ClientAuthMethod::PublicKey {
+    let identity = match opts.identity_path.as_deref() {
+        Some(path) => Some(load_identity(path)),
+        None => None,
+    };
+
+    let auth_method = match (&opts.auth_choice, identity.as_ref()) {
+        (AuthChoice::Password(password), _) => ClientAuthMethod::Password(password),
+        (AuthChoice::PublicKey { .. }, Some(identity)) => {
+            ClientAuthMethod::PublicKeyIdentity(identity)
+        }
+        (AuthChoice::PublicKey { wrong_key }, None) => ClientAuthMethod::PublicKey {
             wrong_key: *wrong_key,
         },
     };
@@ -206,7 +215,7 @@ fn main() {
 
 fn usage() {
     eprintln!(
-        "Usage: bssh [user@]<host> [port] [username] [password|--publickey|--publickey-wrong] [--user name] [--password password] [--known-hosts path] [--host-key-alias id] [--smoke] [--exec command]"
+        "Usage: bssh [user@]<host> [port] [username] [password|--publickey|--publickey-wrong] [--identity path] [--user name] [--password password] [--known-hosts path] [--host-key-alias id] [--smoke] [--exec command]"
     );
 }
 
@@ -268,6 +277,7 @@ fn parse_options(args: &[String]) -> Result<Options, String> {
     let mut exec_command = None;
     let mut known_hosts_path = DEFAULT_KNOWN_HOSTS.to_string();
     let mut host_key_alias = None;
+    let mut identity_path = None;
 
     while idx < args.len() {
         match args[idx].as_str() {
@@ -282,6 +292,14 @@ fn parse_options(args: &[String]) -> Result<Options, String> {
             "--publickey-wrong" | "publickey-wrong" => {
                 auth_choice = AuthChoice::PublicKey { wrong_key: true };
                 idx += 1;
+            }
+            "--identity" => {
+                let path = args
+                    .get(idx + 1)
+                    .ok_or_else(|| "bssh: --identity requires a path".to_string())?;
+                identity_path = Some(path.clone());
+                auth_choice = AuthChoice::PublicKey { wrong_key: false };
+                idx += 2;
             }
             "--user" => {
                 let user = args
@@ -330,11 +348,30 @@ fn parse_options(args: &[String]) -> Result<Options, String> {
         port,
         username,
         auth_choice,
+        identity_path,
         smoke,
         exec_command,
         known_hosts_path,
         host_key_alias,
     })
+}
+
+fn load_identity(path: &str) -> RsaIdentity {
+    let pem = match read_file(path) {
+        Some(pem) => pem,
+        None => {
+            eprintln!("bssh: failed to read identity '{}'", path);
+            std::process::exit(1);
+        }
+    };
+
+    match RsaIdentity::from_pkcs1_pem(&pem) {
+        Ok(identity) => identity,
+        Err(e) => {
+            eprintln!("bssh: failed to parse identity '{}': {}", path, e);
+            std::process::exit(1);
+        }
+    }
 }
 
 fn known_host_id(host: &str, port: u16, alias: Option<&str>) -> String {

--- a/userspace/programs/src/bssh.rs
+++ b/userspace/programs/src/bssh.rs
@@ -2,10 +2,10 @@
 //!
 //! Connects to a remote SSH server and opens an interactive shell session.
 //!
-//! Usage: bssh <host> [port] [username] [password|--publickey|--publickey-wrong] [--smoke] [--exec command]
+//! Usage: bssh [user@]<host> [port] [username] [password|--publickey|--publickey-wrong] [--smoke] [--exec command]
 //!   Default port: 22
 //!   Default username: root
-//!   Default password: (prompted)
+//!   Default password: breenix
 
 use libbreenix::fs;
 use libbreenix::io;
@@ -206,7 +206,7 @@ fn main() {
 
 fn usage() {
     eprintln!(
-        "Usage: bssh <host> [port] [username] [password|--publickey|--publickey-wrong] [--known-hosts path] [--host-key-alias id] [--smoke] [--exec command]"
+        "Usage: bssh [user@]<host> [port] [username] [password|--publickey|--publickey-wrong] [--user name] [--password password] [--known-hosts path] [--host-key-alias id] [--smoke] [--exec command]"
     );
 }
 
@@ -215,7 +215,12 @@ fn parse_options(args: &[String]) -> Result<Options, String> {
         return Err("bssh: missing host".to_string());
     }
 
-    let host = args[1].clone();
+    let (host, username_from_host) = match args[1].split_once('@') {
+        Some((user, host)) if !user.is_empty() && !host.is_empty() => {
+            (host.to_string(), Some(user.to_string()))
+        }
+        _ => (args[1].clone(), None),
+    };
     let mut idx = 2;
 
     let port = if let Some(arg) = args.get(idx) {
@@ -238,12 +243,13 @@ fn parse_options(args: &[String]) -> Result<Options, String> {
             idx += 1;
             arg.clone()
         } else {
-            "root".to_string()
+            username_from_host.unwrap_or_else(|| "root".to_string())
         }
     } else {
-        "root".to_string()
+        username_from_host.unwrap_or_else(|| "root".to_string())
     };
 
+    let mut username = username;
     let mut auth_choice = AuthChoice::Password("breenix".to_string());
     if let Some(arg) = args.get(idx) {
         if arg == "--publickey" || arg == "publickey" {
@@ -276,6 +282,20 @@ fn parse_options(args: &[String]) -> Result<Options, String> {
             "--publickey-wrong" | "publickey-wrong" => {
                 auth_choice = AuthChoice::PublicKey { wrong_key: true };
                 idx += 1;
+            }
+            "--user" => {
+                let user = args
+                    .get(idx + 1)
+                    .ok_or_else(|| "bssh: --user requires a username".to_string())?;
+                username = user.clone();
+                idx += 2;
+            }
+            "--password" => {
+                let password = args
+                    .get(idx + 1)
+                    .ok_or_else(|| "bssh: --password requires a password".to_string())?;
+                auth_choice = AuthChoice::Password(password.clone());
+                idx += 2;
             }
             "--known-hosts" => {
                 let path = args


### PR DESCRIPTION
## Summary
- add keyboard-interactive fallback after password USERAUTH_FAILURE when the server advertises it
- add bssh USERAUTH traces for method list, publickey signature phase, and keyboard-interactive prompts
- accept standard user@host syntax plus --user/--password flags for real host accounts

## Validation
- cargo build --release --features testing,external_test_bins --bin qemu-uefi (zero warning/error lines)
- cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64 (zero warning/error lines)
- ./run.sh --parallels --test 60 rebuilt userspace/ext2 and booted fresh ARM64 Parallels VM
- 3 consecutive bssh -> 10.0.1.210:22 publickey exec runs from the guest returned TURN101_FIXED_1/2/3 with rc=0
- wrong-password probe against 10.0.1.210:22 captured methods publickey,password,keyboard-interactive and exercised keyboard-interactive prompt handling

Artifacts: /Users/wrb/Downloads/Ralph/breenix-interrupt-io-roadmap-1780056222/turn101-artifacts/final-real-mac-proof
