### PR TITLE
Fix CPU0 vtimer death on Parallels/HVF introduced by b0644d39

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -1175,24 +1175,37 @@ pub fn dump_all_idle_redirect_histories() {
 //
 // Every scheduler/idle SP pivot checks whether the current SP is already in
 // the destination stack's live range. The clean path is two comparisons. A
-// violation is record-only: capture it in a bounded per-CPU ring and emit one
-// raw-UART line per CPU, without changing control flow.
+// violation is record-only: capture it in a bounded per-CPU ring without
+// changing control flow. Human-readable output is deferred to the fatal
+// postmortem path so this masked pivot corridor never performs UART MMIO.
 
 const STACK_PIVOT_HISTORY_SIZE: usize = 16;
 const STACK_PIVOT_HISTORY_FIELDS: usize = 3;
-static STACK_PIVOT_HISTORY: [[AtomicU64; STACK_PIVOT_HISTORY_SIZE * STACK_PIVOT_HISTORY_FIELDS];
-    crate::arch_impl::aarch64::constants::MAX_CPUS] = {
+type StackPivotHistory = [[AtomicU64;
+    STACK_PIVOT_HISTORY_SIZE * STACK_PIVOT_HISTORY_FIELDS];
+    crate::arch_impl::aarch64::constants::MAX_CPUS];
+static STACK_PIVOT_HISTORY: CacheLineAligned<StackPivotHistory> = CacheLineAligned({
     const INIT_FIELD: AtomicU64 = AtomicU64::new(0);
     const INIT_CPU: [AtomicU64; STACK_PIVOT_HISTORY_SIZE * STACK_PIVOT_HISTORY_FIELDS] =
         [INIT_FIELD; STACK_PIVOT_HISTORY_SIZE * STACK_PIVOT_HISTORY_FIELDS];
     [INIT_CPU; crate::arch_impl::aarch64::constants::MAX_CPUS]
-};
-static STACK_PIVOT_HISTORY_IDX: [AtomicU64;
-    crate::arch_impl::aarch64::constants::MAX_CPUS] =
-    [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
-static STACK_PIVOT_ALIAS_REPORTED: [AtomicBool;
-    crate::arch_impl::aarch64::constants::MAX_CPUS] =
-    [const { AtomicBool::new(false) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
+});
+static STACK_PIVOT_HISTORY_IDX: CacheLineAligned<
+    [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS],
+> = CacheLineAligned([
+    const { AtomicU64::new(0) };
+    crate::arch_impl::aarch64::constants::MAX_CPUS
+]);
+
+#[cold]
+#[inline(never)]
+fn record_stack_pivot_alias(cpu: usize, dest_top: u64, cur_sp: u64, site: u8) {
+    let index = STACK_PIVOT_HISTORY_IDX[cpu].fetch_add(1, Ordering::Relaxed) as usize;
+    let base = (index % STACK_PIVOT_HISTORY_SIZE) * STACK_PIVOT_HISTORY_FIELDS;
+    STACK_PIVOT_HISTORY[cpu][base].store(site as u64, Ordering::Relaxed);
+    STACK_PIVOT_HISTORY[cpu][base + 1].store(dest_top, Ordering::Relaxed);
+    STACK_PIVOT_HISTORY[cpu][base + 2].store(cur_sp, Ordering::Relaxed);
+}
 
 #[inline(always)]
 fn assert_pivot_free(cpu: usize, dest_top: u64, cur_sp: u64, site: u8) {
@@ -1205,23 +1218,7 @@ fn assert_pivot_free(cpu: usize, dest_top: u64, cur_sp: u64, site: u8) {
         return;
     }
 
-    let index = STACK_PIVOT_HISTORY_IDX[cpu].fetch_add(1, Ordering::Relaxed) as usize;
-    let base = (index % STACK_PIVOT_HISTORY_SIZE) * STACK_PIVOT_HISTORY_FIELDS;
-    STACK_PIVOT_HISTORY[cpu][base].store(site as u64, Ordering::Relaxed);
-    STACK_PIVOT_HISTORY[cpu][base + 1].store(dest_top, Ordering::Relaxed);
-    STACK_PIVOT_HISTORY[cpu][base + 2].store(cur_sp, Ordering::Relaxed);
-
-    if !STACK_PIVOT_ALIAS_REPORTED[cpu].swap(true, Ordering::AcqRel) {
-        raw_uart_str("[STACK_PIVOT_ALIAS] cpu=");
-        raw_uart_dec(cpu as u64);
-        raw_uart_str(" site=");
-        raw_uart_dec(site as u64);
-        raw_uart_str(" dest_top=");
-        raw_uart_hex(dest_top);
-        raw_uart_str(" cur_sp=");
-        raw_uart_hex(cur_sp);
-        raw_uart_str("\n");
-    }
+    record_stack_pivot_alias(cpu, dest_top, cur_sp, site);
 }
 
 pub fn dump_stack_pivot_alias_history() {
@@ -2863,23 +2860,68 @@ fn setup_idle_return_locked(
 }
 
 #[inline(always)]
-fn reset_idle_continuation_locked(sched: &mut Scheduler, new_id: u64, idle_sp: u64) {
-    // The null-trampoline fallback may observe stale handoff IDs after it
-    // discovers there is no scheduler pointer to consume.  Only the thread
-    // actually being restarted as idle may have its continuation replaced.
-    if !sched.is_idle_thread_inner(new_id) {
+fn reset_idle_continuation_locked(
+    sched: &mut Scheduler,
+    cpu_id: usize,
+    target_id: u64,
+    idle_sp: u64,
+) {
+    let Some(cpu_state) = sched.cpu_state.get(cpu_id) else {
+        debug_assert!(false, "idle continuation reset for invalid CPU {cpu_id}");
+        return;
+    };
+    let owned_idle_id = cpu_state.idle_thread;
+    let current_id = cpu_state.current_thread;
+
+    // A global "is any idle thread" predicate is insufficient: a stale
+    // handoff ID can name another CPU's idle thread, and CPU 0's idle TCB also
+    // represents the bootstrap thread. Require exact per-CPU ownership and a
+    // scheduler state that has already committed this idle thread as current.
+    debug_assert_eq!(
+        target_id, owned_idle_id,
+        "idle continuation reset target is not CPU-owned idle"
+    );
+    debug_assert_eq!(
+        current_id,
+        Some(target_id),
+        "idle continuation reset target is not current"
+    );
+    if target_id != owned_idle_id || current_id != Some(target_id) {
         return;
     }
 
-    if let Some(thread) = sched.get_thread_mut(new_id) {
-        let idle_addr = idle_loop_arm64 as *const () as u64;
-        thread.saved_by_inline_schedule = false;
-        thread.inline_schedule_saved_sp = 0;
-        thread.inline_schedule_caller_lr = 0;
-        thread.context.sp = idle_sp;
-        thread.context.elr_el1 = idle_addr;
-        thread.context.x30 = idle_addr;
+    // handle_irq_event() must perform ICC_DIR_EL1 before irq_exit(), and the
+    // HARDIRQ bit blocks scheduler entry until then. Keep this helper outside
+    // every IRQ dispatch so it cannot strand a split-EOI deactivation.
+    debug_assert!(
+        !crate::per_cpu_aarch64::in_interrupt(),
+        "idle continuation reset while GIC deactivation may be pending"
+    );
+    if crate::per_cpu_aarch64::in_interrupt() {
+        return;
     }
+
+    // CPU 0 has no scheduler-owned, disposable idle continuation: its idle
+    // TCB is the bootstrap thread that ran kernel_main. Fresh-idle dispatch is
+    // still guaranteed by the explicit branch SP/PC at both call sites, but
+    // this persistent CpuContext must never be treated like a secondary CPU's
+    // purpose-built idle context.
+    if cpu_id == 0 {
+        return;
+    }
+
+    let Some(thread) = sched.get_thread_mut(target_id) else {
+        debug_assert!(false, "CPU-owned idle thread is absent from scheduler");
+        return;
+    };
+
+    let idle_addr = idle_loop_arm64 as *const () as u64;
+    thread.saved_by_inline_schedule = false;
+    thread.inline_schedule_saved_sp = 0;
+    thread.inline_schedule_caller_lr = 0;
+    thread.context.sp = idle_sp;
+    thread.context.elr_el1 = idle_addr;
+    thread.context.x30 = idle_addr;
 }
 
 /// Dispatch an idle thread — called inside scheduler lock hold.
@@ -3906,8 +3948,8 @@ extern "C" fn inline_schedule_trampoline() -> ! {
             // Persist the exact normalized stack value used by the live pivot.
             // Use the current idle ID from this lock hold, never either stale
             // handoff ID.
-            reset_idle_continuation_locked(sched, idle_id, idle_sp);
             sched.fix_exception_cleanup_cpu_state();
+            reset_idle_continuation_locked(sched, cpu_id, idle_id, idle_sp);
             idle_sp
         })
         // with_scheduler returns None only when the scheduler object itself is
@@ -4128,7 +4170,7 @@ extern "C" fn inline_schedule_trampoline() -> ! {
 
     let fresh_idle_sp = if is_idle {
         let idle_sp = idle_dispatch_stack(cpu_id, Aarch64PerCpu::kernel_stack_top());
-        reset_idle_continuation_locked(sched, new_id, idle_sp);
+        reset_idle_continuation_locked(sched, cpu_id, new_id, idle_sp);
         idle_sp
     } else {
         0


### PR DESCRIPTION
## Summary

Fixes CPU0's virtual timer (PPI 27) freezing on Parallels/HVF — a regression introduced by `b0644d39` ("fix(aarch64): guard pivots and scrub idle resumes", 2026-08-01). QEMU was never affected (aarch64 boot tests always passed there); only the HVF-backed Parallels bootstrap vCPU hit this. Manual bisection isolated the culprit, two independent analyses (Opus + a separate Codex/gpt-5.6 pass) reconciled to a single mechanism, and the fix removes the unsafe mutation while preserving `b0644d39`'s legitimate purpose.

## Bisect evidence

**Endpoints validated:**
- `72522cef` (branch point / main tip) — **BAD**: CPU0 `tick_count` freezes after ~6 ticks while `IRQ_TOTAL`/`CTX_SWITCH` keep climbing on every other counter — the classic "CPU0 alone stops taking timer interrupts" signature.
- `d27c2362` (pre-`b0644d39`) — **GOOD**: CPU0 keeps pace with peer CPUs indefinitely.

**Step log summary (manual bisection via `boot_check.sh`, sequential Parallels boots per commit):**
- Checked out `b0644d39` directly — reproduced the freeze, confirming it as the first bad commit (matches `72522cef`'s behavior, `d27c2362`'s parent range was clean).
- Same-evening follow-ups `c1da5c8b`, `d7c6b841`, `8ae33511` narrowed the null-fallback target (stale `new_id` → scheduler-owned `idle_id`) but did **not** fix it — HEAD @ `72522cef` remained BAD.
- Two candidate fixes were boot-tested and rejected before the final one:
  - Preserving saved inline continuations only — still froze, at 14 CPU0 ticks.
  - Completely suppressing the CPU0 scrub only — still froze, at 4 ticks.
- The complete guarded + cache-line-aligned + cold-path implementation (this PR) — **GOOD**, repeatedly.

## Reconciled mechanism

`reset_idle_continuation_locked()` (called from both the inline-schedule trampoline's null fallback and the ERET fast path's idle branch) unconditionally overwrites a thread's **saved** `CpuContext` — clobbering `saved_by_inline_schedule`, `context.sp`, `elr_el1`, and `x30` with idle-loop values — whenever the target ID matched an "is this idle" test that was not a sufficient ownership proof.

That test is CPU0-specific in effect because CPU0's idle thread is *not* a purpose-built idle thread: `Scheduler::new()` (via `init_with_current()`) installs the **currently-executing boot thread** as `cpu_state[0].idle_thread`. CPUs 1-7 get disposable, purpose-built idle TCBs from `register_cpu_idle_thread()`. So on CPUs 1-7 the scrub rewrites a context nobody needs; on CPU0 alone it can destroy a **live** kernel continuation belonging to a thread mid-flight in `kernel_main`/init/the bsshd-spawn corridor — the null-fallback path (reachable via a stale handoff ID even after the `c1da5c8b`/`d7c6b841` narrowing, since on CPU0 `idle_id` *is* the boot thread) is what actually fires here.

A parallel GIC audit found `handle_irq_event()` performs `deactivate_irq()` (`ICC_DIR_EL1`) **before** `irq_exit()`, and `check_need_resched_and_switch_arm64()` rejects scheduling under the full HARDIRQ/SOFTIRQ/NMI/PREEMPT mask — so the originally-hypothesized "scrub strands a live `ICC_DIR` obligation" route is **not reachable at this HEAD**. That hypothesis is explicitly disclosed as disproven rather than quietly dropped. The pivot-diagnostic instrumentation `b0644d39` also added was independently implicated as a secondary amplifier: its violation path performed synchronous raw-UART MMIO under masked DAIF, and on Parallels every such byte can trigger a VM exit, widening the same masked window. Isolating *just* the scrub-ownership fix still failed in testing (see step log above); only combining it with removing the live-path UART emission (keeping the lock-free postmortem ring, cache-line-aligned) produced a clean, repeatable boot — so both defects were real and both are fixed here.

## What this fix preserves

- `b0644d39`'s original stale-idle-continuation repair, for **verified, purpose-built secondary (CPU1-7) idle threads** — unchanged.
- The full lock-free per-CPU pivot postmortem ring (`assert_pivot_free` / `record_stack_pivot_alias`) — only the synchronous UART emission on the live/clean path was removed; rare-violation recording moved to a cold, out-of-line function, and both ring objects are now cache-line-aligned.
- Every GOLD-MASTER frozen region (idle loop, sleep-gate/WFI sequence, dispatch-ERET ISB, GIC SGI enablement, timer-handler arm-at-top) — untouched. Only `context_switch.rs` changed, entirely outside those regions.
- Debug-build assertions (and a release-build safe no-op) on any scrub call site that doesn't prove `target_id == cpu_state[cpu].idle_thread && current_thread == target_id` — so a future regression of this kind fails loudly instead of silently reintroducing the bug. CPU0's bootstrap/idle TCB is never scrubbed, full stop.

## Validation

- **Parallels (HVF), fresh VM per boot, `run.sh --parallels`, current HEAD:** 3/3 boots GOOD — CPU0 tick counter advanced continuously (65,000 / 75,000 / 65,000 ticks observed respectively) with heartbeats out to 123.6s / 150.6s / 125.6s uptime, **zero** `CPU0 REGRESSION ALARM`, `KERNEL PANIC`, or `STACK_PIVOT_ALIAS` markers across all three.
- **QEMU x86_64, 10-way parallel Docker boot test (`docker/qemu/run-boot-parallel.sh 10`):** 10/10 PASS, 0 failed — confirms no x86_64 regression (this bug and fix are aarch64/HVF-only; x86_64 was never affected).
- **Builds, zero warnings, re-verified against this exact commit:**
  - `cargo build --release --features testing,external_test_bins --bin qemu-uefi`
  - `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64`
  - `cargo build --release --target x86_64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel`

## Test plan

- [x] Manual bisection: endpoints validated, culprit commit isolated (`b0644d39`)
- [x] Two independent root-cause analyses reconciled against actual source (not just hypothesis-picking)
- [x] 3/3 fresh-VM Parallels boots, full CPU0 tick parity, zero fatal markers
- [x] 10/10 QEMU x86_64 parallel boot test
- [x] Zero-warning builds: `qemu-uefi` (x86_64), `kernel-aarch64` (aarch64), `kernel` (x86_64 custom target)
- [x] Zero-diff on all GOLD-MASTER frozen regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Ryan Breen
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
