### PR TITLE
Fix ARM64 fork kernel stack reuse for bsshd

### DIFF
--- a/kernel/src/arch_impl/aarch64/syscall_entry.rs
+++ b/kernel/src/arch_impl/aarch64/syscall_entry.rs
@@ -940,6 +940,10 @@ fn sys_fork_aarch64(frame: &Aarch64ExceptionFrame) -> u64 {
     }; // PM lock dropped, interrupts restored
     crate::serial_aarch64::raw_serial_char(b'2'); // Fork phase 1 done, PM lock dropped
 
+    // Reclaim scheduler-owned kernel stacks from fully retired fork children before
+    // consuming another slot from the finite ARM64 kernel stack pool.
+    crate::task::scheduler::reclaim_terminated_threads();
+
     // Create child page table OUTSIDE PM lock (heap allocation safe — interrupts enabled)
     crate::serial_aarch64::raw_serial_char(b'3'); // Fork: allocating page table
     let child_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
@@ -962,10 +966,14 @@ fn sys_fork_aarch64(frame: &Aarch64ExceptionFrame) -> u64 {
     match fork_result {
         Ok(child_pid) => {
             // Extract child thread info while still under PM lock (no logging!)
-            let child_info = if let Some(ref manager) = *manager_guard {
-                manager
-                    .get_process(child_pid)
-                    .and_then(|p| p.main_thread.as_ref().map(|t| (t.id, t.clone())))
+            let child_info = if let Some(ref mut manager) = *manager_guard {
+                manager.get_process_mut(child_pid).and_then(|p| {
+                    p.main_thread.as_mut().map(|t| {
+                        let mut scheduler_thread = t.clone();
+                        scheduler_thread.kernel_stack_allocation = t.kernel_stack_allocation.take();
+                        (t.id, scheduler_thread)
+                    })
+                })
             } else {
                 None
             };

--- a/kernel/src/memory/kernel_stack.rs
+++ b/kernel/src/memory/kernel_stack.rs
@@ -7,16 +7,19 @@
 use crate::memory::arch_stub::VirtAddr;
 #[cfg(target_arch = "x86_64")]
 use crate::memory::frame_allocator::allocate_frame;
+#[cfg(target_arch = "x86_64")]
 use spin::Mutex;
 #[cfg(target_arch = "x86_64")]
 use x86_64::{structures::paging::PageTableFlags, VirtAddr};
 
 /// Base address for kernel stack allocation
+#[cfg(target_arch = "x86_64")]
 const KERNEL_STACK_BASE: u64 = 0xffffc900_0000_0000;
 
 /// End address for kernel stack allocation (128 MiB total space)
 /// Increased to 128 MiB to support 512KB stacks (kernel stacks are leaked,
 /// not freed, so we need enough slots for all processes created during tests)
+#[cfg(target_arch = "x86_64")]
 const KERNEL_STACK_END: u64 = 0xffffc900_0800_0000;
 
 /// Size of each kernel stack (512 KiB)
@@ -26,21 +29,27 @@ const KERNEL_STACK_END: u64 = 0xffffc900_0800_0000;
 /// → write_char_to_framebuffer → split_screen → font rendering
 /// This path can use 300KB+ of stack when combined with interrupt frame overhead
 /// and nested help command processing with terminal output formatting.
+#[cfg(target_arch = "x86_64")]
 const KERNEL_STACK_SIZE: u64 = 512 * 1024;
 
 /// Size of guard page (4 KiB)
+#[cfg(target_arch = "x86_64")]
 const GUARD_PAGE_SIZE: u64 = 4 * 1024;
 
 /// Total size per stack slot (stack + guard)
+#[cfg(target_arch = "x86_64")]
 const STACK_SLOT_SIZE: u64 = KERNEL_STACK_SIZE + GUARD_PAGE_SIZE;
 
 /// Maximum number of kernel stacks
+#[cfg(target_arch = "x86_64")]
 const MAX_KERNEL_STACKS: usize =
     ((KERNEL_STACK_END - KERNEL_STACK_BASE) / STACK_SLOT_SIZE) as usize;
 
 /// Bitmap to track allocated stacks (1 bit per stack)
 /// Using u64 array for efficient bit operations
+#[cfg(target_arch = "x86_64")]
 const BITMAP_SIZE: usize = (MAX_KERNEL_STACKS + 63) / 64;
+#[cfg(target_arch = "x86_64")]
 static STACK_BITMAP: Mutex<[u64; BITMAP_SIZE]> = Mutex::new([0; BITMAP_SIZE]);
 
 /// A kernel stack allocation
@@ -66,6 +75,7 @@ impl KernelStack {
     }
 
     /// Get the guard page address
+    #[cfg(target_arch = "x86_64")]
     #[allow(dead_code)]
     pub fn guard_page(&self) -> VirtAddr {
         VirtAddr::new(self.bottom.as_u64() - GUARD_PAGE_SIZE)
@@ -74,13 +84,22 @@ impl KernelStack {
 
 impl Drop for KernelStack {
     fn drop(&mut self) {
-        // Mark the stack as free in the bitmap
-        let mut bitmap = STACK_BITMAP.lock();
-        let word_index = self.index / 64;
-        let bit_index = self.index % 64;
-        bitmap[word_index] &= !(1u64 << bit_index);
+        #[cfg(target_arch = "aarch64")]
+        {
+            aarch64::free_kernel_stack(self.index);
+            return;
+        }
 
-        log::trace!("Freed kernel stack slot {}", self.index);
+        #[cfg(target_arch = "x86_64")]
+        {
+            // Mark the stack as free in the bitmap
+            let mut bitmap = STACK_BITMAP.lock();
+            let word_index = self.index / 64;
+            let bit_index = self.index % 64;
+            bitmap[word_index] &= !(1u64 << bit_index);
+
+            log::trace!("Freed kernel stack slot {}", self.index);
+        }
     }
 }
 
@@ -207,7 +226,7 @@ pub fn init() {
 #[cfg(target_arch = "aarch64")]
 mod aarch64 {
     use super::VirtAddr;
-    use core::sync::atomic::{AtomicU64, Ordering};
+    use spin::Mutex;
 
     /// ARM64 kernel stack base (in high-half direct map)
     /// Physical range: 0x5420_0000 .. 0x5620_0000 (32MB for kernel stacks)
@@ -231,12 +250,17 @@ mod aarch64 {
     /// Total slot size (stack + guard)
     const ARM64_STACK_SLOT_SIZE: u64 = ARM64_KERNEL_STACK_SIZE + ARM64_GUARD_PAGE_SIZE;
 
-    /// Next available stack slot (atomic bump allocator)
-    static NEXT_STACK_SLOT: AtomicU64 = AtomicU64::new(ARM64_KERNEL_STACK_BASE);
+    /// Bitmap to track allocated ARM64 stacks.
+    const ARM64_MAX_KERNEL_STACKS: usize =
+        ((ARM64_KERNEL_STACK_END - ARM64_KERNEL_STACK_BASE) / ARM64_STACK_SLOT_SIZE) as usize;
+    const ARM64_BITMAP_SIZE: usize = (ARM64_MAX_KERNEL_STACKS + 63) / 64;
+    static ARM64_STACK_BITMAP: Mutex<[u64; ARM64_BITMAP_SIZE]> = Mutex::new([0; ARM64_BITMAP_SIZE]);
 
     /// A kernel stack allocation for ARM64
     #[derive(Debug)]
     pub struct Aarch64KernelStack {
+        /// Index in the bitmap
+        pub index: usize,
         /// Bottom of the stack (lowest address, above guard page)
         pub bottom: VirtAddr,
         /// Top of the stack (highest address)
@@ -252,16 +276,39 @@ mod aarch64 {
 
     /// Allocate a kernel stack for ARM64
     ///
-    /// Uses a simple bump allocator in the high-half direct map region.
-    /// Stacks are not freed (leaked) - this is acceptable for the
-    /// current single-process test workload.
+    /// Uses a bitmap over a reserved high-half direct map region so fork-heavy
+    /// userspace workloads can reuse stacks after waitpid reaps children.
     pub fn allocate_kernel_stack() -> Result<Aarch64KernelStack, &'static str> {
-        let slot_base = NEXT_STACK_SLOT.fetch_add(ARM64_STACK_SLOT_SIZE, Ordering::SeqCst);
+        let mut bitmap = ARM64_STACK_BITMAP.lock();
 
-        if slot_base + ARM64_STACK_SLOT_SIZE > ARM64_KERNEL_STACK_END {
-            return Err("ARM64 kernel stack pool exhausted");
+        let mut slot_index = None;
+        for (word_idx, word) in bitmap.iter_mut().enumerate() {
+            if *word == u64::MAX {
+                continue;
+            }
+
+            for bit_idx in 0..64 {
+                let global_idx = word_idx * 64 + bit_idx;
+                if global_idx >= ARM64_MAX_KERNEL_STACKS {
+                    break;
+                }
+
+                if (*word & (1u64 << bit_idx)) == 0 {
+                    *word |= 1u64 << bit_idx;
+                    slot_index = Some(global_idx);
+                    break;
+                }
+            }
+
+            if slot_index.is_some() {
+                break;
+            }
         }
 
+        let index = slot_index.ok_or("ARM64 kernel stack pool exhausted")?;
+        drop(bitmap);
+
+        let slot_base = ARM64_KERNEL_STACK_BASE + (index as u64 * ARM64_STACK_SLOT_SIZE);
         let stack_bottom = VirtAddr::new(slot_base + ARM64_GUARD_PAGE_SIZE);
         let stack_top = VirtAddr::new(slot_base + ARM64_STACK_SLOT_SIZE);
 
@@ -272,9 +319,21 @@ mod aarch64 {
         );
 
         Ok(Aarch64KernelStack {
+            index,
             bottom: stack_bottom,
             top: stack_top,
         })
+    }
+
+    pub fn free_kernel_stack(index: usize) {
+        if index >= ARM64_MAX_KERNEL_STACKS {
+            return;
+        }
+
+        let mut bitmap = ARM64_STACK_BITMAP.lock();
+        let word_index = index / 64;
+        let bit_index = index % 64;
+        bitmap[word_index] &= !(1u64 << bit_index);
     }
 
     /// Initialize the ARM64 kernel stack allocator
@@ -315,7 +374,7 @@ pub fn allocate_kernel_stack() -> Result<KernelStack, &'static str> {
     let aarch64_stack = allocate_kernel_stack_aarch64()?;
     // Convert to KernelStack format for API compatibility
     Ok(KernelStack {
-        index: 0, // Not used for ARM64
+        index: aarch64_stack.index,
         bottom: aarch64_stack.bottom,
         top: aarch64_stack.top,
     })

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -1747,20 +1747,20 @@ impl ProcessManager {
         let child_tls_block = VirtAddr::new(0x10000 + child_thread_id * 0x1000);
 
         // Allocate a kernel stack for the child thread
-        let child_kernel_stack_top =
+        let (child_kernel_stack_top, child_kernel_stack_allocation) =
             if parent_thread.privilege == crate::task::thread::ThreadPrivilege::User {
                 let kernel_stack = crate::memory::kernel_stack::allocate_kernel_stack()
                     .map_err(|_e| "Failed to allocate kernel stack for child thread")?;
                 let kernel_stack_top = kernel_stack.top();
 
-                // Store the kernel stack (leak for now - TODO: proper cleanup)
-                Box::leak(Box::new(kernel_stack));
-
-                kernel_stack_top
+                (kernel_stack_top, Some(kernel_stack))
             } else {
-                parent_thread
-                    .kernel_stack_top
-                    .unwrap_or(parent_thread.stack_top)
+                (
+                    parent_thread
+                        .kernel_stack_top
+                        .unwrap_or(parent_thread.stack_top),
+                    None,
+                )
             };
 
         // Create the child's main thread
@@ -1778,6 +1778,7 @@ impl ProcessManager {
         // Set the ID, kernel stack, and owner PID
         child_thread.id = child_thread_id;
         child_thread.kernel_stack_top = Some(child_kernel_stack_top);
+        child_thread.kernel_stack_allocation = child_kernel_stack_allocation;
         child_thread.owner_pid = Some(child_pid.as_u64());
 
         child_thread.context = parent_context.clone();

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -760,6 +760,35 @@ impl Scheduler {
         let _ = (thread_id, thread_name, is_user);
     }
 
+    /// Drop terminated threads that are no longer referenced by any CPU state.
+    ///
+    /// ARM64 userspace kernel stacks are owned by scheduler threads because the
+    /// scheduler clone can outlive the process-table copy until it has fully
+    /// disappeared from CPU current/previous slots.
+    #[cfg(target_arch = "aarch64")]
+    pub fn reclaim_terminated_threads(&mut self) {
+        for queue in self.per_cpu_queues.iter_mut() {
+            queue.retain(|&thread_id| {
+                self.threads.iter().any(|thread| {
+                    thread.id() == thread_id && thread.state != ThreadState::Terminated
+                })
+            });
+        }
+
+        self.threads.retain(|thread| {
+            if thread.state != ThreadState::Terminated {
+                return true;
+            }
+
+            let thread_id = thread.id();
+            (0..MAX_CPUS).any(|cpu| {
+                self.cpu_state[cpu].current_thread == Some(thread_id)
+                    || self.cpu_state[cpu].previous_thread == Some(thread_id)
+                    || self.cpu_state[cpu].idle_thread == thread_id
+            })
+        });
+    }
+
     /// Add a thread as the current running thread without scheduling.
     ///
     /// Used when manually starting the first userspace thread (init process).
@@ -2165,8 +2194,7 @@ impl Scheduler {
                         tid,
                         tid,
                         0,
-                        ((was_blocked_on_io as u32) << 31)
-                            | self.ready_queue_length() as u32,
+                        ((was_blocked_on_io as u32) << 31) | self.ready_queue_length() as u32,
                     );
                 }
                 continue;
@@ -2216,8 +2244,7 @@ impl Scheduler {
                         tid,
                         tid,
                         0,
-                        ((was_blocked_on_io as u32) << 31)
-                            | self.ready_queue_length() as u32,
+                        ((was_blocked_on_io as u32) << 31) | self.ready_queue_length() as u32,
                     );
                     ENQUEUE_DEFERRED.fetch_add(1, Ordering::Relaxed);
                 } else if already_queued {
@@ -2226,8 +2253,7 @@ impl Scheduler {
                         tid,
                         tid,
                         0,
-                        ((was_blocked_on_io as u32) << 31)
-                            | self.ready_queue_length() as u32,
+                        ((was_blocked_on_io as u32) << 31) | self.ready_queue_length() as u32,
                     );
                     ENQUEUE_ALREADY_QUEUED_OK.fetch_add(1, Ordering::Relaxed);
                 }
@@ -2512,6 +2538,16 @@ pub fn spawn_front(thread: Box<Thread>) {
             }
         } else {
             panic!("Scheduler not initialized");
+        }
+    });
+}
+
+#[cfg(target_arch = "aarch64")]
+pub fn reclaim_terminated_threads() {
+    without_interrupts(|| {
+        let mut scheduler_lock = SCHEDULER.lock();
+        if let Some(scheduler) = scheduler_lock.as_mut() {
+            scheduler.reclaim_terminated_threads();
         }
     });
 }


### PR DESCRIPTION
## Summary
- replace the ARM64 kernel stack bump allocator with bitmap-backed reuse
- move fork-child kernel stack ownership into the scheduler clone so waitpid cannot free a stack while CPU scheduler state may still reference it
- reclaim fully retired terminated scheduler threads before ARM64 fork consumes another stack slot

## Root cause
TURN 337 reproduced the inbound bsshd degradation on a fresh ARM64/Parallels boot at strict-host-key handshake 91, after 90 successful SSH exec sessions. Serial showed bsshd accepted the connection and reached fork, then failed with Os(ENOMEM). That points to ARM64 fork/kernel-stack allocation, not TCP receive or userspace SSH packet handling.

## Verification
- rustfmt --check kernel/src/memory/kernel_stack.rs kernel/src/process/manager.rs kernel/src/task/scheduler.rs kernel/src/arch_impl/aarch64/syscall_entry.rs
- git diff --check -- kernel/src/memory/kernel_stack.rs kernel/src/process/manager.rs kernel/src/task/scheduler.rs kernel/src/arch_impl/aarch64/syscall_entry.rs
- cargo build --release --features testing,external_test_bins --bin qemu-uefi (exit 0, warning/error grep empty)
- fresh ARM64 Parallels run: 150/150 strict-host-key inbound bsshd handshakes with echo OK-FIXED2-NNN && uname

Artifacts: /Users/wrb/Downloads/Ralph/breenix-interrupt-io-roadmap-1780056222/turn337-artifacts/

Note: full cargo fmt is still blocked by pre-existing unrelated trailing whitespace in tests/shared_qemu.rs; the touched files were checked with rustfmt directly.