### PR TITLE
Follow-up: x86 heap-lock IRQ safety parity + guard hardening

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -3895,28 +3895,24 @@ extern "C" fn inline_schedule_trampoline() -> ! {
             crate::task::scheduler::force_unlock_scheduler();
         }
 
-        let idle_sp_candidate = crate::task::scheduler::with_scheduler(|sched| {
+        let idle_sp = crate::task::scheduler::with_scheduler(|sched| {
             let idle_id = sched.cpu_state[cpu_id].idle_thread;
-            sched
+            let candidate = sched
                 .get_thread(idle_id)
                 .and_then(|thread| thread.kernel_stack_top.map(|stack| stack.as_u64()))
-                .unwrap_or_else(|| super::constants::percpu_kernel_stack_top(cpu_id))
-        });
-        let idle_sp = idle_dispatch_stack(
-            cpu_id,
-            idle_sp_candidate
-                .unwrap_or_else(|| super::constants::percpu_kernel_stack_top(cpu_id)),
-        );
+                .unwrap_or_else(|| super::constants::percpu_kernel_stack_top(cpu_id));
+            let idle_sp = idle_dispatch_stack(cpu_id, candidate);
 
-        // Persist the exact normalized stack value used by the live pivot.  Use
-        // the current idle ID from this lock hold, never either stale handoff ID.
-        // with_scheduler returns None only when the scheduler object itself is
-        // absent; in that case there is no persisted idle Thread to update.
-        let _ = crate::task::scheduler::with_scheduler(|sched| {
-            let idle_id = sched.cpu_state[cpu_id].idle_thread;
+            // Persist the exact normalized stack value used by the live pivot.
+            // Use the current idle ID from this lock hold, never either stale
+            // handoff ID.
             reset_idle_continuation_locked(sched, idle_id, idle_sp);
             sched.fix_exception_cleanup_cpu_state();
-        });
+            idle_sp
+        })
+        // with_scheduler returns None only when the scheduler object itself is
+        // absent; in that case there is no persisted idle Thread to update.
+        .unwrap_or_else(|| super::constants::percpu_kernel_stack_top(cpu_id));
 
         unsafe {
             Aarch64PerCpu::set_user_rsp_scratch(idle_sp);

--- a/kernel/src/arch_impl/aarch64/cpu.rs
+++ b/kernel/src/arch_impl/aarch64/cpu.rs
@@ -30,6 +30,16 @@ const DAIF_ALL_IMM: u32 = 0xF; // D, A, I, F
 
 pub struct Aarch64Cpu;
 
+struct DaifRestoreGuard(u64);
+
+impl Drop for DaifRestoreGuard {
+    fn drop(&mut self) {
+        unsafe {
+            core::arch::asm!("msr daif, {}", in(reg) self.0, options(nomem, nostack));
+        }
+    }
+}
+
 impl CpuOps for Aarch64Cpu {
     /// Enable IRQ and FIQ interrupts by clearing the I and F bits in DAIF.
     ///
@@ -110,13 +120,13 @@ impl CpuOps for Aarch64Cpu {
             core::arch::asm!("msr daifset, #3", options(nomem, nostack));
         }
 
+        let restore_guard = DaifRestoreGuard(daif);
+
         // Execute the closure
         let result = f();
 
-        // Restore previous DAIF state exactly
-        unsafe {
-            core::arch::asm!("msr daif, {}", in(reg) daif, options(nomem, nostack));
-        }
+        // Restore previous DAIF state exactly before returning the result.
+        drop(restore_guard);
 
         result
     }

--- a/kernel/src/memory/heap.rs
+++ b/kernel/src/memory/heap.rs
@@ -28,12 +28,15 @@ pub const HEAP_SIZE: u64 = 64 * 1024 * 1024;
 
 /// IRQ-safe wrapper around the kernel's free-list allocator.
 ///
-/// On AArch64, every hold of the inner heap mutex masks IRQ and FIQ and restores
-/// the exact prior DAIF state after the heap operation.  The scheduler may grow
-/// or drop a queue while holding its mutex, so scheduler -> heap is an existing
-/// lock-order edge.  Masking interrupts here prevents a task that already owns
-/// the heap mutex from being interrupted and adding the reverse heap -> scheduler
-/// edge on exception return.
+/// On both architectures, every hold of the inner heap mutex masks local
+/// interrupts and restores the exact prior interrupt state after the heap
+/// operation.  AArch64 masks IRQ and FIQ in DAIF; x86_64 masks the local IF flag
+/// via `arch_without_interrupts`, which delegates to
+/// `x86_64::instructions::interrupts::without_interrupts`, around the identical
+/// inner allocator call.  The scheduler may grow or drop a queue while holding
+/// its mutex, so scheduler -> heap is an existing lock-order edge.  Masking
+/// interrupts here prevents a task that already owns the heap mutex from being
+/// interrupted and adding the reverse heap -> scheduler edge on exception return.
 ///
 /// Keep the masked region limited to one inner heap operation.  In particular,
 /// never acquire another lock, allocate, or format output while the inner heap
@@ -51,15 +54,7 @@ impl IrqSafeLockedHeap {
 
     #[inline(always)]
     fn with_inner<R>(&self, operation: impl FnOnce(&LockedHeap) -> R) -> R {
-        #[cfg(target_arch = "aarch64")]
-        {
-            crate::arch_impl::aarch64::cpu::without_interrupts(|| operation(&self.inner))
-        }
-
-        #[cfg(target_arch = "x86_64")]
-        {
-            operation(&self.inner)
-        }
+        crate::arch_without_interrupts(|| operation(&self.inner))
     }
 
     unsafe fn init(&self, heap_bottom: *mut u8, heap_size: usize) {
@@ -83,7 +78,8 @@ unsafe impl GlobalAlloc for IrqSafeLockedHeap {
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         let ptr = unsafe { self.alloc(layout) };
         if !ptr.is_null() {
-            // Zeroing does not touch allocator metadata, so do it after DAIF is restored.
+            // Zeroing does not touch allocator metadata, so do it after interrupt
+            // state is restored.
             unsafe {
                 ptr.write_bytes(0, layout.size());
             }


### PR DESCRIPTION
## Summary

Follow-up to #414. That PR's round-6 adversarial review (`a9a83e28` heap IRQ-safety + `8ae33511` idle-stack normalize) came back **APPROVE-WITH-NITS, NO BLOCKERS**, and four of the five nits were still open when #414 merged. This branch (`b34bba86`) closes those four; the fifth is out of scope and stays explicitly open below.

## Replies to PR #414's round-6 review notes

> ADVERSARIAL REVIEW r6 ... APPROVE-WITH-NITS, NO BLOCKERS ... NITS: (1) post-fix runtime evidence is 3 CLEAN boots ... needs >=25 boots. (2) x86_64 arm of with_inner is a pass-through while Scheduler::schedule() ... allocates under SCHEDULER and interrupts/context_switch.rs:167 calls it from the timer path -> identical inversion still live on x86. (3) 8ae33511 splits one SCHEDULER critical section into two even though idle_dispatch_stack() is a pure function, losing atomicity between the idle-stack lookup and the continuation write. (4) commit message understates the masked window (whole first-fit walk + contention spin, not just mrs/msr). (5) r5 nit BLOCK_FLAGS_NORMAL_NX==BLOCK_FLAGS_KERNEL_DATA still open; new canary doc answers the wrong direction.

**Nit 1 — insufficient post-fix boot evidence (3 boots, needs ≥25).** CLOSED before #414 merged: the 25×smp=4 post-fix gate documented in #414 §(b) ("Post-fix (25×smp=4 boots, full fix incl. `8ae33511`) — 25/25 CLEAN, 0 anomalies") superseded the 3-boot smoke this nit flagged, against the pre-fix baseline of 22/25 clean / 3 anomalies (2 hangs + 1 crash, all at `[spawn] path=/bin/bsshd` with the `LockedHeap::dealloc`+`RawSpinlock::lock`/`SCHEDULER`-wait signature). This branch is a semantics-preserving refactor on the AArch64 side — same masked window (full inner allocator call), same restore guarantee — so that 25/25 evidence still covers AArch64 runtime behavior. It does not, by itself, cover the *new* x86_64 masking path (nit 2) or the collapsed lock hold (nit 3); those are verified here by zero-warning clean builds on both `qemu-uefi` (x86_64) and `kernel-aarch64` (aarch64, `-Z build-std=core,alloc`) re-run against this exact HEAD, not a fresh dedicated 25-boot campaign. Disclosed honestly, same pattern #414 itself used for its Parallels-loader follow-up.

**Nit 2 — x86_64 `with_inner` was a pass-through (identical `heap → SCHEDULER → heap` inversion live on x86).** CLOSED in `kernel/src/memory/heap.rs`: `IrqSafeLockedHeap::with_inner` now routes through `crate::arch_without_interrupts` unconditionally instead of branching `#[cfg(target_arch = "aarch64")]` vs a bare pass-through on x86_64. `arch_without_interrupts` delegates to `x86_64::instructions::interrupts::without_interrupts`, masking the local `IF` flag around the identical inner allocator call AArch64 already masked DAIF around. This is exactly the fix #414 §(f)(1) disclosed as an open follow-up ("x86_64 heap/scheduler lock-order inversion is still live ... Out of scope for this aarch64-focused track") — now closed.

**Nit 3 — `8ae33511` split one SCHEDULER critical section into two, losing atomicity between the idle-stack lookup and the continuation write.** CLOSED in `kernel/src/arch_impl/aarch64/context_switch.rs`: `inline_schedule_trampoline` previously called `with_scheduler` once to read `idle_thread` and compute a candidate SP, dropped the lock, called the pure `idle_dispatch_stack()`, then re-entered `with_scheduler` a second time — re-reading `idle_thread` — to persist the normalized SP via `reset_idle_continuation_locked`. Between the two acquisitions, `cpu_state[cpu_id].idle_thread` could change, so the persisted write could target a different idle thread than the one the SP was computed for. Now the lookup, `idle_dispatch_stack()` call, and `reset_idle_continuation_locked` persist all happen inside one `with_scheduler` closure under a single lock hold.

**Nit 4 — commit message understated the masked window (implied "just mrs/msr" rather than the whole allocator call + contention spin).** CLOSED: this commit's message states explicitly — "DAIFSet executes before the branch into the allocator, so the entire allocator operation — not just part of it — runs with IRQ/FIQ masked" — and the `IrqSafeLockedHeap` doc comment in `heap.rs` is rewritten to describe both architectures' masked-region semantics accurately (was AArch64-only prose), including the `alloc_zeroed` comment ("DAIF is restored" → "interrupt state is restored") now that the wrapper is arch-symmetric.

**Nit 5 — `BLOCK_FLAGS_NORMAL_NX == BLOCK_FLAGS_KERNEL_DATA` naming duplication (r5 nit, still open).** Left OPEN, explicitly out of scope for this branch — it's a `boot.S` literal-naming cosmetic issue, unrelated to the heap-lock/IRQ-safety surface this PR touches. Still tracked as #414 §(f)(4) ("cosmetic naming duplication only ... candidate for a follow-up rename/dedup").

## Additional hardening bundled with the nit-2 fix

`kernel/src/arch_impl/aarch64/cpu.rs`: `Aarch64Cpu::without_interrupts` now restores DAIF via a `DaifRestoreGuard` RAII type (`Drop` runs `msr daif, {}`) instead of a bare `asm!` call placed after `f()` in straight-line code. Ties the restore to scope exit rather than sequential control flow reaching a specific line — the same discipline the x86_64 side gets for free from `x86_64::instructions::interrupts::without_interrupts`.

## Test plan

- [x] `cargo build --release --features testing,external_test_bins --bin qemu-uefi` (x86_64) — zero warnings, re-verified against this exact HEAD
- [x] `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` — zero warnings, re-verified against this exact HEAD
- [x] Zero-diff on GOLD-MASTER frozen regions (`context_switch.rs` idle loop / dispatch-ERET ISB / EL0 dispatch banner, `gic.rs`, `timer_interrupt.rs`) — this branch's only `context_switch.rs` hunk is inside `inline_schedule_trampoline`, outside every frozen region
- [x] AArch64 runtime masking-window semantics unchanged from #414's already-gated `a9a83e28`/`8ae33511` (25/25 clean, 22/25 pre-fix baseline — see Nit 1 reply above)
- [ ] Dedicated fresh ≥25×smp=4 boot gate against this exact HEAD (covering the new x86_64 masking path + collapsed lock hold) — not run in this branch; disclosed as a follow-up, not blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Ryan Breen
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
