### PR TITLE
EC=0x0 campaign round 1: EL1 fault circuit-breaker, first-fault evidence probe, attributable scheduler diagnostics

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(never)", "cfg(feature, values(\"particle_animation\", \"xhci_linux_harness\"))"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(never)", "cfg(feature, values(\"ec0_fault_inject\", \"particle_animation\", \"xhci_linux_harness\"))"] }
 
 [[bin]]
 name = "kernel"
@@ -40,6 +40,7 @@ test_page_fault = []
 test_userspace = []
 test_all_exceptions = []
 external_test_bins = []
+ec0_fault_inject = []  # Inject one EL1 UDF on CPU 0 after about 10 seconds
 vmnet = []  # Use vmnet network config (192.168.64.x) instead of SLIRP (10.0.2.x)
 interactive = ["testing"]  # Boot into init_shell instead of running automated tests
 

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -15,9 +15,16 @@ fn main() {
         (ts.subsec_nanos() >> 16) & 0xFFFF
     );
     println!("cargo:rustc-env=BREENIX_BUILD_ID={}", build_id);
-    // Rerun whenever xhci.rs changes (we always `touch` it before building,
-    // so the build ID is always fresh for each deploy cycle).
-    println!("cargo:rerun-if-changed=src/drivers/usb/xhci.rs");
+    // Rerun whenever ANY kernel source file changes, so BUILD_ID always
+    // reflects the actual build and never lies about staleness.
+    //
+    // NOTE: emitting any `cargo:rerun-if-changed` disables cargo's default
+    // "rerun if anything in the package changed" behavior, so without this
+    // directive BUILD_ID only re-stamped on the few files explicitly listed
+    // below (e.g. xhci.rs) -- a stale BUILD_ID silently misled a validation
+    // run once. Cargo recursively watches the whole tree when given a
+    // directory path, so this restores honest "any source change" coverage.
+    println!("cargo:rerun-if-changed=src");
 
     // Get absolute paths from Cargo environment
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -1042,6 +1042,85 @@ pub fn dump_all_save_skew_snapshots() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// INLINE_SAVE_SKEW detection (diagnostic only, no behavior change)
+//
+// SAVE_SKEW (above) instruments `save_userspace_context_inline` /
+// `save_kernel_context_inline`, the two save writers reached from the
+// exception-frame (`check_need_resched_and_switch_arm64`) path. Those are NOT
+// the only place a thread's context gets saved: `schedule_from_kernel`'s
+// cooperative-yield / inline-schedule path saves the outgoing thread's
+// callee-saved registers via the `aarch64_inline_schedule_switch` asm helper
+// (x19-x30 + sp, stored directly into `Thread.context` at fixed offsets) with
+// no SAVE_SKEW-style gate at all. This probe closes that gap: it fires when
+// idle was the thread actually executing on entry to `schedule_from_kernel`
+// (`entered_idle_executing`) but the scheduling decision picked a NON-idle
+// `old_id` as the save target -- i.e. the imminent asm save is about to write
+// idle's live register file into a non-idle thread's context, the same
+// mechanism documented in ROOT_CAUSE.md's cpu_state/old_id skew candidate.
+//
+// Strictly lock-free atomics; written only on the (rare) bad-save condition.
+// Record-and-continue only -- no logging in the save path itself, no lock
+// acquisition, no behavior change.
+static INLINE_SAVE_SKEW_SEEN: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS] =
+    [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
+static INLINE_SAVE_SKEW_OLD_ID: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS] =
+    [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
+static INLINE_SAVE_SKEW_SP: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS] =
+    [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
+
+/// Record a bad inline-schedule save (idle executing, but the save target is
+/// a non-idle thread) into this CPU's last-wins INLINE_SAVE_SKEW slot.
+/// Lock-free; only the cheap atomic stores below run, and only when the
+/// caller has already confirmed the bad-save condition.
+#[inline(always)]
+fn record_inline_save_skew(cpu_id: usize, old_id: u64, sp: u64) {
+    if cpu_id >= crate::arch_impl::aarch64::constants::MAX_CPUS {
+        return;
+    }
+    INLINE_SAVE_SKEW_OLD_ID[cpu_id].store(old_id, Ordering::Relaxed);
+    INLINE_SAVE_SKEW_SP[cpu_id].store(sp, Ordering::Relaxed);
+    // Publish last (release) so a reader that sees SEEN!=0 also sees the fields.
+    INLINE_SAVE_SKEW_SEEN[cpu_id].store(1, Ordering::Release);
+}
+
+/// Read-side accessor for the INLINE_SAVE_SKEW slot, used by the fatal
+/// postmortem in exception.rs. Returns None if no bad inline-schedule save
+/// was recorded on this CPU. Fields: (old_id, sp).
+pub fn inline_save_skew_snapshot(cpu_id: usize) -> Option<(u64, u64)> {
+    if cpu_id >= crate::arch_impl::aarch64::constants::MAX_CPUS {
+        return None;
+    }
+    if INLINE_SAVE_SKEW_SEEN[cpu_id].load(Ordering::Acquire) == 0 {
+        return None;
+    }
+    Some((
+        INLINE_SAVE_SKEW_OLD_ID[cpu_id].load(Ordering::Relaxed),
+        INLINE_SAVE_SKEW_SP[cpu_id].load(Ordering::Relaxed),
+    ))
+}
+
+/// All-CPU [INLINE_SAVE_SKEW] postmortem readout, modeled on
+/// `dump_all_save_skew_snapshots`.
+pub fn dump_all_inline_save_skew_snapshots() {
+    let mut any_recorded = false;
+    for cpu_id in 0..crate::arch_impl::aarch64::constants::MAX_CPUS {
+        if let Some((old_id, sp)) = inline_save_skew_snapshot(cpu_id) {
+            any_recorded = true;
+            raw_uart_str("[INLINE_SAVE_SKEW] cpu=");
+            raw_uart_dec(cpu_id as u64);
+            raw_uart_str(" old_id=");
+            raw_uart_dec(old_id);
+            raw_uart_str(" sp=");
+            raw_uart_hex(sp);
+            raw_uart_str("\n");
+        }
+    }
+    if !any_recorded {
+        raw_uart_str("[INLINE_SAVE_SKEW] none recorded on any cpu\n");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
 // DISPATCH_MISMATCH detection (diagnostic only, no behavior change)
 //
 // Confirms/refutes the "frame was never rebuilt from context" half of the
@@ -3868,6 +3947,27 @@ pub fn schedule_from_kernel() {
         new_id as u16,
     );
     crate::task::scheduler::increment_context_switch_count();
+
+    // INLINE_SAVE_SKEW probe (record-and-continue, no behavior change): the
+    // upcoming `aarch64_inline_schedule_switch` call below performs the
+    // uninstrumented x19-x30+sp save for this (the inline-schedule /
+    // cooperative-yield) path -- a save writer that neither SAVE_SKEW nor
+    // ERET_ANOMALY instruments (those cover the exception-frame save/dispatch
+    // paths only). If idle was the thread actually executing when this
+    // function was entered (`entered_idle_executing`, captured above, valid
+    // throughout since interrupts stay disabled) but the save target `old_id`
+    // is NON-idle, the imminent asm save is about to write idle's live
+    // register file into a non-idle thread's context -- the same bug family
+    // as SAVE_SKEW/ERET_ANOMALY, caught here at this other writer instead.
+    // Lock-free, last-wins per CPU. See dump_all_inline_save_skew_snapshots
+    // for the postmortem readout.
+    if entered_idle_executing && !sched.is_idle_thread_inner(old_id) {
+        let probe_sp: u64;
+        unsafe {
+            core::arch::asm!("mov {}, sp", out(reg) probe_sp, options(nomem, nostack, preserves_flags));
+        }
+        record_inline_save_skew(cpu_id, old_id, probe_sp);
+    }
 
     let old_context_ptr = match sched.get_thread_mut(old_id) {
         Some(old_thread) => {

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -1042,6 +1042,131 @@ pub fn dump_all_save_skew_snapshots() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// IDLE_REDIRECT history (diagnostic only, no behavior change)
+
+#[derive(Clone, Copy)]
+#[repr(u64)]
+enum IdleRedirectReason {
+    IdleDispatch = 1,
+    ThreadMissing = 2,
+    ThreadTerminated = 3,
+    KernelTtbrPmLockBusy = 4,
+    KernelProcessGone = 5,
+    KernelRestoreFailed = 6,
+    UserBadContext = 7,
+    UserTtbrPmLockBusy = 8,
+    UserProcessGone = 9,
+}
+
+impl IdleRedirectReason {
+    fn from_code(code: u64) -> Option<Self> {
+        match code {
+            1 => Some(Self::IdleDispatch),
+            2 => Some(Self::ThreadMissing),
+            3 => Some(Self::ThreadTerminated),
+            4 => Some(Self::KernelTtbrPmLockBusy),
+            5 => Some(Self::KernelProcessGone),
+            6 => Some(Self::KernelRestoreFailed),
+            7 => Some(Self::UserBadContext),
+            8 => Some(Self::UserTtbrPmLockBusy),
+            9 => Some(Self::UserProcessGone),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::IdleDispatch => "IDLE_DISPATCH",
+            Self::ThreadMissing => "THREAD_MISSING",
+            Self::ThreadTerminated => "THREAD_TERMINATED",
+            Self::KernelTtbrPmLockBusy => "KERNEL_TTBR_PM_LOCK_BUSY",
+            Self::KernelProcessGone => "KERNEL_PROCESS_GONE",
+            Self::KernelRestoreFailed => "KERNEL_RESTORE_FAILED",
+            Self::UserBadContext => "USER_BAD_CONTEXT",
+            Self::UserTtbrPmLockBusy => "USER_TTBR_PM_LOCK_BUSY",
+            Self::UserProcessGone => "USER_PROCESS_GONE",
+        }
+    }
+}
+
+const IDLE_REDIRECT_HISTORY_SIZE: usize = 64;
+const IDLE_REDIRECT_FIELDS: usize = 4;
+static IDLE_REDIRECT_HISTORY: [[AtomicU64; IDLE_REDIRECT_HISTORY_SIZE * IDLE_REDIRECT_FIELDS];
+    crate::arch_impl::aarch64::constants::MAX_CPUS] = {
+    const INIT_FIELD: AtomicU64 = AtomicU64::new(0);
+    const INIT_CPU: [AtomicU64; IDLE_REDIRECT_HISTORY_SIZE * IDLE_REDIRECT_FIELDS] =
+        [INIT_FIELD; IDLE_REDIRECT_HISTORY_SIZE * IDLE_REDIRECT_FIELDS];
+    [INIT_CPU; crate::arch_impl::aarch64::constants::MAX_CPUS]
+};
+static IDLE_REDIRECT_HISTORY_IDX: [AtomicU64;
+    crate::arch_impl::aarch64::constants::MAX_CPUS] =
+    [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
+
+#[inline(never)]
+fn record_idle_redirect(
+    cpu_id: usize,
+    reason: IdleRedirectReason,
+    current_before: u64,
+    current_after: u64,
+) {
+    if cpu_id >= crate::arch_impl::aarch64::constants::MAX_CPUS {
+        return;
+    }
+    let index = IDLE_REDIRECT_HISTORY_IDX[cpu_id].fetch_add(1, Ordering::Relaxed) as usize;
+    let base = (index % IDLE_REDIRECT_HISTORY_SIZE) * IDLE_REDIRECT_FIELDS;
+    IDLE_REDIRECT_HISTORY[cpu_id][base].store(reason as u64, Ordering::Relaxed);
+    IDLE_REDIRECT_HISTORY[cpu_id][base + 1].store(cpu_id as u64, Ordering::Relaxed);
+    IDLE_REDIRECT_HISTORY[cpu_id][base + 2].store(current_before, Ordering::Relaxed);
+    IDLE_REDIRECT_HISTORY[cpu_id][base + 3].store(current_after, Ordering::Relaxed);
+}
+
+/// Dump the bounded, per-CPU setup_idle_return_locked event history.
+pub fn dump_all_idle_redirect_histories() {
+    for cpu_id in 0..crate::arch_impl::aarch64::constants::MAX_CPUS {
+        let total = IDLE_REDIRECT_HISTORY_IDX[cpu_id].load(Ordering::Relaxed) as usize;
+        let count = total.min(IDLE_REDIRECT_HISTORY_SIZE);
+        if count == 0 {
+            continue;
+        }
+        let start = total.saturating_sub(IDLE_REDIRECT_HISTORY_SIZE);
+        raw_uart_str("[IDLE_REDIRECT_HISTORY] cpu=");
+        raw_uart_dec(cpu_id as u64);
+        raw_uart_str(" last=");
+        raw_uart_dec(count as u64);
+        raw_uart_str(" total=");
+        raw_uart_dec(total as u64);
+        raw_uart_str("\n");
+        for index in start..total {
+            let base = (index % IDLE_REDIRECT_HISTORY_SIZE) * IDLE_REDIRECT_FIELDS;
+            let reason_code =
+                IDLE_REDIRECT_HISTORY[cpu_id][base].load(Ordering::Relaxed);
+            let recorded_cpu =
+                IDLE_REDIRECT_HISTORY[cpu_id][base + 1].load(Ordering::Relaxed);
+            let current_before =
+                IDLE_REDIRECT_HISTORY[cpu_id][base + 2].load(Ordering::Relaxed);
+            let current_after =
+                IDLE_REDIRECT_HISTORY[cpu_id][base + 3].load(Ordering::Relaxed);
+            raw_uart_str("  [");
+            raw_uart_dec(index as u64);
+            raw_uart_str("] reason=");
+            raw_uart_dec(reason_code);
+            if let Some(reason) = IdleRedirectReason::from_code(reason_code) {
+                raw_uart_str("(");
+                raw_uart_str(reason.label());
+                raw_uart_str(")");
+            }
+            raw_uart_str(" cpu=");
+            raw_uart_dec(recorded_cpu);
+            raw_uart_str(" current_thread=");
+            raw_uart_dec(current_before);
+            raw_uart_str("->");
+            raw_uart_dec(current_after);
+            raw_uart_str("\n");
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
 // INLINE_SAVE_SKEW detection (diagnostic only, no behavior change)
 //
 // SAVE_SKEW (above) instruments `save_userspace_context_inline` /
@@ -1051,51 +1176,81 @@ pub fn dump_all_save_skew_snapshots() {
 // cooperative-yield / inline-schedule path saves the outgoing thread's
 // callee-saved registers via the `aarch64_inline_schedule_switch` asm helper
 // (x19-x30 + sp, stored directly into `Thread.context` at fixed offsets) with
-// no SAVE_SKEW-style gate at all. This probe closes that gap: it fires when
-// idle was the thread actually executing on entry to `schedule_from_kernel`
-// (`entered_idle_executing`) but the scheduling decision picked a NON-idle
-// `old_id` as the save target -- i.e. the imminent asm save is about to write
-// idle's live register file into a non-idle thread's context, the same
-// mechanism documented in ROOT_CAUSE.md's cpu_state/old_id skew candidate.
+// no SAVE_SKEW-style gate at all. This probe closes that gap in both
+// directions: idle registers targeting a non-idle thread, and non-idle
+// registers targeting an idle thread.
 //
 // Strictly lock-free atomics; written only on the (rare) bad-save condition.
 // Record-and-continue only -- no logging in the save path itself, no lock
 // acquisition, no behavior change.
-static INLINE_SAVE_SKEW_SEEN: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS] =
-    [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
-static INLINE_SAVE_SKEW_OLD_ID: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS] =
-    [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
-static INLINE_SAVE_SKEW_SP: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS] =
-    [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
+#[derive(Clone, Copy)]
+#[repr(usize)]
+enum InlineSaveSkewDirection {
+    IdleIntoNonIdle = 0,
+    NonIdleIntoIdle = 1,
+}
 
-/// Record a bad inline-schedule save (idle executing, but the save target is
-/// a non-idle thread) into this CPU's last-wins INLINE_SAVE_SKEW slot.
+impl InlineSaveSkewDirection {
+    const ALL: [Self; 2] = [Self::IdleIntoNonIdle, Self::NonIdleIntoIdle];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::IdleIntoNonIdle => "idle_into_non_idle",
+            Self::NonIdleIntoIdle => "non_idle_into_idle",
+        }
+    }
+}
+
+const INLINE_SAVE_SKEW_SLOTS: usize =
+    crate::arch_impl::aarch64::constants::MAX_CPUS * InlineSaveSkewDirection::ALL.len();
+static INLINE_SAVE_SKEW_SEEN: [AtomicU64; INLINE_SAVE_SKEW_SLOTS] =
+    [const { AtomicU64::new(0) }; INLINE_SAVE_SKEW_SLOTS];
+static INLINE_SAVE_SKEW_OLD_ID: [AtomicU64; INLINE_SAVE_SKEW_SLOTS] =
+    [const { AtomicU64::new(0) }; INLINE_SAVE_SKEW_SLOTS];
+static INLINE_SAVE_SKEW_SP: [AtomicU64; INLINE_SAVE_SKEW_SLOTS] =
+    [const { AtomicU64::new(0) }; INLINE_SAVE_SKEW_SLOTS];
+
+fn inline_save_skew_slot(cpu_id: usize, direction: InlineSaveSkewDirection) -> usize {
+    cpu_id * InlineSaveSkewDirection::ALL.len() + direction as usize
+}
+
+/// Record a bad inline-schedule save into this CPU/direction's last-wins slot.
 /// Lock-free; only the cheap atomic stores below run, and only when the
 /// caller has already confirmed the bad-save condition.
 #[inline(always)]
-fn record_inline_save_skew(cpu_id: usize, old_id: u64, sp: u64) {
+fn record_inline_save_skew(
+    cpu_id: usize,
+    direction: InlineSaveSkewDirection,
+    old_id: u64,
+    sp: u64,
+) {
     if cpu_id >= crate::arch_impl::aarch64::constants::MAX_CPUS {
         return;
     }
-    INLINE_SAVE_SKEW_OLD_ID[cpu_id].store(old_id, Ordering::Relaxed);
-    INLINE_SAVE_SKEW_SP[cpu_id].store(sp, Ordering::Relaxed);
+    let slot = inline_save_skew_slot(cpu_id, direction);
+    INLINE_SAVE_SKEW_OLD_ID[slot].store(old_id, Ordering::Relaxed);
+    INLINE_SAVE_SKEW_SP[slot].store(sp, Ordering::Relaxed);
     // Publish last (release) so a reader that sees SEEN!=0 also sees the fields.
-    INLINE_SAVE_SKEW_SEEN[cpu_id].store(1, Ordering::Release);
+    INLINE_SAVE_SKEW_SEEN[slot].store(1, Ordering::Release);
 }
 
 /// Read-side accessor for the INLINE_SAVE_SKEW slot, used by the fatal
-/// postmortem in exception.rs. Returns None if no bad inline-schedule save
-/// was recorded on this CPU. Fields: (old_id, sp).
-pub fn inline_save_skew_snapshot(cpu_id: usize) -> Option<(u64, u64)> {
+/// postmortem in exception.rs. Returns None if no bad inline-schedule save in
+/// this direction was recorded on this CPU. Fields: (old_id, sp).
+fn inline_save_skew_snapshot(
+    cpu_id: usize,
+    direction: InlineSaveSkewDirection,
+) -> Option<(u64, u64)> {
     if cpu_id >= crate::arch_impl::aarch64::constants::MAX_CPUS {
         return None;
     }
-    if INLINE_SAVE_SKEW_SEEN[cpu_id].load(Ordering::Acquire) == 0 {
+    let slot = inline_save_skew_slot(cpu_id, direction);
+    if INLINE_SAVE_SKEW_SEEN[slot].load(Ordering::Acquire) == 0 {
         return None;
     }
     Some((
-        INLINE_SAVE_SKEW_OLD_ID[cpu_id].load(Ordering::Relaxed),
-        INLINE_SAVE_SKEW_SP[cpu_id].load(Ordering::Relaxed),
+        INLINE_SAVE_SKEW_OLD_ID[slot].load(Ordering::Relaxed),
+        INLINE_SAVE_SKEW_SP[slot].load(Ordering::Relaxed),
     ))
 }
 
@@ -1104,15 +1259,19 @@ pub fn inline_save_skew_snapshot(cpu_id: usize) -> Option<(u64, u64)> {
 pub fn dump_all_inline_save_skew_snapshots() {
     let mut any_recorded = false;
     for cpu_id in 0..crate::arch_impl::aarch64::constants::MAX_CPUS {
-        if let Some((old_id, sp)) = inline_save_skew_snapshot(cpu_id) {
-            any_recorded = true;
-            raw_uart_str("[INLINE_SAVE_SKEW] cpu=");
-            raw_uart_dec(cpu_id as u64);
-            raw_uart_str(" old_id=");
-            raw_uart_dec(old_id);
-            raw_uart_str(" sp=");
-            raw_uart_hex(sp);
-            raw_uart_str("\n");
+        for direction in InlineSaveSkewDirection::ALL {
+            if let Some((old_id, sp)) = inline_save_skew_snapshot(cpu_id, direction) {
+                any_recorded = true;
+                raw_uart_str("[INLINE_SAVE_SKEW] cpu=");
+                raw_uart_dec(cpu_id as u64);
+                raw_uart_str(" direction=");
+                raw_uart_str(direction.label());
+                raw_uart_str(" old_id=");
+                raw_uart_dec(old_id);
+                raw_uart_str(" sp=");
+                raw_uart_hex(sp);
+                raw_uart_str("\n");
+            }
         }
     }
     if !any_recorded {
@@ -2529,7 +2688,9 @@ fn setup_idle_return_locked(
     sched: &mut Scheduler,
     frame: &mut Aarch64ExceptionFrame,
     cpu_id: usize,
+    reason: IdleRedirectReason,
 ) {
+    let current_before = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
     // Set frame ELR and SPSR to safe values FIRST
     let idle_addr = idle_loop_arm64 as *const () as u64;
     frame.elr = idle_addr;
@@ -2584,6 +2745,8 @@ fn setup_idle_return_locked(
         Aarch64PerCpu::set_current_thread_ptr(core::ptr::null_mut());
         Aarch64PerCpu::clear_preempt_active();
     }
+    let current_after = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
+    record_idle_redirect(cpu_id, reason, current_before, current_after);
 }
 
 /// Dispatch an idle thread — called inside scheduler lock hold.
@@ -2601,7 +2764,7 @@ fn dispatch_idle_locked(
     frame: &mut Aarch64ExceptionFrame,
     cpu_id: usize,
 ) {
-    setup_idle_return_locked(sched, frame, cpu_id);
+    setup_idle_return_locked(sched, frame, cpu_id, IdleRedirectReason::IdleDispatch);
 }
 
 /// Dispatch a non-idle thread — called inside scheduler lock hold.
@@ -2641,7 +2804,12 @@ fn dispatch_thread_locked(
             Some(info) => info,
             None => {
                 trace_dispatch_redirect(thread_id, TRACE_REDIRECT_THREAD_MISSING);
-                setup_idle_return_locked(sched, frame, cpu_id);
+                setup_idle_return_locked(
+                    sched,
+                    frame,
+                    cpu_id,
+                    IdleRedirectReason::ThreadMissing,
+                );
                 return;
             }
         };
@@ -2649,7 +2817,12 @@ fn dispatch_thread_locked(
     // DEFENSE: Verify thread is not terminated before dispatch.
     if state == ThreadState::Terminated {
         trace_dispatch_redirect(thread_id, TRACE_REDIRECT_THREAD_TERMINATED);
-        setup_idle_return_locked(sched, frame, cpu_id);
+        setup_idle_return_locked(
+            sched,
+            frame,
+            cpu_id,
+            IdleRedirectReason::ThreadTerminated,
+        );
         return;
     }
 
@@ -2695,8 +2868,17 @@ fn dispatch_thread_locked(
                     if let Some(thread) = sched.get_thread_mut(thread_id) {
                         thread.state = ThreadState::Ready;
                     }
-                    setup_idle_return_locked(sched, frame, cpu_id);
+                    setup_idle_return_locked(
+                        sched,
+                        frame,
+                        cpu_id,
+                        IdleRedirectReason::KernelTtbrPmLockBusy,
+                    );
                     let idle_id = sched.cpu_state[cpu_id].idle_thread;
+                    let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
+                    crate::task::scheduler::record_cpu_state_change(
+                        cpu_id, 10, old_val, idle_id,
+                    );
                     sched.cpu_state[cpu_id].current_thread = Some(idle_id);
                     sched.requeue_thread_after_save(thread_id);
                     sched.set_need_resched_inner();
@@ -2716,8 +2898,17 @@ fn dispatch_thread_locked(
                     if let Some(thread) = sched.get_thread_mut(thread_id) {
                         thread.state = ThreadState::Terminated;
                     }
-                    setup_idle_return_locked(sched, frame, cpu_id);
+                    setup_idle_return_locked(
+                        sched,
+                        frame,
+                        cpu_id,
+                        IdleRedirectReason::KernelProcessGone,
+                    );
                     let idle_id = sched.cpu_state[cpu_id].idle_thread;
+                    let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
+                    crate::task::scheduler::record_cpu_state_change(
+                        cpu_id, 11, old_val, idle_id,
+                    );
                     sched.cpu_state[cpu_id].current_thread = Some(idle_id);
                     return;
                 }
@@ -2756,8 +2947,15 @@ fn dispatch_thread_locked(
             if let Some(thread) = sched.get_thread_mut(thread_id) {
                 thread.state = ThreadState::Terminated;
             }
-            setup_idle_return_locked(sched, frame, cpu_id);
+            setup_idle_return_locked(
+                sched,
+                frame,
+                cpu_id,
+                IdleRedirectReason::KernelRestoreFailed,
+            );
             let idle_id = sched.cpu_state[cpu_id].idle_thread;
+            let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
+            crate::task::scheduler::record_cpu_state_change(cpu_id, 12, old_val, idle_id);
             sched.cpu_state[cpu_id].current_thread = Some(idle_id);
             return;
         }
@@ -2846,8 +3044,15 @@ fn dispatch_thread_locked(
                 if let Some(thread) = sched.get_thread_mut(thread_id) {
                     thread.state = ThreadState::Terminated;
                 }
-                setup_idle_return_locked(sched, frame, cpu_id);
+                setup_idle_return_locked(
+                    sched,
+                    frame,
+                    cpu_id,
+                    IdleRedirectReason::UserBadContext,
+                );
                 let idle_id = sched.cpu_state[cpu_id].idle_thread;
+                let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
+                crate::task::scheduler::record_cpu_state_change(cpu_id, 13, old_val, idle_id);
                 sched.cpu_state[cpu_id].current_thread = Some(idle_id);
                 return;
             }
@@ -2888,8 +3093,15 @@ fn dispatch_thread_locked(
                 if let Some(thread) = sched.get_thread_mut(thread_id) {
                     thread.state = ThreadState::Ready;
                 }
-                setup_idle_return_locked(sched, frame, cpu_id);
+                setup_idle_return_locked(
+                    sched,
+                    frame,
+                    cpu_id,
+                    IdleRedirectReason::UserTtbrPmLockBusy,
+                );
                 let idle_id = sched.cpu_state[cpu_id].idle_thread;
+                let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
+                crate::task::scheduler::record_cpu_state_change(cpu_id, 14, old_val, idle_id);
                 sched.cpu_state[cpu_id].current_thread = Some(idle_id);
                 sched.requeue_thread_after_save(thread_id);
                 sched.set_need_resched_inner();
@@ -2908,8 +3120,15 @@ fn dispatch_thread_locked(
                 if let Some(thread) = sched.get_thread_mut(thread_id) {
                     thread.state = ThreadState::Terminated;
                 }
-                setup_idle_return_locked(sched, frame, cpu_id);
+                setup_idle_return_locked(
+                    sched,
+                    frame,
+                    cpu_id,
+                    IdleRedirectReason::UserProcessGone,
+                );
                 let idle_id = sched.cpu_state[cpu_id].idle_thread;
+                let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
+                crate::task::scheduler::record_cpu_state_change(cpu_id, 15, old_val, idle_id);
                 sched.cpu_state[cpu_id].current_thread = Some(idle_id);
                 return;
             }
@@ -3955,18 +4174,24 @@ pub fn schedule_from_kernel() {
     // ERET_ANOMALY instruments (those cover the exception-frame save/dispatch
     // paths only). If idle was the thread actually executing when this
     // function was entered (`entered_idle_executing`, captured above, valid
-    // throughout since interrupts stay disabled) but the save target `old_id`
-    // is NON-idle, the imminent asm save is about to write idle's live
-    // register file into a non-idle thread's context -- the same bug family
-    // as SAVE_SKEW/ERET_ANOMALY, caught here at this other writer instead.
-    // Lock-free, last-wins per CPU. See dump_all_inline_save_skew_snapshots
-    // for the postmortem readout.
-    if entered_idle_executing && !sched.is_idle_thread_inner(old_id) {
+    // throughout since interrupts stay disabled) and the save target `old_id`
+    // disagrees about whether idle is running, the imminent asm save targets
+    // the wrong context class. Each direction has its own last-wins slot so
+    // one cannot overwrite evidence of the other direction.
+    let old_is_idle = sched.is_idle_thread_inner(old_id);
+    let inline_save_skew_direction = if entered_idle_executing && !old_is_idle {
+        Some(InlineSaveSkewDirection::IdleIntoNonIdle)
+    } else if !entered_idle_executing && old_is_idle {
+        Some(InlineSaveSkewDirection::NonIdleIntoIdle)
+    } else {
+        None
+    };
+    if let Some(direction) = inline_save_skew_direction {
         let probe_sp: u64;
         unsafe {
             core::arch::asm!("mov {}, sp", out(reg) probe_sp, options(nomem, nostack, preserves_flags));
         }
-        record_inline_save_skew(cpu_id, old_id, probe_sp);
+        record_inline_save_skew(cpu_id, direction, old_id, probe_sp);
     }
 
     let old_context_ptr = match sched.get_thread_mut(old_id) {

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -3813,9 +3813,26 @@ pub fn schedule_from_kernel() {
     }
 
     let real_thread_ptr = Aarch64PerCpu::current_thread_ptr();
+    // Captured once here, before the scheduling decision below: whether idle
+    // is the thread actually executing on this CPU right now. Interrupts are
+    // disabled for the remainder of this function (see disable_interrupts()
+    // above), so this stays accurate through the save-path INLINE_SAVE_SKEW
+    // check further down.
+    let entered_idle_executing = real_thread_ptr.is_null();
     if !real_thread_ptr.is_null() {
         let real_tid = unsafe { &*(real_thread_ptr as *const Thread) }.id();
         sched.fix_stale_idle_cpu_state(real_tid);
+    } else {
+        // current_thread_ptr is NULL: idle is the thread actually executing
+        // on this CPU. If cpu_state.current_thread still names a non-idle
+        // thread (stale from before an idle redirect that skipped updating
+        // cpu_state), correct it to idle now -- BEFORE
+        // schedule_deferred_requeue() below reads current_thread as the save
+        // target. Otherwise idle's live register file would be saved into
+        // that stale, unrelated non-idle thread's context. See
+        // Scheduler::fix_stale_current_thread_when_idle_executing and
+        // docs/planning/aarch64-launcher-spawn-crash/ROOT_CAUSE.md.
+        sched.fix_stale_current_thread_when_idle_executing();
     }
 
     let schedule_result = sched.schedule_deferred_requeue();

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -1104,18 +1104,20 @@ static IDLE_REDIRECT_HISTORY_IDX: [AtomicU64;
 
 #[inline(never)]
 fn record_idle_redirect(
+    sched: &Scheduler,
     cpu_id: usize,
     reason: IdleRedirectReason,
     current_before: u64,
-    current_after: u64,
 ) {
     if cpu_id >= crate::arch_impl::aarch64::constants::MAX_CPUS {
         return;
     }
+    let idle_thread = sched.cpu_state[cpu_id].idle_thread;
+    let current_after = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
     let index = IDLE_REDIRECT_HISTORY_IDX[cpu_id].fetch_add(1, Ordering::Relaxed) as usize;
     let base = (index % IDLE_REDIRECT_HISTORY_SIZE) * IDLE_REDIRECT_FIELDS;
     IDLE_REDIRECT_HISTORY[cpu_id][base].store(reason as u64, Ordering::Relaxed);
-    IDLE_REDIRECT_HISTORY[cpu_id][base + 1].store(cpu_id as u64, Ordering::Relaxed);
+    IDLE_REDIRECT_HISTORY[cpu_id][base + 1].store(idle_thread, Ordering::Relaxed);
     IDLE_REDIRECT_HISTORY[cpu_id][base + 2].store(current_before, Ordering::Relaxed);
     IDLE_REDIRECT_HISTORY[cpu_id][base + 3].store(current_after, Ordering::Relaxed);
 }
@@ -1138,14 +1140,10 @@ pub fn dump_all_idle_redirect_histories() {
         raw_uart_str("\n");
         for index in start..total {
             let base = (index % IDLE_REDIRECT_HISTORY_SIZE) * IDLE_REDIRECT_FIELDS;
-            let reason_code =
-                IDLE_REDIRECT_HISTORY[cpu_id][base].load(Ordering::Relaxed);
-            let recorded_cpu =
-                IDLE_REDIRECT_HISTORY[cpu_id][base + 1].load(Ordering::Relaxed);
-            let current_before =
-                IDLE_REDIRECT_HISTORY[cpu_id][base + 2].load(Ordering::Relaxed);
-            let current_after =
-                IDLE_REDIRECT_HISTORY[cpu_id][base + 3].load(Ordering::Relaxed);
+            let reason_code = IDLE_REDIRECT_HISTORY[cpu_id][base].load(Ordering::Relaxed);
+            let idle_thread = IDLE_REDIRECT_HISTORY[cpu_id][base + 1].load(Ordering::Relaxed);
+            let current_before = IDLE_REDIRECT_HISTORY[cpu_id][base + 2].load(Ordering::Relaxed);
+            let current_after = IDLE_REDIRECT_HISTORY[cpu_id][base + 3].load(Ordering::Relaxed);
             raw_uart_str("  [");
             raw_uart_dec(index as u64);
             raw_uart_str("] reason=");
@@ -1155,8 +1153,8 @@ pub fn dump_all_idle_redirect_histories() {
                 raw_uart_str(reason.label());
                 raw_uart_str(")");
             }
-            raw_uart_str(" cpu=");
-            raw_uart_dec(recorded_cpu);
+            raw_uart_str(" idle_thread=");
+            raw_uart_dec(idle_thread);
             raw_uart_str(" current_thread=");
             raw_uart_dec(current_before);
             raw_uart_str("->");
@@ -2688,8 +2686,7 @@ fn setup_idle_return_locked(
     sched: &mut Scheduler,
     frame: &mut Aarch64ExceptionFrame,
     cpu_id: usize,
-    reason: IdleRedirectReason,
-) {
+) -> u64 {
     let current_before = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
     // Set frame ELR and SPSR to safe values FIRST
     let idle_addr = idle_loop_arm64 as *const () as u64;
@@ -2745,8 +2742,7 @@ fn setup_idle_return_locked(
         Aarch64PerCpu::set_current_thread_ptr(core::ptr::null_mut());
         Aarch64PerCpu::clear_preempt_active();
     }
-    let current_after = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
-    record_idle_redirect(cpu_id, reason, current_before, current_after);
+    current_before
 }
 
 /// Dispatch an idle thread — called inside scheduler lock hold.
@@ -2764,7 +2760,8 @@ fn dispatch_idle_locked(
     frame: &mut Aarch64ExceptionFrame,
     cpu_id: usize,
 ) {
-    setup_idle_return_locked(sched, frame, cpu_id, IdleRedirectReason::IdleDispatch);
+    let current_before = setup_idle_return_locked(sched, frame, cpu_id);
+    record_idle_redirect(sched, cpu_id, IdleRedirectReason::IdleDispatch, current_before);
 }
 
 /// Dispatch a non-idle thread — called inside scheduler lock hold.
@@ -2804,11 +2801,12 @@ fn dispatch_thread_locked(
             Some(info) => info,
             None => {
                 trace_dispatch_redirect(thread_id, TRACE_REDIRECT_THREAD_MISSING);
-                setup_idle_return_locked(
+                let current_before = setup_idle_return_locked(sched, frame, cpu_id);
+                record_idle_redirect(
                     sched,
-                    frame,
                     cpu_id,
                     IdleRedirectReason::ThreadMissing,
+                    current_before,
                 );
                 return;
             }
@@ -2817,11 +2815,12 @@ fn dispatch_thread_locked(
     // DEFENSE: Verify thread is not terminated before dispatch.
     if state == ThreadState::Terminated {
         trace_dispatch_redirect(thread_id, TRACE_REDIRECT_THREAD_TERMINATED);
-        setup_idle_return_locked(
+        let current_before = setup_idle_return_locked(sched, frame, cpu_id);
+        record_idle_redirect(
             sched,
-            frame,
             cpu_id,
             IdleRedirectReason::ThreadTerminated,
+            current_before,
         );
         return;
     }
@@ -2868,18 +2867,17 @@ fn dispatch_thread_locked(
                     if let Some(thread) = sched.get_thread_mut(thread_id) {
                         thread.state = ThreadState::Ready;
                     }
-                    setup_idle_return_locked(
-                        sched,
-                        frame,
-                        cpu_id,
-                        IdleRedirectReason::KernelTtbrPmLockBusy,
-                    );
+                    let current_before = setup_idle_return_locked(sched, frame, cpu_id);
                     let idle_id = sched.cpu_state[cpu_id].idle_thread;
                     let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
-                    crate::task::scheduler::record_cpu_state_change(
-                        cpu_id, 10, old_val, idle_id,
-                    );
+                    crate::task::scheduler::record_cpu_state_change(cpu_id, 10, old_val, idle_id);
                     sched.cpu_state[cpu_id].current_thread = Some(idle_id);
+                    record_idle_redirect(
+                        sched,
+                        cpu_id,
+                        IdleRedirectReason::KernelTtbrPmLockBusy,
+                        current_before,
+                    );
                     sched.requeue_thread_after_save(thread_id);
                     sched.set_need_resched_inner();
                     return;
@@ -2898,18 +2896,17 @@ fn dispatch_thread_locked(
                     if let Some(thread) = sched.get_thread_mut(thread_id) {
                         thread.state = ThreadState::Terminated;
                     }
-                    setup_idle_return_locked(
-                        sched,
-                        frame,
-                        cpu_id,
-                        IdleRedirectReason::KernelProcessGone,
-                    );
+                    let current_before = setup_idle_return_locked(sched, frame, cpu_id);
                     let idle_id = sched.cpu_state[cpu_id].idle_thread;
                     let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
-                    crate::task::scheduler::record_cpu_state_change(
-                        cpu_id, 11, old_val, idle_id,
-                    );
+                    crate::task::scheduler::record_cpu_state_change(cpu_id, 11, old_val, idle_id);
                     sched.cpu_state[cpu_id].current_thread = Some(idle_id);
+                    record_idle_redirect(
+                        sched,
+                        cpu_id,
+                        IdleRedirectReason::KernelProcessGone,
+                        current_before,
+                    );
                     return;
                 }
             }
@@ -2947,16 +2944,17 @@ fn dispatch_thread_locked(
             if let Some(thread) = sched.get_thread_mut(thread_id) {
                 thread.state = ThreadState::Terminated;
             }
-            setup_idle_return_locked(
-                sched,
-                frame,
-                cpu_id,
-                IdleRedirectReason::KernelRestoreFailed,
-            );
+            let current_before = setup_idle_return_locked(sched, frame, cpu_id);
             let idle_id = sched.cpu_state[cpu_id].idle_thread;
             let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
             crate::task::scheduler::record_cpu_state_change(cpu_id, 12, old_val, idle_id);
             sched.cpu_state[cpu_id].current_thread = Some(idle_id);
+            record_idle_redirect(
+                sched,
+                cpu_id,
+                IdleRedirectReason::KernelRestoreFailed,
+                current_before,
+            );
             return;
         }
     } else {
@@ -3044,16 +3042,17 @@ fn dispatch_thread_locked(
                 if let Some(thread) = sched.get_thread_mut(thread_id) {
                     thread.state = ThreadState::Terminated;
                 }
-                setup_idle_return_locked(
-                    sched,
-                    frame,
-                    cpu_id,
-                    IdleRedirectReason::UserBadContext,
-                );
+                let current_before = setup_idle_return_locked(sched, frame, cpu_id);
                 let idle_id = sched.cpu_state[cpu_id].idle_thread;
                 let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
                 crate::task::scheduler::record_cpu_state_change(cpu_id, 13, old_val, idle_id);
                 sched.cpu_state[cpu_id].current_thread = Some(idle_id);
+                record_idle_redirect(
+                    sched,
+                    cpu_id,
+                    IdleRedirectReason::UserBadContext,
+                    current_before,
+                );
                 return;
             }
         }
@@ -3093,16 +3092,17 @@ fn dispatch_thread_locked(
                 if let Some(thread) = sched.get_thread_mut(thread_id) {
                     thread.state = ThreadState::Ready;
                 }
-                setup_idle_return_locked(
-                    sched,
-                    frame,
-                    cpu_id,
-                    IdleRedirectReason::UserTtbrPmLockBusy,
-                );
+                let current_before = setup_idle_return_locked(sched, frame, cpu_id);
                 let idle_id = sched.cpu_state[cpu_id].idle_thread;
                 let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
                 crate::task::scheduler::record_cpu_state_change(cpu_id, 14, old_val, idle_id);
                 sched.cpu_state[cpu_id].current_thread = Some(idle_id);
+                record_idle_redirect(
+                    sched,
+                    cpu_id,
+                    IdleRedirectReason::UserTtbrPmLockBusy,
+                    current_before,
+                );
                 sched.requeue_thread_after_save(thread_id);
                 sched.set_need_resched_inner();
                 return;
@@ -3120,16 +3120,17 @@ fn dispatch_thread_locked(
                 if let Some(thread) = sched.get_thread_mut(thread_id) {
                     thread.state = ThreadState::Terminated;
                 }
-                setup_idle_return_locked(
-                    sched,
-                    frame,
-                    cpu_id,
-                    IdleRedirectReason::UserProcessGone,
-                );
+                let current_before = setup_idle_return_locked(sched, frame, cpu_id);
                 let idle_id = sched.cpu_state[cpu_id].idle_thread;
                 let old_val = sched.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
                 crate::task::scheduler::record_cpu_state_change(cpu_id, 15, old_val, idle_id);
                 sched.cpu_state[cpu_id].current_thread = Some(idle_id);
+                record_idle_redirect(
+                    sched,
+                    cpu_id,
+                    IdleRedirectReason::UserProcessGone,
+                    current_before,
+                );
                 return;
             }
         }

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -30,6 +30,35 @@ pub static CPU0_LAST_SYNC_ELR: AtomicU64 = AtomicU64::new(0);
 static PC_ALIGN_VERBOSE_CAPTURED: AtomicBool = AtomicBool::new(false);
 static FATAL_POSTMORTEM_CAPTURED: [AtomicBool; 8] = [const { AtomicBool::new(false) }; 8];
 static EL1_UNHANDLED_FAULT_LATCHED: [AtomicBool; 8] = [const { AtomicBool::new(false) }; 8];
+static FATAL_POSTMORTEM_UART_LOCK: AtomicBool = AtomicBool::new(false);
+
+struct FatalPostmortemUartGuard {
+    acquired: bool,
+}
+
+impl Drop for FatalPostmortemUartGuard {
+    fn drop(&mut self) {
+        if self.acquired {
+            FATAL_POSTMORTEM_UART_LOCK.store(false, Ordering::Release);
+        }
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn acquire_fatal_postmortem_uart() -> FatalPostmortemUartGuard {
+    const MAX_SPINS: usize = 1_000_000;
+    for _ in 0..MAX_SPINS {
+        if FATAL_POSTMORTEM_UART_LOCK
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+        {
+            return FatalPostmortemUartGuard { acquired: true };
+        }
+        core::hint::spin_loop();
+    }
+    FatalPostmortemUartGuard { acquired: false }
+}
 
 struct El1FirstFaultEvidence {
     instruction_word: Option<u32>,
@@ -204,7 +233,9 @@ fn handle_unhandled_el1_exception(frame: &Aarch64ExceptionFrame, ec: u32, esr: u
             .is_ok();
     if first_fault {
         let evidence = capture_el1_first_fault_evidence(frame.elr);
+        let fatal_uart_guard = acquire_fatal_postmortem_uart();
         dump_el1_first_fault(frame, ec, esr, far, cpu_id, &evidence);
+        drop(fatal_uart_guard);
     }
 
     loop {
@@ -318,6 +349,8 @@ fn dump_fatal_postmortem_once(label: &str) {
     crate::arch_impl::aarch64::context_switch::dump_defer_requeue_snapshots();
     raw_uart_str("\n  Trace buffers:\n");
     crate::tracing::dump_all_buffers();
+    raw_uart_str("\n  Idle redirect histories:\n");
+    crate::arch_impl::aarch64::context_switch::dump_all_idle_redirect_histories();
 }
 
 /// ARM64 syscall result type (mirrors x86_64 version)
@@ -428,6 +461,11 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
 
             // Check if from userspace (EL0) - SPSR[3:0] indicates source EL
             let from_el0 = (frame_ref.spsr & 0xF) == 0;
+            let fatal_uart_guard = if from_el0 {
+                None
+            } else {
+                Some(acquire_fatal_postmortem_uart())
+            };
             let ttbr0: u64;
             unsafe {
                 core::arch::asm!("mrs {}, ttbr0_el1", out(reg) ttbr0, options(nomem, nostack));
@@ -673,6 +711,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
             }
             defer_current_user_thread_sigsegv_exit("[DATA_ABORT]");
             dump_fatal_postmortem_once("DATA_ABORT");
+            drop(fatal_uart_guard);
 
             // Mark scheduler thread as terminated (best effort)
             terminate_current_scheduler_thread();
@@ -694,6 +733,11 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
             let frame_ref = unsafe { &mut *frame };
             let ifsc = (iss & 0x3F) as u16;
             let from_el0 = (frame_ref.spsr & 0xF) == 0;
+            let fatal_uart_guard = if from_el0 {
+                None
+            } else {
+                Some(acquire_fatal_postmortem_uart())
+            };
 
             let ttbr0: u64;
             unsafe {
@@ -978,6 +1022,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                     raw_uart_str("\n");
                 }
             }
+            drop(fatal_uart_guard);
 
             if from_el0 {
                 // From userspace - terminate the process with SIGSEGV
@@ -1388,10 +1433,8 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 // writer, distinct from the exception-frame save path that
                 // SAVE_SKEW covers. Present iff idle was actually executing
                 // on this CPU but the scheduling decision picked a non-idle
-                // `old_id` as the save target, i.e. the imminent
-                // aarch64_inline_schedule_switch asm save was about to write
-                // idle's live register file into that non-idle thread's
-                // context. Diagnostic only, all-CPU (mirrors SAVE_SKEW /
+                // `old_id` with the opposite idle/non-idle class, in either
+                // direction. Diagnostic only, all-CPU (mirrors SAVE_SKEW /
                 // ERET_ANOMALY above).
                 crate::arch_impl::aarch64::context_switch::dump_all_inline_save_skew_snapshots();
             }

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -29,6 +29,190 @@ pub static CPU0_LAST_SYNC_FAR: AtomicU64 = AtomicU64::new(0);
 pub static CPU0_LAST_SYNC_ELR: AtomicU64 = AtomicU64::new(0);
 static PC_ALIGN_VERBOSE_CAPTURED: AtomicBool = AtomicBool::new(false);
 static FATAL_POSTMORTEM_CAPTURED: [AtomicBool; 8] = [const { AtomicBool::new(false) }; 8];
+static EL1_UNHANDLED_FAULT_LATCHED: [AtomicBool; 8] = [const { AtomicBool::new(false) }; 8];
+
+struct El1FirstFaultEvidence {
+    instruction_word: Option<u32>,
+    tpidr_el1: u64,
+    mpidr_el1: u64,
+    sctlr_el1: u64,
+    vbar_el1: u64,
+    ttbr1_el1: u64,
+    tcr_el1: u64,
+    cntvct_el0: u64,
+}
+
+#[cold]
+#[inline(never)]
+fn capture_el1_first_fault_evidence(elr: u64) -> El1FirstFaultEvidence {
+    extern "C" {
+        static __bss_start: u8;
+    }
+
+    // The linker script does not export an __etext symbol. __bss_start is the
+    // first existing upper-bound symbol after .text/.rodata/.data, so it keeps
+    // the volatile read inside the mapped high-half kernel image.
+    const KERNEL_IMAGE_TEXT_FLOOR: u64 = 0xFFFF_0000_4008_0000;
+    let kernel_image_upper = core::ptr::addr_of!(__bss_start) as u64;
+    let instruction_word = if elr >= KERNEL_IMAGE_TEXT_FLOOR
+        && elr <= kernel_image_upper.saturating_sub(core::mem::size_of::<u32>() as u64)
+        && elr & 0x3 == 0
+    {
+        Some(unsafe { core::ptr::read_volatile(elr as *const u32) })
+    } else {
+        None
+    };
+
+    let tpidr_el1: u64;
+    let mpidr_el1: u64;
+    let sctlr_el1: u64;
+    let vbar_el1: u64;
+    let ttbr1_el1: u64;
+    let tcr_el1: u64;
+    let cntvct_el0: u64;
+    unsafe {
+        core::arch::asm!(
+            "mrs {tpidr}, tpidr_el1",
+            "mrs {mpidr}, mpidr_el1",
+            "mrs {sctlr}, sctlr_el1",
+            "mrs {vbar}, vbar_el1",
+            "mrs {ttbr1}, ttbr1_el1",
+            "mrs {tcr}, tcr_el1",
+            "mrs {cntvct}, cntvct_el0",
+            tpidr = out(reg) tpidr_el1,
+            mpidr = out(reg) mpidr_el1,
+            sctlr = out(reg) sctlr_el1,
+            vbar = out(reg) vbar_el1,
+            ttbr1 = out(reg) ttbr1_el1,
+            tcr = out(reg) tcr_el1,
+            cntvct = out(reg) cntvct_el0,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    El1FirstFaultEvidence {
+        instruction_word,
+        tpidr_el1,
+        mpidr_el1,
+        sctlr_el1,
+        vbar_el1,
+        ttbr1_el1,
+        tcr_el1,
+        cntvct_el0,
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn raw_uart_hex_u32(value: u32) {
+    use crate::arch_impl::aarch64::context_switch::{raw_uart_char, raw_uart_str};
+
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    raw_uart_str("0x");
+    for shift in (0..32).step_by(4).rev() {
+        raw_uart_char(HEX[((value >> shift) & 0xF) as usize]);
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn dump_el1_first_fault(
+    frame: &Aarch64ExceptionFrame,
+    ec: u32,
+    esr: u64,
+    far: u64,
+    cpu_id: usize,
+    evidence: &El1FirstFaultEvidence,
+) {
+    use crate::arch_impl::aarch64::context_switch::{raw_uart_dec, raw_uart_hex, raw_uart_str};
+
+    raw_uart_str("[UNHANDLED_EC] cpu=");
+    raw_uart_dec(cpu_id as u64);
+    raw_uart_str(" EC=");
+    raw_uart_hex(ec as u64);
+    raw_uart_str(" ELR=");
+    raw_uart_hex(frame.elr);
+    raw_uart_str("\n[EL1_FIRST_FAULT] instruction_word=");
+    if let Some(word) = evidence.instruction_word {
+        raw_uart_hex_u32(word);
+    } else {
+        raw_uart_str("unavailable");
+    }
+    raw_uart_str(" tpidr_el1=");
+    raw_uart_hex(evidence.tpidr_el1);
+    raw_uart_str(" mpidr_el1=");
+    raw_uart_hex(evidence.mpidr_el1);
+    raw_uart_str("\n  sctlr_el1=");
+    raw_uart_hex(evidence.sctlr_el1);
+    raw_uart_str(" vbar_el1=");
+    raw_uart_hex(evidence.vbar_el1);
+    raw_uart_str(" ttbr1_el1=");
+    raw_uart_hex(evidence.ttbr1_el1);
+    raw_uart_str("\n  tcr_el1=");
+    raw_uart_hex(evidence.tcr_el1);
+    raw_uart_str(" cntvct_el0=");
+    raw_uart_hex(evidence.cntvct_el0);
+    raw_uart_str("\n");
+
+    let sp_at_crash = frame as *const _ as u64 + 272;
+    raw_uart_str("[FATAL_REGS] cpu=");
+    raw_uart_dec(cpu_id as u64);
+    raw_uart_str(" spsr=");
+    raw_uart_hex(frame.spsr);
+    raw_uart_str(" esr=");
+    raw_uart_hex(esr);
+    raw_uart_str(" far=");
+    raw_uart_hex(far);
+    raw_uart_str(" elr=");
+    raw_uart_hex(frame.elr);
+    raw_uart_str(" sp=");
+    raw_uart_hex(sp_at_crash);
+
+    let registers = unsafe { core::slice::from_raw_parts(&frame.x0 as *const u64, 31) };
+    for (register, value) in registers.iter().enumerate() {
+        if register % 4 == 0 {
+            raw_uart_str("\n  ");
+        } else {
+            raw_uart_str(" ");
+        }
+        raw_uart_str("x");
+        raw_uart_dec(register as u64);
+        raw_uart_str("=");
+        raw_uart_hex(*value);
+    }
+    raw_uart_str("\n");
+
+    crate::arch_impl::aarch64::context_switch::dump_all_save_skew_snapshots();
+    crate::task::scheduler::dump_cpu_state_history_postmortem(cpu_id);
+    crate::arch_impl::aarch64::context_switch::dump_all_dispatch_mismatch_snapshots();
+    crate::arch_impl::aarch64::context_switch::dump_all_eret_frame_anomaly_snapshots();
+    crate::arch_impl::aarch64::context_switch::dump_all_inline_save_skew_snapshots();
+    dump_fatal_postmortem_once("UNHANDLED_EC");
+}
+
+#[cold]
+#[inline(never)]
+fn handle_unhandled_el1_exception(frame: &Aarch64ExceptionFrame, ec: u32, esr: u64, far: u64) -> ! {
+    unsafe {
+        core::arch::asm!("msr daifset, #0xf", options(nomem, nostack));
+    }
+
+    let cpu_id = crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as usize;
+    let first_fault = cpu_id < EL1_UNHANDLED_FAULT_LATCHED.len()
+        && EL1_UNHANDLED_FAULT_LATCHED[cpu_id]
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+    if first_fault {
+        let evidence = capture_el1_first_fault_evidence(frame.elr);
+        dump_el1_first_fault(frame, ec, esr, far, cpu_id, &evidence);
+    }
+
+    loop {
+        unsafe {
+            core::arch::asm!("wfi", options(nomem, nostack));
+        }
+    }
+}
 
 /// Set the per-CPU idle/boot stack in `user_rsp_scratch` so the assembly ERET
 /// path restores SP to a safe stack when redirecting to idle_loop_arm64.
@@ -1006,6 +1190,9 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
         }
 
         _ => {
+            if unsafe { (*frame).spsr & 0xF } != 0 {
+                handle_unhandled_el1_exception(unsafe { &*frame }, ec, esr, far);
+            }
             // Mask all interrupts to prevent cascading exceptions on SMP
             // (timer IRQs cause context switches that schedule more threads
             // onto this CPU, each hitting the same unhandled exception)

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -1180,6 +1180,19 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 // Diagnostic only, all-CPU (mirrors SAVE_SKEW/DISPATCH_MISMATCH
                 // above).
                 crate::arch_impl::aarch64::context_switch::dump_all_eret_frame_anomaly_snapshots();
+
+                // [INLINE_SAVE_SKEW]: lock-free per-CPU record from the
+                // inline-schedule (cooperative-yield) save path in
+                // schedule_from_kernel (context_switch.rs) -- the OTHER save
+                // writer, distinct from the exception-frame save path that
+                // SAVE_SKEW covers. Present iff idle was actually executing
+                // on this CPU but the scheduling decision picked a non-idle
+                // `old_id` as the save target, i.e. the imminent
+                // aarch64_inline_schedule_switch asm save was about to write
+                // idle's live register file into that non-idle thread's
+                // context. Diagnostic only, all-CPU (mirrors SAVE_SKEW /
+                // ERET_ANOMALY above).
+                crate::arch_impl::aarch64::context_switch::dump_all_inline_save_skew_snapshots();
             }
             dump_fatal_postmortem_once("UNHANDLED_EC");
             // Redirect to idle instead of hanging — allows system to recover.

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -47,17 +47,40 @@ impl Drop for FatalPostmortemUartGuard {
 #[cold]
 #[inline(never)]
 fn acquire_fatal_postmortem_uart() -> FatalPostmortemUartGuard {
-    const MAX_SPINS: usize = 1_000_000;
-    for _ in 0..MAX_SPINS {
+    let start: u64;
+    let frequency: u64;
+    unsafe {
+        core::arch::asm!(
+            "mrs {start}, cntvct_el0",
+            "mrs {frequency}, cntfrq_el0",
+            start = out(reg) start,
+            frequency = out(reg) frequency,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+    let deadline = start.saturating_add(frequency / 4);
+
+    loop {
         if FATAL_POSTMORTEM_UART_LOCK
             .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
         {
             return FatalPostmortemUartGuard { acquired: true };
         }
+
+        let now: u64;
+        unsafe {
+            core::arch::asm!(
+                "mrs {}, cntvct_el0",
+                out(reg) now,
+                options(nomem, nostack, preserves_flags),
+            );
+        }
+        if now >= deadline {
+            return FatalPostmortemUartGuard { acquired: false };
+        }
         core::hint::spin_loop();
     }
-    FatalPostmortemUartGuard { acquired: false }
 }
 
 struct El1FirstFaultEvidence {
@@ -75,15 +98,16 @@ struct El1FirstFaultEvidence {
 #[inline(never)]
 fn capture_el1_first_fault_evidence(elr: u64) -> El1FirstFaultEvidence {
     extern "C" {
+        static __kernel_virt_start: u8;
         static __bss_start: u8;
     }
 
     // The linker script does not export an __etext symbol. __bss_start is the
     // first existing upper-bound symbol after .text/.rodata/.data, so it keeps
     // the volatile read inside the mapped high-half kernel image.
-    const KERNEL_IMAGE_TEXT_FLOOR: u64 = 0xFFFF_0000_4008_0000;
+    let kernel_image_text_floor = core::ptr::addr_of!(__kernel_virt_start) as u64;
     let kernel_image_upper = core::ptr::addr_of!(__bss_start) as u64;
-    let instruction_word = if elr >= KERNEL_IMAGE_TEXT_FLOOR
+    let instruction_word = if elr >= kernel_image_text_floor
         && elr <= kernel_image_upper.saturating_sub(core::mem::size_of::<u32>() as u64)
         && elr & 0x3 == 0
     {
@@ -1245,6 +1269,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 core::arch::asm!("msr daifset, #0xf", options(nomem, nostack));
             }
             let frame_ref = unsafe { &mut *frame };
+            let fatal_uart_guard = acquire_fatal_postmortem_uart();
             // Use lock-free raw UART — serial_println! acquires a spinlock that may be
             // held by another CPU, causing deadlock when this exception fires during a
             // context switch that already holds the scheduler lock.
@@ -1439,6 +1464,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 crate::arch_impl::aarch64::context_switch::dump_all_inline_save_skew_snapshots();
             }
             dump_fatal_postmortem_once("UNHANDLED_EC");
+            drop(fatal_uart_guard);
             // Redirect to idle instead of hanging — allows system to recover.
             // CRITICAL: Set frame values BEFORE switch_to_idle_best_effort()
             frame_ref.elr = crate::arch_impl::aarch64::idle_loop_arm64 as *const () as u64;

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -1154,6 +1154,20 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 // the bad save can happen on a peer CPU that never faults.
                 crate::arch_impl::aarch64::context_switch::dump_all_save_skew_snapshots();
 
+                // [cpu_state_history]: per-CPU (setter_id, old->new) write-history
+                // ring for cpu_state[cpu].current_thread (scheduler.rs setter-id
+                // table above dump_cpu_state_history). Names which of the known
+                // writers (commit_cpu_state_after_save, switch_to_idle,
+                // switch_to_idle_best_effort, register_idle_thread,
+                // init_with_current, set_current_thread,
+                // fix_stale_current_thread_when_idle_executing) last touched
+                // cpu_state on each implicated CPU. Dumped for the faulting
+                // CPU plus every other CPU whose SAVE_SKEW slot fired (see
+                // dump_cpu_state_history_postmortem doc comment). Lock-free
+                // (atomics only, no locks) and record-only -- no behavior
+                // change.
+                crate::task::scheduler::dump_cpu_state_history_postmortem(cpu_id as usize);
+
                 // [DISPATCH_MISMATCH]: lock-free per-CPU record from the
                 // dispatch-finalization path (context_switch.rs). Present iff
                 // a frame's elr diverged from its thread's authoritative

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -564,6 +564,90 @@ static CPU_STATE_HISTORY_IDX: [core::sync::atomic::AtomicU64; MAX_CPUS] = {
     [INIT; MAX_CPUS]
 };
 
+#[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+static EC0_FAULT_INJECT_TID: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+static EC0_FAULT_INJECT_DEADLINE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+#[inline(never)]
+fn retain_ec0_fault_inject_on_cpu0(
+    queue: &mut VecDeque<u64>,
+    thread_id: u64,
+    current_cpu: usize,
+) -> bool {
+    if current_cpu == 0 || EC0_FAULT_INJECT_TID.load(Ordering::Acquire) != thread_id {
+        return false;
+    }
+    queue.push_front(thread_id);
+    true
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+#[cold]
+#[inline(never)]
+extern "C" fn ec0_fault_inject_thread(_arg: u64) -> ! {
+    let deadline = EC0_FAULT_INJECT_DEADLINE.load(Ordering::Acquire);
+    loop {
+        let now: u64;
+        unsafe {
+            core::arch::asm!(
+                "mrs {}, cntvct_el0",
+                out(reg) now,
+                options(nomem, nostack, preserves_flags),
+            );
+        }
+        if now >= deadline {
+            break;
+        }
+        unsafe {
+            core::arch::asm!("wfi", options(nomem, nostack));
+        }
+    }
+
+    if current_cpu_id_raw() != 0 {
+        loop {
+            unsafe {
+                core::arch::asm!("wfi", options(nomem, nostack));
+            }
+        }
+    }
+
+    unsafe {
+        core::arch::asm!("udf #0", options(noreturn));
+    }
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+#[cold]
+#[inline(never)]
+fn install_ec0_fault_inject_thread(scheduler: &mut Scheduler) {
+    let start: u64;
+    let frequency: u64;
+    unsafe {
+        core::arch::asm!(
+            "mrs {start}, cntvct_el0",
+            "mrs {frequency}, cntfrq_el0",
+            start = out(reg) start,
+            frequency = out(reg) frequency,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+    let deadline = start.saturating_add(frequency.saturating_mul(10));
+    EC0_FAULT_INJECT_DEADLINE.store(deadline, Ordering::Release);
+
+    let thread = Thread::new_kernel(
+        alloc::string::String::from("ec0_fault_inject/0"),
+        ec0_fault_inject_thread,
+        0,
+    )
+    .unwrap_or_else(|error| panic!("failed to create EC0 fault injector: {}", error));
+    let thread_id = thread.id();
+    EC0_FAULT_INJECT_TID.store(thread_id, Ordering::Release);
+    scheduler.threads.push(Box::new(thread));
+    scheduler.per_cpu_queues[0].push_back(thread_id);
+}
+
 /// Record a cpu_state change for diagnostics (circular buffer).
 #[cfg(target_arch = "aarch64")]
 #[inline(never)]
@@ -997,6 +1081,14 @@ impl Scheduler {
                     continue;
                 }
                 while let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() {
+                    #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+                    if retain_ec0_fault_inject_on_cpu0(
+                        &mut self.per_cpu_queues[steal_cpu],
+                        n,
+                        current_cpu,
+                    ) {
+                        break;
+                    }
                     if let Some(thread) = self.get_thread(n) {
                         if thread.state == ThreadState::Terminated {
                             continue;
@@ -1033,6 +1125,14 @@ impl Scheduler {
                             continue;
                         }
                         if let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() {
+                            #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+                            if retain_ec0_fault_inject_on_cpu0(
+                                &mut self.per_cpu_queues[steal_cpu],
+                                n,
+                                current_cpu,
+                            ) {
+                                continue;
+                            }
                             found = Some(n);
                             break;
                         }
@@ -1274,6 +1374,14 @@ impl Scheduler {
                     continue;
                 }
                 while let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() {
+                    #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+                    if retain_ec0_fault_inject_on_cpu0(
+                        &mut self.per_cpu_queues[steal_cpu],
+                        n,
+                        current_cpu,
+                    ) {
+                        break;
+                    }
                     if let Some(thread) = self.get_thread(n) {
                         if thread.state == ThreadState::Terminated {
                             continue;
@@ -1311,6 +1419,14 @@ impl Scheduler {
                             continue;
                         }
                         if let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() {
+                            #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+                            if retain_ec0_fault_inject_on_cpu0(
+                                &mut self.per_cpu_queues[steal_cpu],
+                                n,
+                                current_cpu,
+                            ) {
+                                continue;
+                            }
                             found = Some(n);
                             break;
                         }
@@ -2546,6 +2662,8 @@ pub fn init_with_current(current_thread: Box<Thread>) {
 
     // Create scheduler with current thread as both idle and current
     let mut scheduler = Scheduler::new(current_thread);
+    #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+    install_ec0_fault_inject_thread(&mut scheduler);
     #[cfg(target_arch = "aarch64")]
     {
         let old_val = scheduler.cpu_state[0].current_thread.unwrap_or(0xDEAD);

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -549,6 +549,9 @@ const MAX_CPUS: usize = 1;
 ///  13 = dispatch_thread_locked (EL0 bad-context redirect)
 ///  14 = dispatch_thread_locked (EL0 TTBR_PM_LOCK_BUSY redirect)
 ///  15 = dispatch_thread_locked (EL0 PROCESS_GONE redirect)
+///  16 = Scheduler::add_thread_as_current
+///  17 = Scheduler::terminate_current (new_thread = 0xDEAD means None)
+///  18 = Scheduler::new (initial CPU 0 idle thread)
 #[cfg(target_arch = "aarch64")]
 const HISTORY_SIZE: usize = 256;
 #[cfg(target_arch = "aarch64")]
@@ -614,7 +617,7 @@ extern "C" fn ec0_fault_inject_thread(_arg: u64) -> ! {
     }
 
     unsafe {
-        core::arch::asm!("udf #0", options(noreturn));
+        core::arch::asm!("udf #0x1234", options(noreturn));
     }
 }
 
@@ -784,6 +787,11 @@ impl Scheduler {
             previous_thread: None,
         };
         let mut cpu_state = [EMPTY_STATE; MAX_CPUS];
+        #[cfg(target_arch = "aarch64")]
+        {
+            let old_val = cpu_state[0].current_thread.unwrap_or(0xDEAD);
+            record_cpu_state_change(0, 18, old_val, idle_id);
+        }
         cpu_state[0] = CpuSchedulerState {
             current_thread: Some(idle_id),
             idle_thread: idle_id,
@@ -926,7 +934,13 @@ impl Scheduler {
         thread.state = ThreadState::Running;
         thread.has_started = true;
         self.threads.push(thread);
-        self.cpu_state[Self::current_cpu_id()].current_thread = Some(thread_id);
+        let cpu = Self::current_cpu_id();
+        #[cfg(target_arch = "aarch64")]
+        {
+            let old_val = self.cpu_state[cpu].current_thread.unwrap_or(0xDEAD);
+            record_cpu_state_change(cpu, 16, old_val, thread_id);
+        }
+        self.cpu_state[cpu].current_thread = Some(thread_id);
         // CRITICAL: Only log on x86_64 to avoid deadlock on ARM64
         #[cfg(target_arch = "x86_64")]
         log_serial_println!(
@@ -1117,6 +1131,8 @@ impl Scheduler {
             // Pop from local queue first; fall back to any CPU
             next_thread_id = {
                 let mut found = None;
+                #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+                let mut retained_injector = false;
                 if let Some(n) = self.per_cpu_queues[current_cpu].pop_front() {
                     found = Some(n);
                 } else {
@@ -1131,10 +1147,26 @@ impl Scheduler {
                                 n,
                                 current_cpu,
                             ) {
+                                retained_injector = true;
                                 continue;
                             }
                             found = Some(n);
                             break;
+                        }
+                    }
+                }
+                #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
+                if found.is_none() && retained_injector {
+                    // The injector remains on its CPU 0 queue. If no later peer is
+                    // stealable, remove the queued duplicate of the already-running
+                    // current thread and keep running that thread on this CPU.
+                    if let Some(position) = self.per_cpu_queues[current_cpu]
+                        .iter()
+                        .position(|&id| id == next_thread_id)
+                    {
+                        if let Some(current_id) = self.per_cpu_queues[current_cpu].remove(position)
+                        {
+                            found = Some(current_id);
                         }
                     }
                 }
@@ -2423,7 +2455,13 @@ impl Scheduler {
             current.set_terminated();
             // Don't put back in ready queue
         }
-        self.cpu_state[Self::current_cpu_id()].current_thread = None;
+        let cpu = Self::current_cpu_id();
+        #[cfg(target_arch = "aarch64")]
+        {
+            let old_val = self.cpu_state[cpu].current_thread.unwrap_or(0xDEAD);
+            record_cpu_state_change(cpu, 17, old_val, 0xDEAD);
+        }
+        self.cpu_state[cpu].current_thread = None;
     }
 
     /// Check if scheduler has any runnable threads

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -572,7 +572,6 @@ fn record_cpu_state_change(cpu: usize, setter_id: u64, old_val: u64, new_val: u6
 
 /// Dump the cpu_state change history for a CPU (debug utility).
 #[cfg(target_arch = "aarch64")]
-#[allow(dead_code)]
 pub fn dump_cpu_state_history(cpu: usize) {
     use crate::arch_impl::aarch64::context_switch::{raw_uart_dec, raw_uart_str};
     if cpu >= MAX_CPUS {
@@ -611,6 +610,26 @@ pub fn dump_cpu_state_history(cpu: usize) {
         raw_uart_str("->");
         raw_uart_dec(new);
         raw_uart_str("\n");
+    }
+}
+
+/// Dump the cpu_state change history for the aarch64 UNHANDLED_EC fatal
+/// postmortem (exception.rs): the faulting CPU, plus every OTHER CPU whose
+/// SAVE_SKEW slot fired (queried via `save_skew_snapshot`, the same read-side
+/// accessor `dump_all_save_skew_snapshots` uses) since a bad save recorded on
+/// a peer CPU is exactly the case this history is needed to explain. Kept as
+/// its own function (rather than inlined at the call site) so the call site
+/// in exception.rs stays a single line. Lock-free (atomics only, no locks)
+/// and record-only -- no behavior change.
+#[cfg(target_arch = "aarch64")]
+pub fn dump_cpu_state_history_postmortem(faulting_cpu: usize) {
+    dump_cpu_state_history(faulting_cpu);
+    for other_cpu in 0..MAX_CPUS {
+        if other_cpu != faulting_cpu
+            && crate::arch_impl::aarch64::context_switch::save_skew_snapshot(other_cpu).is_some()
+        {
+            dump_cpu_state_history(other_cpu);
+        }
     }
 }
 

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -535,14 +535,22 @@ const MAX_CPUS: usize = 1;
 ///   2 = switch_to_idle
 ///   3 = switch_to_idle_best_effort
 ///   4 = register_idle_thread
-///   5 = init_with_current / Scheduler::new
-///   6 = set_current_thread / add_thread_as_current
+///   5 = init_with_current
+///   6 = Scheduler::set_current_thread
 ///   7 = fix_stale_current_thread_when_idle_executing (schedule_from_kernel
 ///       idle path -- corrects a stale non-idle current_thread while idle is
 ///       the thread actually executing, before it can be used as a save
 ///       target; see ROOT_CAUSE.md's cpu_state/old_id skew candidate)
+///   8 = fix_stale_idle_cpu_state
+///   9 = fix_exception_cleanup_cpu_state
+///  10 = dispatch_thread_locked (kernel TTBR_PM_LOCK_BUSY redirect)
+///  11 = dispatch_thread_locked (kernel PROCESS_GONE redirect)
+///  12 = dispatch_thread_locked (kernel RESTORE_FAILED redirect)
+///  13 = dispatch_thread_locked (EL0 bad-context redirect)
+///  14 = dispatch_thread_locked (EL0 TTBR_PM_LOCK_BUSY redirect)
+///  15 = dispatch_thread_locked (EL0 PROCESS_GONE redirect)
 #[cfg(target_arch = "aarch64")]
-const HISTORY_SIZE: usize = 8;
+const HISTORY_SIZE: usize = 256;
 #[cfg(target_arch = "aarch64")]
 static CPU_STATE_HISTORY: [[core::sync::atomic::AtomicU64; HISTORY_SIZE * 3]; MAX_CPUS] = {
     const INIT_ENTRY: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
@@ -558,7 +566,13 @@ static CPU_STATE_HISTORY_IDX: [core::sync::atomic::AtomicU64; MAX_CPUS] = {
 
 /// Record a cpu_state change for diagnostics (circular buffer).
 #[cfg(target_arch = "aarch64")]
-fn record_cpu_state_change(cpu: usize, setter_id: u64, old_val: u64, new_val: u64) {
+#[inline(never)]
+pub(crate) fn record_cpu_state_change(
+    cpu: usize,
+    setter_id: u64,
+    old_val: u64,
+    new_val: u64,
+) {
     if cpu < MAX_CPUS {
         let idx =
             CPU_STATE_HISTORY_IDX[cpu].fetch_add(1, core::sync::atomic::Ordering::Relaxed) as usize;
@@ -741,6 +755,8 @@ impl Scheduler {
         let idle_id = idle_thread.id();
         self.threads.push(idle_thread);
         self.cpu_state[cpu_id].idle_thread = idle_id;
+        let old_val = self.cpu_state[cpu_id].current_thread.unwrap_or(0xDEAD);
+        record_cpu_state_change(cpu_id, 4, old_val, idle_id);
         self.cpu_state[cpu_id].current_thread = Some(idle_id);
     }
 
@@ -2378,6 +2394,12 @@ impl Scheduler {
     /// Set the current thread (used by spawn mechanism)
     #[allow(dead_code)]
     pub fn set_current_thread(&mut self, thread_id: u64) {
+        #[cfg(target_arch = "aarch64")]
+        {
+            let cpu = Self::current_cpu_id();
+            let old_val = self.cpu_state[cpu].current_thread.unwrap_or(0xDEAD);
+            record_cpu_state_change(cpu, 6, old_val, thread_id);
+        }
         self.cpu_state[Self::current_cpu_id()].current_thread = Some(thread_id);
     }
 
@@ -2418,7 +2440,7 @@ impl Scheduler {
         let current = self.cpu_state[cpu].current_thread;
         let idle = self.cpu_state[cpu].idle_thread;
         if current == Some(idle) && real_tid != idle {
-            record_cpu_state_change(cpu, 1, idle, real_tid);
+            record_cpu_state_change(cpu, 8, idle, real_tid);
             self.cpu_state[cpu].current_thread = Some(real_tid);
         }
     }
@@ -2498,7 +2520,7 @@ impl Scheduler {
         let idle = self.cpu_state[cpu].idle_thread;
         let current = self.cpu_state[cpu].current_thread.unwrap_or(0xDEAD);
         if current != idle {
-            record_cpu_state_change(cpu, 3, current, idle);
+            record_cpu_state_change(cpu, 9, current, idle);
             self.cpu_state[cpu].current_thread = Some(idle);
         }
         self.resolve_exception_cleanup_previous_thread(cpu);
@@ -2524,6 +2546,11 @@ pub fn init_with_current(current_thread: Box<Thread>) {
 
     // Create scheduler with current thread as both idle and current
     let mut scheduler = Scheduler::new(current_thread);
+    #[cfg(target_arch = "aarch64")]
+    {
+        let old_val = scheduler.cpu_state[0].current_thread.unwrap_or(0xDEAD);
+        record_cpu_state_change(0, 5, old_val, thread_id);
+    }
     scheduler.cpu_state[0].current_thread = Some(thread_id);
 
     *scheduler_lock = Some(scheduler);

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -537,6 +537,10 @@ const MAX_CPUS: usize = 1;
 ///   4 = register_idle_thread
 ///   5 = init_with_current / Scheduler::new
 ///   6 = set_current_thread / add_thread_as_current
+///   7 = fix_stale_current_thread_when_idle_executing (schedule_from_kernel
+///       idle path -- corrects a stale non-idle current_thread while idle is
+///       the thread actually executing, before it can be used as a save
+///       target; see ROOT_CAUSE.md's cpu_state/old_id skew candidate)
 #[cfg(target_arch = "aarch64")]
 const HISTORY_SIZE: usize = 8;
 #[cfg(target_arch = "aarch64")]
@@ -2397,6 +2401,40 @@ impl Scheduler {
         if current == Some(idle) && real_tid != idle {
             record_cpu_state_change(cpu, 1, idle, real_tid);
             self.cpu_state[cpu].current_thread = Some(real_tid);
+        }
+    }
+
+    /// Fix stale cpu_state where it names a non-idle thread as current while
+    /// idle is actually the thread executing (i.e. `current_thread_ptr` is
+    /// NULL, the per-CPU fast-path marker for "idle is running").
+    ///
+    /// This is the inverse of `fix_stale_idle_cpu_state` above: that function
+    /// corrects "cpu_state says idle, but a real thread is running"; this one
+    /// corrects "cpu_state says a real (non-idle) thread, but idle is what's
+    /// actually running" -- e.g. after an idle dispatch that branched directly
+    /// into `idle_loop_arm64` without updating `cpu_state.current_thread`,
+    /// followed by a timer IRQ re-entering `schedule_from_kernel` while idle
+    /// is executing but `cpu_state[cpu].current_thread` still names whatever
+    /// thread was current before that redirect.
+    ///
+    /// Without this correction, the stale non-idle `current_thread` would be
+    /// read straight through as `old_id` (the save target) by the scheduling
+    /// decision that follows, and idle's live register file would be written
+    /// into that unrelated (still-alive) thread's context -- the confirmed
+    /// "idle register file leaking into a non-idle thread's dispatch frame"
+    /// mechanism behind the ERET_ANOMALY / EC=0x0 crash family (see
+    /// docs/planning/aarch64-launcher-spawn-crash/ROOT_CAUSE.md, candidate #1:
+    /// "cpu_state / `old_id` save-target skew"). Callers must invoke this
+    /// BEFORE the scheduling decision (`schedule_deferred_requeue`) runs.
+    #[cfg(target_arch = "aarch64")]
+    pub fn fix_stale_current_thread_when_idle_executing(&mut self) {
+        let cpu = Self::current_cpu_id();
+        let idle = self.cpu_state[cpu].idle_thread;
+        if let Some(current) = self.cpu_state[cpu].current_thread {
+            if current != idle {
+                record_cpu_state_change(cpu, 7, current, idle);
+                self.cpu_state[cpu].current_thread = Some(idle);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Round 1 of the EC=0x0 campaign: contains the 253k-fault storm, adds a first-fault evidence probe, and overhauls scheduler diagnostics so the next occurrence is attributable. The ambient bug itself is **not** fixed yet.

- **Fault-storm circuit breaker.** A prior boot logged ~253,000 repeated EL1 unhandled-EC faults in a tight loop before the system finally died. `a75377bc` adds a circuit breaker: on the first unhandled EL1 EC, the offending CPU is **parked**, never retried. The EL0 fault-handling path is untouched — this only changes EL1 behavior, and only after the first fault. This turns an unbounded storm into a single, examinable event.
- **First-fault evidence probe.** `6385e0f4` / `687a280c` capture the raw faulting instruction word plus the full sysreg set (ELR_EL1, ESR_EL1, FAR_EL1, SPSR_EL1, etc.) at the moment of the first EC=0 fault. This is designed to settle, on the next occurrence, whether the cause is text corruption (bad instruction bytes at ELR) vs. an execution-state corruption (good bytes, garbage PC/registers) — the two haven't been distinguished yet.
- **Diagnostic overhaul** (`d27c2362`, `6385e0f4`, `52aa4f14`): 256-deep attributable per-CPU `cpu_state` write-history (names the actual writer of a stale value instead of just the value), unique setter IDs on every write site, an `IDLE_REDIRECT` ring that distinguishes committed vs. omitted redirects, and a bidirectional `INLINE_SAVE_SKEW` probe on the inline-schedule save path. All of this is read out in the fatal postmortem dump.
- **Test infrastructure.** `687a280c` adds a `cfg`-gated `ec0_fault_inject` test feature that deliberately triggers an EL1 EC=0 fault. Proven on `smp=1`: one postmortem dump, the CPU parks, no storm — the breaker does what it's supposed to do under a controlled trigger.
- **Build hygiene.** `789d618a` fixes `BUILD_ID` so it re-stamps on any kernel source change (was a stale-stamp landmine that could make two different builds report the same ID).
- **Hardening.** `b750b809` hardens the fatal diagnostics and injector scheduling paths (edge cases in the new diagnostic/injector code from the commits above).

## Honest status — the ambient bug is still open

The EC=0/jump-to-garbage-PC crash is **unresolved**. It is pre-existing at baseline `d27c2362` (i.e., it predates this whole diagnostic campaign), and it reproduces on **QEMU `smp=4`** at roughly 50%+ per boot. This is a **new finding** — it was previously believed to be Parallels-hardware-only. As a direct consequence, **the aarch64 `smp=4` boot test is red on both baseline and this branch** because of this bug; nothing in this PR fixes it. The next step in the campaign is to reproduce it live under GDB on the QEMU repro, now that it's known to reproduce without needing Parallels hardware.

## Correction of the record

Commit `0cfa03e0`'s message ("the confirmed proximate cause of the ERET_ANOMALY / EC=0x0 dispatch-frame-corruption crash family") overstates itself. It is a real, benign fix — a voluntary-path correction to `cpu_state.current_thread` tracking when idle is executing — but it is empirically **not** the root fix for the ambient bug: a 53-second soak run crashed with `0cfa03e0`'s own `fix_stale_current_thread_when_idle_executing` probe silent (i.e., its corrected path wasn't even implicated in that crash). History is kept intact deliberately rather than rewritten, so this PR description is the correction of record for that overstated claim.

## Test plan

- [x] `ec0_fault_inject` cfg-gated test feature proven on QEMU `smp=1`: single postmortem dump, CPU parks, no fault storm
- [x] `789d618a` BUILD_ID re-stamp verified against a kernel source touch
- [ ] aarch64 `smp=4` boot test remains red on both baseline and branch (tracked as the open ambient EC=0 bug, not a regression introduced here)
- [ ] Live GDB repro of the ambient EC=0 bug on QEMU `smp=4` — next round of the campaign

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
