### PR TITLE
docs: mark teardown closure complete (PR #418)

### DIFF
--- a/docs/planning/PROJECT_ROADMAP.md
+++ b/docs/planning/PROJECT_ROADMAP.md
@@ -1,0 +1,37 @@
+# Breenix OS Project Roadmap
+
+This is the master project roadmap for Breenix OS: current development status,
+completed phases, in-progress work, and planned work. Update after each PR
+merge and when starting new work.
+
+Detailed, per-issue tracking lives in Beads (`bd`), not here — this file
+stays a short pointer to what's current. Live turn-by-turn ARM64/Parallels
+work log: `docs/planning/ralph-roadmap.html`.
+
+## Current Development Status
+
+Focus is ARM64/Parallels: teardown/process-lifecycle correctness, SMP
+scheduling, and the userland/POSIX compliance stack (dashboard:
+https://v0-breenix-dashboard.vercel.app/).
+
+## Recently Completed
+
+- ✅ **Teardown closure: fault-driven exit path quiescence** ([PR #418](https://github.com/ryanbreen/breenix/pull/418), Aug 2026)
+  - Follow-through on [PR #417](https://github.com/ryanbreen/breenix/pull/417)'s normal-exit teardown quiescence, extended to the **fault-driven exit path** (SIGSEGV/SIGBUS taken from an aarch64 EL0 synchronous exception), which #417 didn't cover.
+  - `quiesce_ttbr0_for_exit()` installed at all 4 EL0 fault sites (data abort, instruction abort, both fault-deferral drain sites), mirroring #417's normal-exit machinery.
+  - Idempotent teardown at both entry points (`ProcessManager::exit_process`, `handle_thread_exit`): a narrow `already_terminated` guard skips the second `cleanup_cow_frames()` walk without skipping reparent/SIGCHLD/ready-queue bookkeeping, preserving the single-CoW-decref invariant across sigkill-then-exit, sigkill-then-fault, fault-only, and plain-exit orderings.
+  - Single-pid victim quarantine: `Scheduler::terminate_process_threads(pid)` marks and drains every scheduler-owned thread for the faulting process before resource handoff, at all 4 fault sites.
+  - Fault exits now always defer the address-space free through the two-epoch grace (no liveness gate); reclaim order in `Scheduler` is grace-first/liveness-last; a new drain site in `schedule_from_kernel` (alongside the existing `sys_fork` drain) lets fault exits reclaim without waiting on a later fork.
+  - Plus three standalone correctness fixes: `decode_last_dispatched()` used in anomaly postmortems (was reading a packed tid-and-slot word); kernel-stack liveness sampling reordered to check grace-elapsed first; PID-1 init-child retention on exit made explicit.
+  - **Deliberately out of scope** (attempted, found to introduce new blocking defects, stripped back out before merge — see PR body): a `CLONE_VM` thread-group-wide teardown sweep, and a PID-1 "kill init" panic guard. Both tracked as follow-ups below.
+  - The full grave/reclaimer structural rewrite (a proper deferred-reclaim subsystem, replacing these two-epoch-grace point-fixes) stays **parked** on branch `fix/teardown-grave`; design record and spec live at `docs/planning/teardown-lifecycle/` on that branch.
+
+## Planned Follow-ups
+
+- 📋 **CLONE_VM group seal + exec-time `thread_group_id`/`inherited_cr3` detach** — `bd breenix-n2f`
+- 📋 **`Thread::clone` kernel-stack ownership transfer** (mirror `fork`'s `kernel_stack_allocation` transfer) — `bd breenix-uoz`
+- 📋 **Designated-init runtime flag + panic-on-init-exit** — `bd breenix-k19`
+- 📋 **Duplicate SIGCHLD / stale exit code on the already-terminated exit path** — `bd breenix-90v`
+- 📋 **Idle-path CoW-walk latency under IRQ mask** in the `schedule_from_kernel` drain — `bd breenix-dmk`
+
+Run `bd list` / `bd ready` for the full current backlog.


### PR DESCRIPTION
## Summary
- Recreates `docs/planning/PROJECT_ROADMAP.md` (deleted 2025-11-26 as "hopelessly out of date"; README/CLAUDE.md/AGENTS.md/.cursor rules still link to it — this repairs the dead link) as a short, current pointer doc rather than reconstructing 8 months of missing history.
- Adds the teardown-closure entry as COMPLETED for #418: fault-driven exit path now quiesces TTBR0 + defers address-space frees behind the two-epoch grace with liveness-last reclaim; idempotent teardown at both entry points; single-pid victim quarantine; the three standalone decode/read-order/init-children fixes.
- Notes the deliberately-out-of-scope items from #418 (CLONE_VM group teardown sweep, PID-1 init panic guard) as planned follow-ups, each linked to a Beads issue (breenix-n2f, breenix-uoz, breenix-k19, breenix-90v, breenix-dmk).
- Notes the full grave/reclaimer structural rewrite remains parked on `fix/teardown-grave`.

## Test plan
- [x] Docs-only change; no build/test impact.