### PR TITLE
Teardown closure: quiesce the fault-driven exit path (PR #417 follow-through)

### DIFF
--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -4457,6 +4457,8 @@ fn cpu0_breadcrumb(cpu_id: usize, id: u64) {
 
 pub fn schedule_from_kernel() {
     crate::task::process_task::drain_deferred_fault_sigsegv_exits();
+    crate::task::process_task::reclaim_deferred_process_resources();
+    crate::task::scheduler::reclaim_terminated_threads();
 
     let saved_daif = read_daif();
     let cpu_id = Aarch64PerCpu::cpu_id() as usize;

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -1660,7 +1660,8 @@ pub fn dump_all_eret_frame_anomaly_snapshots() {
     for cpu_id in 0..crate::arch_impl::aarch64::constants::MAX_CPUS {
         if let Some((tid, frame_elr, ctx_elr, x26, spsr)) = eret_frame_anomaly_snapshot(cpu_id) {
             any_recorded = true;
-            let owner_tid = LAST_DISPATCHED_TID[cpu_id].load(Ordering::Acquire);
+            let (owner_tid, _) =
+                decode_last_dispatched(LAST_DISPATCHED_TID[cpu_id].load(Ordering::Acquire));
             raw_uart_str("[ERET_ANOMALY] cpu=");
             raw_uart_dec(cpu_id as u64);
             raw_uart_str(" tid=");

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -752,27 +752,34 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
 
                 // The process exit below can retire this root. Leave it before
                 // acquiring the process manager and freeing any resources.
-                super::switch_ttbr0_to_kernel();
+                super::quiesce_ttbr0_for_exit();
 
-                // Find and terminate the process
+                // Resolve the victim without holding the process-manager lock
+                // across the scheduler-side non-runnable transition.
                 let mut terminated = false;
                 let mut already_terminated = false;
-                crate::process::with_process_manager(|pm| {
-                    if let Some((pid, _process)) = pm.find_process_by_cr3_mut(page_table_phys) {
-                        if _process.is_terminated() {
-                            already_terminated = true;
-                            return;
-                        }
+                let victim = crate::process::with_process_manager(|pm| {
+                    pm.find_process_by_cr3_mut(page_table_phys)
+                        .map(|(pid, process)| (pid, process.is_terminated()))
+                })
+                .flatten();
+                if let Some((pid, was_terminated)) = victim {
+                    let _ = crate::task::scheduler::with_scheduler(|sched| {
+                        sched.terminate_process_threads(pid.as_u64());
+                    });
+                    if was_terminated {
+                        already_terminated = true;
+                    } else {
                         crate::tracing::providers::process::trace_process_exit(
                             pid.as_u64() as u16,
                             (-11i16) as u16,
                         );
-                        pm.exit_process(pid, -11); // SIGSEGV exit code
+                        let _ = crate::process::with_process_manager(|pm| {
+                            pm.exit_process(pid, -11); // SIGSEGV exit code
+                        });
                         terminated = true;
-                    } else {
-                        // trace_data_abort already captured the fault
                     }
-                });
+                }
 
                 if terminated || already_terminated {
                     // CRITICAL: Mark the scheduler's thread as Terminated BEFORE
@@ -1113,26 +1120,34 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
 
                 // Install the kernel root before pm.exit_process can retire
                 // the faulting userspace root.
-                super::switch_ttbr0_to_kernel();
+                super::quiesce_ttbr0_for_exit();
 
                 let mut terminated = false;
                 let mut already_terminated = false;
                 let mut killed_pid: u64 = 0;
-                crate::process::with_process_manager(|pm| {
-                    if let Some((pid, _process)) = pm.find_process_by_cr3_mut(page_table_phys) {
-                        if _process.is_terminated() {
-                            already_terminated = true;
-                            return;
-                        }
+                let victim = crate::process::with_process_manager(|pm| {
+                    pm.find_process_by_cr3_mut(page_table_phys)
+                        .map(|(pid, process)| (pid, process.is_terminated()))
+                })
+                .flatten();
+                if let Some((pid, was_terminated)) = victim {
+                    let _ = crate::task::scheduler::with_scheduler(|sched| {
+                        sched.terminate_process_threads(pid.as_u64());
+                    });
+                    if was_terminated {
+                        already_terminated = true;
+                    } else {
                         killed_pid = pid.as_u64();
                         crate::tracing::providers::process::trace_process_exit(
                             pid.as_u64() as u16,
                             (-11i16) as u16,
                         );
-                        pm.exit_process(pid, -11); // SIGSEGV
+                        let _ = crate::process::with_process_manager(|pm| {
+                            pm.exit_process(pid, -11); // SIGSEGV
+                        });
                         terminated = true;
                     }
-                });
+                }
                 // Lock-free diagnostic AFTER releasing process manager lock
                 if terminated {
                     use crate::arch_impl::aarch64::context_switch::{raw_uart_dec, raw_uart_str};
@@ -1204,14 +1219,20 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                     core::arch::asm!("mrs {}, ttbr0_el1", out(reg) ttbr0, options(nomem, nostack));
                 }
                 let page_table_phys = ttbr0 & !0xFFFF_0000_0000_0FFF;
-                super::switch_ttbr0_to_kernel();
-                crate::process::with_process_manager(|pm| {
-                    if let Some((pid, process)) = pm.find_process_by_cr3_mut(page_table_phys) {
-                        if !process.is_terminated() {
-                            pm.exit_process(pid, -11);
-                        }
-                    }
-                });
+                super::quiesce_ttbr0_for_exit();
+                let victim = crate::process::with_process_manager(|pm| {
+                    pm.find_process_by_cr3_mut(page_table_phys)
+                        .map(|(pid, process)| (pid, process.is_terminated()))
+                })
+                .flatten();
+                if let Some((pid, _)) = victim {
+                    let _ = crate::task::scheduler::with_scheduler(|sched| {
+                        sched.terminate_process_threads(pid.as_u64());
+                    });
+                    let _ = crate::process::with_process_manager(|pm| {
+                        pm.exit_process(pid, -11);
+                    });
+                }
                 terminate_current_scheduler_thread();
             }
             // CRITICAL: Set frame values BEFORE switch_to_idle_best_effort()
@@ -1301,14 +1322,20 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                     core::arch::asm!("mrs {}, ttbr0_el1", out(reg) ttbr0, options(nomem, nostack));
                 }
                 let page_table_phys = ttbr0 & !0xFFFF_0000_0000_0FFF;
-                super::switch_ttbr0_to_kernel();
-                crate::process::with_process_manager(|pm| {
-                    if let Some((pid, process)) = pm.find_process_by_cr3_mut(page_table_phys) {
-                        if !process.is_terminated() {
-                            pm.exit_process(pid, -11);
-                        }
-                    }
-                });
+                super::quiesce_ttbr0_for_exit();
+                let victim = crate::process::with_process_manager(|pm| {
+                    pm.find_process_by_cr3_mut(page_table_phys)
+                        .map(|(pid, process)| (pid, process.is_terminated()))
+                })
+                .flatten();
+                if let Some((pid, _)) = victim {
+                    let _ = crate::task::scheduler::with_scheduler(|sched| {
+                        sched.terminate_process_threads(pid.as_u64());
+                    });
+                    let _ = crate::process::with_process_manager(|pm| {
+                        pm.exit_process(pid, -11);
+                    });
+                }
                 terminate_current_scheduler_thread();
             }
             // CRITICAL: Set frame values BEFORE switch_to_idle_best_effort()

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -1118,14 +1118,10 @@ impl ProcessManager {
     /// Exit a process with the given exit code
     #[allow(dead_code)]
     pub fn exit_process(&mut self, pid: ProcessId, exit_code: i32) {
-        if self
-            .processes
-            .get(&pid)
-            .map(|process| process.is_terminated())
-            .unwrap_or(true)
-        {
-            return;
-        }
+        let already_terminated = match self.processes.get(&pid) {
+            Some(process) => process.is_terminated(),
+            None => return,
+        };
 
         // Get parent PID before we borrow the process mutably
         let parent_pid = self.processes.get(&pid).and_then(|p| p.parent);
@@ -1138,23 +1134,32 @@ impl ProcessManager {
                 exit_code
             );
 
-            #[cfg(target_arch = "aarch64")]
-            {
-                // Fault exits always defer: the two-epoch grace covers both a
-                // peer's pre-shadow-stamp dispatch window and hardware TTBR0 lag.
-                // A peer's own EL1-fault shadow-clear window remains the same
-                // parked structural issue as normal-exit deferral.
-                let reclaim = crate::task::process_task::defer_process_resources(process);
-                crate::task::process_task::enqueue_process_reclaim(reclaim);
+            if already_terminated {
+                // Preserve the single-CoW-decref invariant: external terminate()
+                // already walked these mappings, so raw-drop them without ever
+                // routing the page table through another reclaim/decref path.
+                drop(process.page_table.take());
                 drop(process.stack.take());
-            }
-            #[cfg(not(target_arch = "aarch64"))]
-            crate::task::process_task::release_process_resources(process);
+                process.pending_old_page_tables.clear();
+            } else {
+                #[cfg(target_arch = "aarch64")]
+                {
+                    // Fault exits always defer: the two-epoch grace covers both a
+                    // peer's pre-shadow-stamp dispatch window and hardware TTBR0 lag.
+                    // A peer's own EL1-fault shadow-clear window remains the same
+                    // parked structural issue as normal-exit deferral.
+                    let reclaim = crate::task::process_task::defer_process_resources(process);
+                    crate::task::process_task::enqueue_process_reclaim(reclaim);
+                    drop(process.stack.take());
+                }
+                #[cfg(not(target_arch = "aarch64"))]
+                crate::task::process_task::release_process_resources(process);
 
-            // Keep termination after release/deferral. Once page_table is None,
-            // cleanup_cow_frames() cannot repeat the CoW walk; restoring the old
-            // order would walk the same CoW mappings twice.
-            process.terminate(exit_code);
+                // Keep termination after release/deferral. Once page_table is None,
+                // cleanup_cow_frames() cannot repeat the CoW walk; restoring the old
+                // order would walk the same CoW mappings twice.
+                process.terminate(exit_code);
+            }
 
             // Remove from ready queue
             self.ready_queue.retain(|&p| p != pid);

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -1118,6 +1118,15 @@ impl ProcessManager {
     /// Exit a process with the given exit code
     #[allow(dead_code)]
     pub fn exit_process(&mut self, pid: ProcessId, exit_code: i32) {
+        if self
+            .processes
+            .get(&pid)
+            .map(|process| process.is_terminated())
+            .unwrap_or(true)
+        {
+            return;
+        }
+
         // Get parent PID before we borrow the process mutably
         let parent_pid = self.processes.get(&pid).and_then(|p| p.parent);
 
@@ -1129,9 +1138,22 @@ impl ProcessManager {
                 exit_code
             );
 
-            // Drain any pending old page tables from previous exec() calls
-            process.drain_old_page_tables();
+            #[cfg(target_arch = "aarch64")]
+            {
+                // Fault exits always defer: the two-epoch grace covers both a
+                // peer's pre-shadow-stamp dispatch window and hardware TTBR0 lag.
+                // A peer's own EL1-fault shadow-clear window remains the same
+                // parked structural issue as normal-exit deferral.
+                let reclaim = crate::task::process_task::defer_process_resources(process);
+                crate::task::process_task::enqueue_process_reclaim(reclaim);
+                drop(process.stack.take());
+            }
+            #[cfg(not(target_arch = "aarch64"))]
+            crate::task::process_task::release_process_resources(process);
 
+            // Keep termination after release/deferral. Once page_table is None,
+            // cleanup_cow_frames() cannot repeat the CoW walk; restoring the old
+            // order would walk the same CoW mappings twice.
             process.terminate(exit_code);
 
             // Remove from ready queue
@@ -1141,13 +1163,6 @@ impl ProcessManager {
             if self.current_pid == Some(pid) {
                 self.current_pid = None;
             }
-
-            // Free heavy resources immediately rather than waiting for waitpid reap.
-            // CoW refcounts were already decremented by terminate() -> cleanup_cow_frames(),
-            // so it's safe to drop the page table now.
-            process.page_table.take();
-            process.stack.take();
-            process.pending_old_page_tables.clear();
 
             // Clean up window buffers so the compositor stops reading freed pages
             #[cfg(target_arch = "aarch64")]

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -222,7 +222,11 @@ impl ProcessScheduler {
                 if let Some((pid, process)) = manager.find_process_by_thread_mut(thread_id) {
                     let parent_pid = process.parent;
                     let process_name = process.name.clone();
-                    let children = core::mem::take(&mut process.children);
+                    let children = if pid == ProcessId::new(1) {
+                        alloc::vec::Vec::new()
+                    } else {
+                        core::mem::take(&mut process.children)
+                    };
 
                     // Extract FDs without closing them under the PM lock.
                     let fd_entries = process.take_fd_entries();
@@ -259,7 +263,6 @@ impl ProcessScheduler {
 
                     // Reparent children to init (PID 1)
                     if !children.is_empty() {
-                        use crate::process::ProcessId;
                         let init_pid = ProcessId::new(1);
                         for &child_pid in &children {
                             if let Some(child) = manager.get_process_mut(child_pid) {

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -220,6 +220,7 @@ impl ProcessScheduler {
         let phase1_result = {
             if let Some(ref mut manager) = *crate::process::manager() {
                 if let Some((pid, process)) = manager.find_process_by_thread_mut(thread_id) {
+                    let already_terminated = process.is_terminated();
                     let parent_pid = process.parent;
                     let process_name = process.name.clone();
                     let children = if pid == ProcessId::new(1) {
@@ -230,15 +231,24 @@ impl ProcessScheduler {
 
                     // Extract FDs without closing them under the PM lock.
                     let fd_entries = process.take_fd_entries();
-                    #[cfg(target_arch = "aarch64")]
-                    if let Some(reclaim) = defer_live_process_resources(process) {
-                        enqueue_process_reclaim(reclaim);
+                    if already_terminated {
+                        // Preserve the single-CoW-decref invariant: external
+                        // terminate() already walked these mappings, so raw-drop
+                        // them without another reclaim/decref path.
+                        drop(process.page_table.take());
                         drop(process.stack.take());
+                        process.pending_old_page_tables.clear();
                     } else {
+                        #[cfg(target_arch = "aarch64")]
+                        if let Some(reclaim) = defer_live_process_resources(process) {
+                            enqueue_process_reclaim(reclaim);
+                            drop(process.stack.take());
+                        } else {
+                            release_process_resources(process);
+                        }
+                        #[cfg(not(target_arch = "aarch64"))]
                         release_process_resources(process);
                     }
-                    #[cfg(not(target_arch = "aarch64"))]
-                    release_process_resources(process);
 
                     // Keep termination after release/deferral. Once page_table is
                     // None, cleanup_cow_frames() cannot repeat the CoW walk; moving

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -61,7 +61,7 @@ static DEFERRED_FAULT_EXIT_BUFFERS: [DeferredFaultExitBuffer; 1] =
     [const { DeferredFaultExitBuffer::new() }];
 
 #[cfg(target_arch = "aarch64")]
-struct PendingProcessReclaim {
+pub(crate) struct PendingProcessReclaim {
     page_table: Option<alloc::boxed::Box<crate::memory::process_memory::ProcessPageTable>>,
     old_page_tables: alloc::vec::Vec<
         alloc::boxed::Box<crate::memory::process_memory::ProcessPageTable>,
@@ -97,7 +97,7 @@ impl PendingProcessReclaim {
 static PENDING_PROCESS_RECLAIMS: spin::Mutex<alloc::vec::Vec<PendingProcessReclaim>> =
     spin::Mutex::new(alloc::vec::Vec::new());
 
-fn release_process_resources(process: &mut crate::process::Process) {
+pub(crate) fn release_process_resources(process: &mut crate::process::Process) {
     process.cleanup_cow_frames();
     process.drain_old_page_tables();
     drop(process.page_table.take());
@@ -106,7 +106,7 @@ fn release_process_resources(process: &mut crate::process::Process) {
 }
 
 #[cfg(target_arch = "aarch64")]
-fn defer_live_process_resources(
+pub(crate) fn defer_live_process_resources(
     process: &mut crate::process::Process,
 ) -> Option<PendingProcessReclaim> {
     let root_is_live = process
@@ -122,15 +122,22 @@ fn defer_live_process_resources(
         return None;
     }
 
-    Some(PendingProcessReclaim {
-        page_table: process.page_table.take(),
-        old_page_tables: core::mem::take(&mut process.pending_old_page_tables),
-        after_epoch: scheduler::retirement_grace_target(),
-    })
+    Some(defer_process_resources(process))
 }
 
 #[cfg(target_arch = "aarch64")]
-fn enqueue_process_reclaim(reclaim: PendingProcessReclaim) {
+pub(crate) fn defer_process_resources(
+    process: &mut crate::process::Process,
+) -> PendingProcessReclaim {
+    PendingProcessReclaim {
+        page_table: process.page_table.take(),
+        old_page_tables: core::mem::take(&mut process.pending_old_page_tables),
+        after_epoch: scheduler::retirement_grace_target(),
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn enqueue_process_reclaim(reclaim: PendingProcessReclaim) {
     crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().push(reclaim));
 }
 
@@ -217,8 +224,7 @@ impl ProcessScheduler {
                     let process_name = process.name.clone();
                     let children = core::mem::take(&mut process.children);
 
-                    // Mark terminated and extract FDs without closing them
-                    process.terminate_minimal(exit_code);
+                    // Extract FDs without closing them under the PM lock.
                     let fd_entries = process.take_fd_entries();
                     #[cfg(target_arch = "aarch64")]
                     if let Some(reclaim) = defer_live_process_resources(process) {
@@ -229,6 +235,11 @@ impl ProcessScheduler {
                     }
                     #[cfg(not(target_arch = "aarch64"))]
                     release_process_resources(process);
+
+                    // Keep termination after release/deferral. Once page_table is
+                    // None, cleanup_cow_frames() cannot repeat the CoW walk; moving
+                    // terminate()/terminate_minimal() earlier breaks that invariant.
+                    process.terminate_minimal(exit_code);
 
                     #[cfg(feature = "btrt")]
                     crate::test_framework::btrt::on_process_exit(pid.as_u64(), exit_code);

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -2591,6 +2591,25 @@ impl Scheduler {
         })
     }
 
+    /// Make every scheduler-owned thread for a process non-runnable.
+    #[cfg(target_arch = "aarch64")]
+    pub fn terminate_process_threads(&mut self, owner_pid: u64) {
+        for thread in self.threads.iter_mut() {
+            if thread.owner_pid == Some(owner_pid) {
+                thread.set_terminated();
+            }
+        }
+
+        let threads = &self.threads;
+        for queue in self.per_cpu_queues.iter_mut() {
+            queue.retain(|&thread_id| {
+                !threads.iter().any(|thread| {
+                    thread.id() == thread_id && thread.owner_pid == Some(owner_pid)
+                })
+            });
+        }
+    }
+
     /// Remove a thread from all per-CPU queues (used when blocking)
     pub fn remove_from_ready_queue(&mut self, thread_id: u64) {
         for q in self.per_cpu_queues.iter_mut() {

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -991,18 +991,21 @@ impl Scheduler {
                 return true;
             }
 
-            let stack_is_live = thread
-                .kernel_stack_top
-                .map(|top| {
-                    crate::memory::kernel_stack::is_kernel_stack_slot_live(top.as_u64())
-                })
-                .unwrap_or(false);
             let grace_elapsed = graces
                 .iter()
                 .find(|grace| grace.thread_id == thread.id())
                 .map(|grace| retirement_grace_elapsed(&grace.after_epoch))
                 .unwrap_or(false);
-            if stack_is_live || !grace_elapsed {
+            if !grace_elapsed {
+                return true;
+            }
+            if thread
+                .kernel_stack_top
+                .map(|top| {
+                    crate::memory::kernel_stack::is_kernel_stack_slot_live(top.as_u64())
+                })
+                .unwrap_or(false)
+            {
                 return true;
             }
 


### PR DESCRIPTION
## Summary

Follow-through on PR #417 (`fix/teardown-quiescence`): closes the remaining
teardown holes on the **fault-driven exit path** (`SIGSEGV`/`SIGBUS` exits
taken from an aarch64 EL0 synchronous exception) that #417's normal-exit
quiescence machinery didn't cover, plus three small standalone correctness
fixes surfaced along the way.

This is shipped as an **honest partial fix**. It closes everything that
survived five adversarial review rounds without a scope-widening defect; two
larger pieces of the original plan (a CLONE_VM thread-group teardown sweep,
and PID-1 death semantics) were attempted, found to introduce new blocking
defects, and were deliberately stripped back out. See "What it does not
claim" below.

## What ships

- **`quiesce_ttbr0_for_exit()` at all 4 EL0 fault sites** (`exception.rs`):
  each fault-exit path (data abort, instruction abort, and the two
  fault-deferral drain sites) now installs the kernel TTBR0 and clears both
  per-CPU TTBR0 return shadows *before* the process manager can retire the
  faulting root, mirroring #417's normal-exit machinery for the fault path.
- **Idempotent teardown at both entry points**: `ProcessManager::exit_process`
  (narrow `already_terminated` guard — computed via `.get()`, only short-
  circuits the resource release once flow reaches an already-terminated
  process, never skips reparent/`SIGCHLD`/ready-queue bookkeeping) and
  `handle_thread_exit` (matching `already_terminated` branch). Both raw-drop
  `page_table`/`stack`/`pending_old_page_tables` without a second
  `cleanup_cow_frames()` walk when a process was already torn down by a
  direct `Process::terminate()` caller — preserves the single-CoW-decref
  invariant across sigkill-then-exit, sigkill-then-fault, fault-only, and
  plain-exit orderings.
- **Victim-thread quarantine**: `Scheduler::terminate_process_threads(pid)`
  marks every scheduler-owned thread for the faulting process `Terminated`
  and drains it from the per-CPU ready queues *before* resource handoff, at
  all 4 fault sites.
- **Unconditional grace-stamped deferral on the fault path**: fault exits now
  always defer the address-space free through the existing two-epoch grace
  (`defer_process_resources`, no liveness gate), vs. the liveness-conditional
  `defer_live_process_resources` kept for normal exit. Reclaim order in
  `Scheduler` is grace-first/liveness-last (grace-elapsed checked and
  returned-early *before* kernel-stack liveness sampling — previously the
  reverse), and an extra drain site
  (`reclaim_deferred_process_resources` + `reclaim_terminated_threads`) now
  runs from `schedule_from_kernel` in addition to the existing `sys_fork`
  drain site, so fault exits can reclaim without waiting on a later fork.
- **Three standalone fixes**, review-verified as pure bugfixes with no
  behavioral coupling to the above:
  - `decode_last_dispatched()` used in `dump_all_eret_frame_anomaly_snapshots`
    instead of the raw packed `LAST_DISPATCHED_TID` word, so anomaly
    postmortems report the actual owner tid instead of a packed
    tid-and-slot garbage value.
  - Kernel-stack liveness sampling reordered to check grace-elapsed first
    (matching the deferred process-resource reaper's read order), rather
    than sampling live-stack state before the grace check.
  - Init-child retention on `PID 1` exit made explicit (`if pid ==
    ProcessId::new(1) { Vec::new() } else { take(children) }`) instead of
    relying on the take→reparent→`extend()` round-trip. **Correction to an
    earlier commit message on this branch**: this was originally written up
    as fixing a bug where main "silently discarded" init's children on exit.
    Review proved that's wrong — on main, `handle_thread_exit` always takes
    `process.children`, and because `get_process_mut(1)` aliases the exiting
    process when `pid == 1`, the reparent block's `extend()` round-trips them
    straight back. Main never drops them; this commit is a **behavioral
    no-op refactor**, not a fix. (History was reworded before ever pushing
    — nothing rewritten post-push.)

## What it does not claim

- **Full `CLONE_VM` thread-group teardown.** A group-wide teardown sweep
  (quarantine + exit every thread sharing the victim's `thread_group_id`,
  not just the single faulting pid) was attempted and passed three review
  rounds, but a fourth (dual Opus + Codex Sol) round found it introduced 4
  new blocking defects: `exec()` doesn't clear `thread_group_id`, so the
  sweep could target the wrong victim after an exec; the `owner_pids`
  snapshot could go stale across a lock drop mid-sweep; sibling kernel
  stacks were dropped without the grace machinery; and FD teardown for
  every group member ran under the process-manager lock with IRQs off. An
  independent Codex Sol audit verified those defects were real, and also
  verified the safety claim that matters for merging without the sweep:
  **the 5-commit core here is never worse than main for `CLONE_VM`
  siblings** — main frees the shared root synchronously on the first
  thread's exit; this branch just grace-defers that free. It retains memory
  longer, never frees earlier. The sweep was stripped back out on that
  basis; group-wide teardown is left as a follow-up (below).
- **PID-1 death semantics.** A `panic!("Attempted to kill init!")` guard
  (Linux `SIGKILL`-init-fatal semantics) was attempted at both teardown
  entry points. Its `#[cfg(not(feature = "testing"))]` scoping turned out to
  be backwards for this repo — `interactive = ["testing"]` in `Cargo.toml`
  means the real interactive/init build also carries the `testing` feature,
  so the cfg-gate disabled the panic in exactly the build where init is
  real PID 1, not just in the `smoke_hello_time` test harness it was meant
  to exempt. That couldn't be fixed cleanly within this round's scope and
  was removed along with the sweep. **Init-death behavior is unchanged from
  main** (no panic guard either way).

## Review history

Five adversarial review rounds on this branch (two of them dual Opus +
Codex Sol, per the 50/50 opus-tier review policy), plus a separate
independent Codex Sol audit that was dispatched specifically to adjudicate
the round-4 hard-stop and scope the final cut:

1. **Round 1** — 4 blocking findings (double-terminate idempotence gap
   producing a new x86 double-free, two ungated fault-path immediate-free
   holes, init-children guard-after-take regression). Fixed in one round.
2. **Round 2** — 2 blocking findings (idempotency guard overbroad enough to
   skip reparent/SIGCHLD for externally-SIGKILLed processes; dead-init
   reparent-target gap, which the round attempted to close via a PID-1
   panic). Fixed.
3. **Round 3 (dual Opus + Codex Sol)** — 3 blocking findings (PID-1 panic
   firing on normal test-harness exits; `handle_thread_exit` missing the
   `already_terminated` guard `exit_process` got; `terminate_process_threads`
   keyed on a single pid, missing `CLONE_VM` siblings). Fixed via a
   `thread_group_id`-based group sweep + cfg-gated panic.
4. **Round 4 (dual Opus + Codex Sol)** — 5 blocking findings, all inside
   round 3's two additions (4 in the `CLONE_VM` sweep, 1 in the panic
   cfg-gate). Declared a **hard stop**: round 3 fixed 3 defects and
   introduced 4 new ones — a net-negative divergence signal — so this went
   back to the operator instead of another automatic fix round.
5. **Independent Codex Sol audit** (post-hard-stop, read-only) — verified
   4 of the 5 round-4 blockers as real (one worse than originally stated),
   found the CLONE_VM safety claim ("core is strictly no-worse than main")
   true, scoped a correct fix for the sweep at 7-9 files across three hard
   protocols with a high likelihood of yet another review round, and
   recommended the surgical strip this PR ships instead.
6. **Strip round** (final surgical strip back to the review-stable core,
   history reworked into 5 clean commits) — 1 blocking finding, commit-
   message accuracy only (the init-children no-op mislabeled above),
   corrected by rewording before push. Zero code-level blocking findings on
   the final diff.

## Gates (honest numbers)

All numbers below were re-verified fresh at the exact merge HEAD
(`0ddb10de`) immediately before opening this PR, except the Parallels
section which is from the same day's validation run against this branch's
final commit set.

- **Builds — zero warnings, zero errors, all three configs:**
  `x86_64` (`--features testing,external_test_bins --bin qemu-uefi`),
  `aarch64` plain (`-Z build-std=core,alloc ... --bin kernel-aarch64`), and
  `aarch64` + `ec0_fault_inject`. All three re-verified with forced
  recompiles at HEAD; the aarch64 configs also link clean (no `CONDBR19`
  relocation failures). There is no dedicated in-repo runtime harness for
  `ec0_fault_inject`; it's a build-time-only gate.
- **x86 Docker boot-parallel: 3/3 PASS** (`./docker/qemu/run-boot-parallel.sh 3`,
  fresh run at HEAD).
- **aarch64 native boot** (`./docker/qemu/run-aarch64-boot-test-native.sh`,
  `smp=4`, `gic-version=3`, fresh run at HEAD): 4 CPUs online, `bsshd`
  started (PID 2) and listening on `0.0.0.0:2222`, 22 heartbeats logged,
  **zero** panic/`DATA_ABORT`/`INSTRUCTION_ABORT`/fault markers across all 5
  retry attempts. The script's own strict pass/fail gate reports FAIL on
  every attempt — but only because of the pre-existing `/bin/bwm` spawn
  `EIO` (reproduces on main too; same gap called out in PR #417's own gates
  section and in every review round on this branch; not touched by this
  branch's 5 changed files).
- **Parallels boot gate: 3/3 clean** (CPU0 ticks 55k-70k+, 100+ heartbeats
  each, zero fault markers, VMs force-stopped and verified stopped).
- **Parallels launcher streak: 10-consecutive-clean achieved** at attempt
  14 of 16 (attempt 1 + attempts 5-14 all `RESULT: PASS`,
  `inject_retries=0`; attempts 2-4 were `ENV: HOST_INPUT_WEDGE` — a
  host-side Parallels USB-HID dispatcher wedge, screen confirmed unlocked
  each time via Quartz, Breenix never exercised those 3 attempts — these
  broke the raw streak count per protocol but are not kernel faults).
  **Zero kernel-fault markers across all 16 attempts.**
- **Parallels 30-minute soak: clean** (uptime ~1,845,993 ms ≈ 30.8 min,
  CPU0 ticks to 1,035,000, 1,835 heartbeats, zero fault markers).
- Frozen gold-master regions (`idle_loop_arm64`, the ISB-before-ERET
  region, `aarch64_enter_exception_frame`, the GIC SGI-enable block,
  `timer_interrupt.rs`) and all 5 Tier-1 files (`syscall/handler.rs`,
  `syscall/time.rs`, `syscall/entry.asm`, `interrupts/timer.rs`,
  `interrupts/timer_entry.asm`) are byte-identical vs. `main` —
  `context_switch.rs`'s two touched spots (the `decode_last_dispatched` fix
  and the two new drain calls appended inside `schedule_from_kernel`, which
  starts at a completely different line than `idle_loop_arm64`) both fall
  outside every frozen region.

## Follow-ups (tracked, not fixed here)

- **`CLONE_VM` group seal + exec-time `thread_group_id`/`inherited_cr3`
  detach** — the group-wide teardown sweep this branch backed out of;
  needs `exec()` to clear/reseal group linkage before a correct sweep is
  safe.
- **Clone kernel-stack ownership transfer** — `Thread::clone` (thread.rs)
  leaves `kernel_stack_allocation` `None` on the clone; a distinct,
  pre-existing gap surfaced by the Codex Sol audit while investigating the
  sweep (not this branch's own regression, not fixed here).
- **Designated-init runtime flag + panic** — the PID-1 `SIGKILL`/death
  semantics this branch backed out of; needs a real "is this the designated
  init" runtime flag instead of a `Cargo.toml` feature-based cfg-gate
  before it can be scoped safely against the `interactive = ["testing"]`
  landmine that broke round 3's attempt.
- **Duplicate `SIGCHLD`/stale-exit-code on the already-terminated path** —
  the `already_terminated` branches added here still run the parent-wake/
  `SIGCHLD`/`btrt`-report block with a possibly-stale exit code. Non-fatal
  (`remove_process()`/`waitpid` reaping is idempotent — a `BTreeMap::remove`
  on an already-removed pid is a silent no-op) but a real data-correctness
  gap worth a fast follow-up.
- **Idle-path CoW-walk latency** — the new `schedule_from_kernel` drain
  site can now run a full address-space CoW walk + per-frame deallocation
  with IRQ/FIQ masked on the idle path (`idle_loop_arm64` masks via `msr
  daifset, #0xf` before reaching this call). Not a correctness bug, but
  worth measuring given this codebase's documented history of
  idle-path/CPU0-timer regressions.

## Parked

The full grave/reclaimer structural rewrite (proper deferred-reclaim
subsystem replacing the two-epoch-grace point-fixes here) stays parked on
`fix/teardown-grave`. Its design record, spec, and per-round findings live
at `docs/planning/teardown-lifecycle/` on that branch.

---

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
