### PR TITLE
docs: switch issue tracking from Beads to GitHub issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -515,27 +515,21 @@ This is the agent's responsibility - do not wait for the user to ask.
 
 ## Work Tracking
 
-We use Beads (bd) instead of Markdown for issue tracking. Run `bd quickstart` to get started.
-
-<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
-## Beads Issue Tracker
-
-This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+We use GitHub Issues (not Beads/bd, and not Markdown TODO files) for issue tracking in this repo.
 
 ### Quick Reference
 
 ```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --claim  # Claim work
-bd close <id>         # Complete work
+gh issue list                          # Find available work
+gh issue view <number>                 # View issue details
+gh issue create --title ... --body ... # File a new issue
+gh issue close <number>                # Complete work
 ```
 
 ### Rules
 
-- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
-- Run `bd prime` for detailed command reference and session close protocol
-- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+- Use `gh issue` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Use MEMORY.md / project memory for persistent agent knowledge
 
 ## Session Completion
 
@@ -543,13 +537,12 @@ bd close <id>         # Complete work
 
 **MANDATORY WORKFLOW:**
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
+1. **File issues for remaining work** - Create GitHub issues for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
+3. **Update issue status** - Close finished work (`gh issue close`), update in-progress items
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```
@@ -562,4 +555,3 @@ bd close <id>         # Complete work
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
-<!-- END BEADS INTEGRATION -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -813,4 +813,4 @@ pkill -9 qemu-system-aarch64 2>/dev/null; pgrep -l qemu || echo "All QEMU proces
 
 ## Work Tracking
 
-We use Beads (bd) instead of Markdown for issue tracking. Run `bd quickstart` to get started.
+We use GitHub Issues (not Beads/bd, and not Markdown TODO files) for issue tracking. Run `gh issue list` to see open work and `gh issue create` to file new issues in this repo.

--- a/docs/planning/PROJECT_ROADMAP.md
+++ b/docs/planning/PROJECT_ROADMAP.md
@@ -4,9 +4,10 @@ This is the master project roadmap for Breenix OS: current development status,
 completed phases, in-progress work, and planned work. Update after each PR
 merge and when starting new work.
 
-Detailed, per-issue tracking lives in Beads (`bd`), not here — this file
-stays a short pointer to what's current. Live turn-by-turn ARM64/Parallels
-work log: `docs/planning/ralph-roadmap.html`.
+Detailed, per-issue tracking lives in GitHub Issues (`gh issue list` /
+`gh issue create` in `ryanbreen/breenix`), not here — this file stays a
+short pointer to what's current. Live turn-by-turn ARM64/Parallels work
+log: `docs/planning/ralph-roadmap.html`.
 
 ## Current Development Status
 
@@ -28,10 +29,10 @@ https://v0-breenix-dashboard.vercel.app/).
 
 ## Planned Follow-ups
 
-- 📋 **CLONE_VM group seal + exec-time `thread_group_id`/`inherited_cr3` detach** — `bd breenix-n2f`
-- 📋 **`Thread::clone` kernel-stack ownership transfer** (mirror `fork`'s `kernel_stack_allocation` transfer) — `bd breenix-uoz`
-- 📋 **Designated-init runtime flag + panic-on-init-exit** — `bd breenix-k19`
-- 📋 **Duplicate SIGCHLD / stale exit code on the already-terminated exit path** — `bd breenix-90v`
-- 📋 **Idle-path CoW-walk latency under IRQ mask** in the `schedule_from_kernel` drain — `bd breenix-dmk`
+- 📋 **CLONE_VM group seal + exec-time `thread_group_id`/`inherited_cr3` detach** — [#471](https://github.com/ryanbreen/breenix/issues/471)
+- 📋 **`Thread::clone` kernel-stack ownership transfer** (mirror `fork`'s `kernel_stack_allocation` transfer) — [#481](https://github.com/ryanbreen/breenix/issues/481)
+- 📋 **Designated-init runtime flag + panic-on-init-exit** — [#464](https://github.com/ryanbreen/breenix/issues/464)
+- 📋 **Duplicate SIGCHLD / stale exit code on the already-terminated exit path** — [#433](https://github.com/ryanbreen/breenix/issues/433)
+- 📋 **Idle-path CoW-walk latency under IRQ mask** in the `schedule_from_kernel` drain — [#448](https://github.com/ryanbreen/breenix/issues/448)
 
-Run `bd list` / `bd ready` for the full current backlog.
+Run `gh issue list --repo ryanbreen/breenix` for the full current backlog.

--- a/docs/planning/ralph-roadmap.html
+++ b/docs/planning/ralph-roadmap.html
@@ -66,20 +66,20 @@
 
   <h2>📋 Queued — non-gold-master (ARM64)</h2>
   <div class="grid">
-    <div class="card"><h3>SOFT_LOCKUP_VIRGL Parallels failure class <span class="badge b-p1">P1</span> <span class="arch">ARM64 · Parallels</span></h3><p>Investigate + classify the <code>SOFT_LOCKUP_VIRGL</code> failure class on Parallels. beads <code>breenix-ha9</code>.</p></div>
-    <div class="card"><h3>F15 — ARM64 AHCI timeout corridor after GICR discovery <span class="badge b-p1">P1</span> <span class="arch">ARM64</span></h3><p>Remaining AHCI timeout corridor after GICR discovery; verify storage-driver-only (non-gold-master) vs <code>gic.rs</code> (signoff). beads <code>breenix-xk8</code>.</p></div>
-    <div class="card"><h3>bsshd SSH exit-status / close for exec <span class="badge b-p2">P2</span> <span class="arch">ARM64</span></h3><p>bsshd should send SSH exit-status + channel close for exec requests. beads <code>breenix-72x</code>.</p></div>
+    <div class="card"><h3>SOFT_LOCKUP_VIRGL Parallels failure class <span class="badge b-p1">P1</span> <span class="arch">ARM64 · Parallels</span></h3><p>Investigate + classify the <code>SOFT_LOCKUP_VIRGL</code> failure class on Parallels. GitHub <a href="https://github.com/ryanbreen/breenix/issues/454">#454</a>.</p></div>
+    <div class="card"><h3>F15 — ARM64 AHCI timeout corridor after GICR discovery <span class="badge b-p1">P1</span> <span class="arch">ARM64</span></h3><p>Remaining AHCI timeout corridor after GICR discovery; verify storage-driver-only (non-gold-master) vs <code>gic.rs</code> (signoff). GitHub <a href="https://github.com/ryanbreen/breenix/issues/485">#485</a>.</p></div>
+    <div class="card"><h3>bsshd SSH exit-status / close for exec <span class="badge b-p2">P2</span> <span class="arch">ARM64</span></h3><p>bsshd should send SSH exit-status + channel close for exec requests. GitHub <a href="https://github.com/ryanbreen/breenix/issues/430">#430</a>.</p></div>
   </div>
 
   <h2>🔒 Signoff-gated — gold-master / CPU0 cluster (awaiting operator)</h2>
   <div class="grid">
-    <div class="card"><h3>CPU0 timer-death + scheduler cluster <span class="badge b-block">signoff</span> <span class="arch">ARM64 · Parallels</span></h3><p>CPU0 vtimer death on Parallels + remote-wake / resched scheduling. Fixes live in frozen gold-master <code>timer_interrupt.rs</code> / <code>gic.rs</code> / <code>context_switch.rs</code> → need operator signoff (this cluster burned ~a week before). beads <code>oia, 9f1, cb7, 6f4, e43, k16, eh4</code>.</p></div>
-    <div class="card"><h3>BusyBox applet DATA_ABORT — ARM64 musl TLS <span class="badge b-block">signoff</span> <span class="arch">ARM64</span></h3><p>BusyBox applet faults on the ARM64 musl TLS path (errno from a zero <code>TPIDR_EL0</code>). User-facing symptom fixed (native <code>bls</code> as <code>/bin/ls</code>); principled TLS fix touches gold-master context-switch → signoff. beads <code>breenix-b7u</code>.</p></div>
+    <div class="card"><h3>CPU0 timer-death + scheduler cluster <span class="badge b-block">signoff</span> <span class="arch">ARM64 · Parallels</span></h3><p>CPU0 vtimer death on Parallels + remote-wake / resched scheduling. Fixes live in frozen gold-master <code>timer_interrupt.rs</code> / <code>gic.rs</code> / <code>context_switch.rs</code> → need operator signoff (this cluster burned ~a week before). GitHub <a href="https://github.com/ryanbreen/breenix/issues/472">#472</a>, <a href="https://github.com/ryanbreen/breenix/issues/434">#434</a>, <a href="https://github.com/ryanbreen/breenix/issues/445">#445</a>, <a href="https://github.com/ryanbreen/breenix/issues/428">#428</a>, <a href="https://github.com/ryanbreen/breenix/issues/449">#449</a>, <a href="https://github.com/ryanbreen/breenix/issues/463">#463</a>, <a href="https://github.com/ryanbreen/breenix/issues/450">#450</a>.</p></div>
+    <div class="card"><h3>BusyBox applet DATA_ABORT — ARM64 musl TLS <span class="badge b-block">signoff</span> <span class="arch">ARM64</span></h3><p>BusyBox applet faults on the ARM64 musl TLS path (errno from a zero <code>TPIDR_EL0</code>). User-facing symptom fixed (native <code>bls</code> as <code>/bin/ls</code>); principled TLS fix touches gold-master context-switch → signoff. GitHub <a href="https://github.com/ryanbreen/breenix/issues/439">#439</a>.</p></div>
   </div>
 
   <h2>⏸ Deprioritized — x86_64 (future)</h2>
   <div class="grid">
-    <div class="card"><h3>E5-1 — execv child returns to kernel RIP under Ring 3 <span class="badge b-parked">x86 future</span> <span class="arch">x86_64</span></h3><p>Process/thread context-sync bug on blocked-in-syscall wake/restore mid-<code>execv</code>. ARM64-focus → deprioritized. beads <code>breenix-ql2</code>.</p></div>
+    <div class="card"><h3>E5-1 — execv child returns to kernel RIP under Ring 3 <span class="badge b-parked">x86 future</span> <span class="arch">x86_64</span></h3><p>Process/thread context-sync bug on blocked-in-syscall wake/restore mid-<code>execv</code>. ARM64-focus → deprioritized. GitHub <a href="https://github.com/ryanbreen/breenix/issues/474">#474</a>.</p></div>
     <div class="card"><h3>NB-2 — ARP stage-22 boot-stages stall <span class="badge b-parked">x86 future</span> <span class="arch">x86_64</span></h3><p>x86 boot-stages hang at <code>[22/252] ARP reply received</code>; ARM64-focus → deprioritized (x86 boot-stages is not used as a gate).</p></div>
   </div>
 
@@ -97,8 +97,8 @@
 
   <h2>✅ Resolved without a fix (closed with evidence)</h2>
   <div class="grid">
-    <div class="card"><h3>0wf — BWM spawn-wedge <span class="badge b-done">dismissed</span></h3><p>6/6 fresh boots reached bwm <code>create_process_with_argv ENTRY</code> + full ELF load — harness/classification noise, not a real wedge. beads closed.</p></div>
-    <div class="card"><h3>c5d — ARM64 BWM GPU compositor for animated windows <span class="badge b-done">already fixed</span></h3><p>Live counters: <code>SUBMIT_3D</code> climbs ~154/s under Bounce while CPU full-frame composite stays flat — already GPU-composited by merged <a href="https://github.com/ryanbreen/breenix/pull/381">#381</a>. beads closed.</p></div>
+    <div class="card"><h3>0wf — BWM spawn-wedge <span class="badge b-done">dismissed</span></h3><p>6/6 fresh boots reached bwm <code>create_process_with_argv ENTRY</code> + full ELF load — harness/classification noise, not a real wedge. closed.</p></div>
+    <div class="card"><h3>c5d — ARM64 BWM GPU compositor for animated windows <span class="badge b-done">already fixed</span></h3><p>Live counters: <code>SUBMIT_3D</code> climbs ~154/s under Bounce while CPU full-frame composite stays flat — already GPU-composited by merged <a href="https://github.com/ryanbreen/breenix/pull/381">#381</a>. closed.</p></div>
     <div class="card"><h3>NB-3 — <code>ls</code> hang in bsh <span class="badge b-done">fixed</span></h3><p>Native <code>bls</code> installed as <code>/bin/ls</code> (the BusyBox applet musl-TLS fault is tracked separately as <code>b7u</code>).</p></div>
     <div class="card"><h3>NB-4 — window clipping <span class="badge b-done">= oi6</span></h3><p>Resolved as the oi6 multi-window virtio-gpu fix (<a href="https://github.com/ryanbreen/breenix/pull/382">#382</a>).</p></div>
   </div>


### PR DESCRIPTION
## Summary
- Retires Beads (bd) as the Breenix issue tracker; GitHub issues in `ryanbreen/breenix` is now the backing store (all open bd issues were migrated 1:1 with full body content).
- Updates `CLAUDE.md` and `AGENTS.md` "Work Tracking" guidance to point at `gh issue list` / `gh issue create` / `gh issue close`, and removes bd-specific commands (`bd ready`, `bd prime`, `bd dolt push`, `bd remember`).
- Swaps the live `docs/planning/PROJECT_ROADMAP.md` and `docs/planning/ralph-roadmap.html` bd-id references for the corresponding migrated GitHub issue numbers.

## Not touched (intentionally)
- Historical `docs/planning/*/plan.md` and `scratchpad.md` entries describing past bd usage are left as-is — they're a record of what happened at the time, not live guidance.
- `.beads/` database itself is retired in place, not deleted.

## Test plan
- [x] Docs-only change; no build/test impact.
- [x] Grepped repo for remaining live (non-historical) bd/Beads references — none found outside this PR's intentional mentions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>