### PR TITLE
Block ARM64 exec with live CLONE_VM siblings

### DIFF
--- a/kernel/src/arch_impl/aarch64/syscall_entry.rs
+++ b/kernel/src/arch_impl/aarch64/syscall_entry.rs
@@ -1298,7 +1298,11 @@ fn sys_exec_aarch64(
                 }
                 Err(e) => {
                     log::error!("sys_exec_aarch64: Failed to exec process: {}", e);
-                    (-12_i64) as u64
+                    if e == "exec blocked while CLONE_VM sibling shares old address space" {
+                        (-11_i64) as u64 // -EAGAIN
+                    } else {
+                        (-12_i64) as u64 // -ENOMEM
+                    }
                 }
             }
         } else {

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -43,6 +43,40 @@ pub struct ProcessManager {
 
 impl ProcessManager {
     #[cfg(target_arch = "aarch64")]
+    fn find_live_clone_vm_sibling_holding_cr3(
+        &self,
+        pid: ProcessId,
+        thread_group_id: u64,
+        old_cr3: u64,
+    ) -> Option<(ProcessId, u64)> {
+        self.processes
+            .iter()
+            .find_map(|(&candidate_pid, candidate)| {
+                if candidate_pid == pid || candidate.is_terminated() {
+                    return None;
+                }
+
+                let candidate_thread_group_id = candidate.thread_group_id?;
+                if candidate_thread_group_id != thread_group_id {
+                    return None;
+                }
+
+                if candidate.inherited_cr3 != Some(old_cr3) {
+                    return None;
+                }
+
+                if let Some(thread) = candidate.main_thread.as_ref() {
+                    if thread.state == crate::task::thread::ThreadState::Terminated {
+                        return None;
+                    }
+                    Some((candidate_pid, thread.id))
+                } else {
+                    Some((candidate_pid, 0))
+                }
+            })
+    }
+
+    #[cfg(target_arch = "aarch64")]
     fn map_initial_arm64_tls(
         page_table: &mut ProcessPageTable,
         tls_base: VirtAddr,
@@ -2969,16 +3003,37 @@ impl ProcessManager {
         // a use-after-free on exec failure: if any subsequent operation fails, the Err return
         // would drop the old Box<ProcessPageTable>, freeing physical memory while TTBR0_EL1
         // still points to it. The old page table is taken later, after all fallible ops succeed.
-        let thread_id = {
-            let process = self.processes.get_mut(&pid).ok_or("Process not found")?;
-            // Drain any pending old page tables from previous exec() calls.
-            process.drain_old_page_tables();
+        let (thread_id, old_cr3, thread_group_id) = {
+            let process = self.processes.get(&pid).ok_or("Process not found")?;
+            let old_cr3 = process.cr3_value();
+            let thread_group_id = process.thread_group_id.unwrap_or(pid.as_u64());
             let main_thread = process
                 .main_thread
                 .as_ref()
                 .ok_or("Process has no main thread")?;
-            main_thread.id
+            (main_thread.id, old_cr3, thread_group_id)
         };
+
+        if let Some(old_cr3) = old_cr3 {
+            if let Some((sibling_pid, sibling_thread_id)) =
+                self.find_live_clone_vm_sibling_holding_cr3(pid, thread_group_id, old_cr3)
+            {
+                log::warn!(
+                    "exec_process_with_argv [ARM64]: rejecting exec for PID {} while CLONE_VM sibling PID {} thread {} still holds inherited CR3 {:#x}",
+                    pid.as_u64(),
+                    sibling_pid.as_u64(),
+                    sibling_thread_id,
+                    old_cr3
+                );
+                return Err("exec blocked while CLONE_VM sibling shares old address space");
+            }
+        }
+
+        {
+            let process = self.processes.get_mut(&pid).ok_or("Process not found")?;
+            // Drain any pending old page tables from previous exec() calls.
+            process.drain_old_page_tables();
+        }
 
         log::info!(
             "exec_process_with_argv [ARM64]: Preserving thread ID {} for process {}",

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -79,6 +79,10 @@ name = "clock_gettime_test"
 path = "src/clock_gettime_test.rs"
 
 [[bin]]
+name = "clonevm_exec_test"
+path = "src/clonevm_exec_test.rs"
+
+[[bin]]
 name = "file_read_test"
 path = "src/file_read_test.rs"
 

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -180,6 +180,7 @@ STD_BINARIES=(
     "argv_test"
     "job_table_test"
     "test_mmap"
+    "clonevm_exec_test"
     "stdin_test"
     "true_test"
     "false_test"

--- a/userspace/programs/src/clonevm_exec_test.rs
+++ b/userspace/programs/src/clonevm_exec_test.rs
@@ -1,0 +1,219 @@
+//! Runtime proof for CLONE_VM sibling lifetime across parent exec.
+//!
+//! The child remains alive in the parent's old address space while the parent
+//! attempts exec. Fixed ARM64 kernels must reject that exec with EAGAIN.
+
+use libbreenix::errno::Errno;
+use libbreenix::error::Error;
+use libbreenix::memory;
+use libbreenix::process;
+use std::ptr;
+
+const SHARED_ALIVE_OFFSET: usize = 0;
+const SHARED_COMMAND_OFFSET: usize = 8;
+const SHARED_TID_OFFSET: usize = 16;
+const CHILD_STACK_SIZE: usize = 64 * 1024;
+const CHILD_SPIN_LIMIT: u64 = 250_000_000;
+
+extern "C" {
+    fn write(fd: i32, buf: *const u8, count: usize) -> isize;
+}
+
+unsafe fn raw_msg(msg: &[u8]) {
+    write(2, msg.as_ptr(), msg.len());
+}
+
+unsafe fn sys_yield() {
+    #[cfg(target_arch = "x86_64")]
+    core::arch::asm!("int 0x80", in("rax") 24u64, options(nostack));
+    #[cfg(target_arch = "aarch64")]
+    core::arch::asm!("svc #0", in("x8") 124u64, in("x0") 0u64, options(nostack));
+}
+
+unsafe fn thread_exit(code: u64) -> ! {
+    #[cfg(target_arch = "x86_64")]
+    core::arch::asm!(
+        "int 0x80",
+        "2:",
+        "pause",
+        "jmp 2b",
+        in("rax") 60u64,
+        in("rdi") code,
+        options(noreturn),
+    );
+    #[cfg(target_arch = "aarch64")]
+    core::arch::asm!(
+        "svc #0",
+        "2:",
+        "yield",
+        "b 2b",
+        in("x8") 93u64,
+        in("x0") code,
+        options(noreturn),
+    );
+}
+
+extern "C" fn child_fn(arg: *mut u8) -> *mut u8 {
+    unsafe {
+        raw_msg(b"CLONEVM_EXEC_TEST: child spinning (alive)\n");
+
+        let alive = arg.add(SHARED_ALIVE_OFFSET) as *mut u64;
+        let command = arg.add(SHARED_COMMAND_OFFSET) as *mut u64;
+        core::ptr::write_volatile(alive, 1);
+
+        for i in 0..CHILD_SPIN_LIMIT {
+            if core::ptr::read_volatile(command) == 2 {
+                raw_msg(b"CLONEVM_EXEC_TEST: child release observed\n");
+                thread_exit(0);
+            }
+
+            core::ptr::write_volatile(alive, i | 1);
+            if i % 1024 == 0 {
+                sys_yield();
+            }
+        }
+
+        raw_msg(b"CLONEVM_EXEC_TEST: child spin limit reached\n");
+        thread_exit(0);
+    }
+}
+
+fn errno_number(errno: Errno) -> i64 {
+    errno as i64
+}
+
+fn main() {
+    if std::env::args().nth(1).as_deref() == Some("--second-stage") {
+        unsafe {
+            raw_msg(b"CLONEVM_EXEC_TEST: second stage calling exec\n");
+        }
+        match process::exec(b"/bin/simple_exit\0") {
+            Ok(_) => unreachable!(),
+            Err(Error::Os(errno)) => {
+                eprintln!(
+                    "CLONEVM_EXEC_TEST: second stage exec returned errno={}",
+                    errno_number(errno)
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
+    unsafe {
+        raw_msg(b"CLONEVM_EXEC_TEST: start\n");
+
+        let stack = match memory::mmap(
+            core::ptr::null_mut(),
+            CHILD_STACK_SIZE,
+            3,
+            0x22,
+            -1,
+            0,
+        ) {
+            Ok(ptr) => ptr,
+            Err(_) => {
+                raw_msg(b"CLONEVM_EXEC_TEST: ERROR stack mmap failed\n");
+                std::process::exit(1);
+            }
+        };
+
+        let shared = match memory::mmap(core::ptr::null_mut(), 4096, 3, 0x22, -1, 0) {
+            Ok(ptr) => ptr,
+            Err(_) => {
+                raw_msg(b"CLONEVM_EXEC_TEST: ERROR shared mmap failed\n");
+                std::process::exit(1);
+            }
+        };
+
+        let alive = shared.add(SHARED_ALIVE_OFFSET) as *mut u64;
+        let command = shared.add(SHARED_COMMAND_OFFSET) as *mut u64;
+        let tid_addr = shared.add(SHARED_TID_OFFSET) as *mut u32;
+        core::ptr::write_volatile(alive, 0);
+        core::ptr::write_volatile(command, 0);
+        core::ptr::write_volatile(tid_addr, 0xFFFF);
+
+        let stack_top = (stack as usize + CHILD_STACK_SIZE) & !0xF;
+        let flags: u64 = 0x00000100 | 0x00000400 | 0x00200000 | 0x01000000;
+
+        raw_msg(b"CLONEVM_EXEC_TEST: parent calling clone\n");
+        let ret: i64;
+        #[cfg(target_arch = "x86_64")]
+        core::arch::asm!(
+            "int 0x80",
+            in("rax") 56u64,
+            in("rdi") flags,
+            in("rsi") stack_top as u64,
+            in("rdx") child_fn as u64,
+            in("r10") shared as u64,
+            in("r8") tid_addr as u64,
+            lateout("rax") ret,
+            options(nostack),
+        );
+        #[cfg(target_arch = "aarch64")]
+        core::arch::asm!(
+            "svc #0",
+            in("x8") 220u64,
+            inlateout("x0") flags as u64 => ret,
+            in("x1") stack_top as u64,
+            in("x2") child_fn as u64,
+            in("x3") shared as u64,
+            in("x4") tid_addr as u64,
+            options(nostack),
+        );
+
+        if ret < 0 {
+            raw_msg(b"CLONEVM_EXEC_TEST: ERROR clone failed\n");
+            std::process::exit(1);
+        }
+
+        raw_msg(b"CLONEVM_EXEC_TEST: parent waiting for live child\n");
+        for _ in 0..2_000_000u64 {
+            if core::ptr::read_volatile(alive) != 0 {
+                break;
+            }
+            sys_yield();
+        }
+
+        if core::ptr::read_volatile(alive) == 0 {
+            raw_msg(b"CLONEVM_EXEC_TEST: ERROR child did not report alive\n");
+            std::process::exit(1);
+        }
+
+        let program = b"/usr/local/test/bin/clonevm_exec_test\0";
+        let arg0 = b"clonevm_exec_test\0";
+        let arg1 = b"--second-stage\0";
+        let argv: [*const u8; 3] = [arg0.as_ptr(), arg1.as_ptr(), ptr::null()];
+
+        raw_msg(b"CLONEVM_EXEC_TEST: parent calling exec\n");
+        match process::execv(program, argv.as_ptr()) {
+            Ok(_) => unreachable!(),
+            Err(Error::Os(errno)) => {
+                let errno_value = errno_number(errno);
+                eprintln!("CLONEVM_EXEC_TEST: exec returned errno={}", errno_value);
+                if errno == Errno::EAGAIN {
+                    raw_msg(b"CLONEVM_EXEC_TEST: fixed path observed EAGAIN\n");
+                    core::ptr::write_volatile(command, 2);
+
+                    for _ in 0..2_000_000u64 {
+                        if core::ptr::read_volatile(tid_addr) == 0 {
+                            break;
+                        }
+                        sys_yield();
+                    }
+
+                    if core::ptr::read_volatile(tid_addr) == 0 {
+                        raw_msg(b"CLONEVM_EXEC_TEST: child exited after release\n");
+                        raw_msg(b"CLONEVM_EXEC_TEST: PASS\n");
+                        std::process::exit(0);
+                    }
+
+                    raw_msg(b"CLONEVM_EXEC_TEST: ERROR child did not exit after release\n");
+                    std::process::exit(1);
+                }
+
+                raw_msg(b"CLONEVM_EXEC_TEST: ERROR unexpected exec errno\n");
+                std::process::exit(1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add an ARM64 exec guard that detects live CLONE_VM siblings still holding the old inherited CR3 before draining/freeing the parent's old page table.
- Return `-EAGAIN` for that specific stopgap rejection from the ARM64 exec syscall path.
- Close `breenix-45i` with a conservative stopgap until proper POSIX thread-group exec teardown exists.

## Root cause
`sys_clone` creates CLONE_VM siblings as separate `Process` objects and stores the parent's page-table root in `inherited_cr3`. ARM64 exec later replaces and drains the parent's old page table, but previously did not clear or reject siblings still holding that old CR3. If such a sibling survived parent exec, context switching it could reinstall a freed address-space root.

## Reproduction note
A fresh pre-fix Parallels boot reached the direct CLONE_VM path through `/bin/hello_world` and completed the thread test, but the current `hello_world` program waits for the child and does not parent-exec afterward. I did not observe a hard UAF crash from the existing binary alone; the crash condition is code-proven by the stale `inherited_cr3` lifetime and would require parent exec with a live CLONE_VM sibling.

## Verification
- `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64`
- warning/error grep over that build log: 0 lines
- Fresh post-fix Parallels boot: bsshd listening, boot script completed, Bounce started and sustained FPS/heartbeat output
- Post-fix `/bin/hello_world` rerun over SSH: CLONE_VM thread test completed and `All std tests passed!`
- Post-fix serial marker counts: `DATA_ABORT=0`, `UNHANDLED_EC=0`, `FATAL=0`, `PANIC=0`, `SCHED_RESCUE=0`, `SOFT_LOCKUP=0`, `DEFER_SNAP/TRACE BUFFER DUMP=0`