### PR TITLE
Teardown follow-ups: clone stack ownership, exit-status reporting + GPU DMA lifetime fix

### DIFF
--- a/kernel/src/drivers/virtio/gpu_pci.rs
+++ b/kernel/src/drivers/virtio/gpu_pci.rs
@@ -2424,18 +2424,13 @@ fn wait_for_ctrlq_completion(
 
     let expected_used_idx = previous_used_idx.wrapping_add(1);
     let expected_token = ctrlq_completion_token(expected_used_idx);
-    match GPU_COMPLETION.wait_timeout(expected_token, GPU_COMPLETION_TIMEOUT_NS) {
-        Ok(true) => {}
-        Ok(false) => {
-            record_gpu_wait_ticks(sleep_start);
-            virtgpu::trace_wait_completion_exit(cmd_type, resource_id, wait_path, false);
-            return Err("GPU PCI command completion timeout");
-        }
-        Err(_eintr) => {
-            record_gpu_wait_ticks(sleep_start);
-            virtgpu::trace_wait_completion_exit(cmd_type, resource_id, wait_path, false);
-            return Err("GPU PCI command completion interrupted");
-        }
+    let completed = GPU_COMPLETION
+        .wait_timeout_uninterruptible(expected_token, GPU_COMPLETION_TIMEOUT_NS)
+        .expect("uninterruptible GPU completion wait returned an error");
+    if !completed {
+        record_gpu_wait_ticks(sleep_start);
+        virtgpu::trace_wait_completion_exit(cmd_type, resource_id, wait_path, false);
+        return Err("GPU PCI command completion timeout");
     }
 
     record_gpu_wait_ticks(sleep_start);

--- a/kernel/src/syscall/clone.rs
+++ b/kernel/src/syscall/clone.rs
@@ -243,9 +243,19 @@ pub fn sys_clone(
 
     // Get the thread from the newly inserted process to add to scheduler
     let scheduler_thread = if let Some(process) = manager.get_process_mut(child_pid) {
-        if let Some(ref thread) = process.main_thread {
-            // Create a copy for the scheduler
-            Some(Box::new(thread.clone()))
+        if let Some(ref mut thread) = process.main_thread {
+            #[cfg(target_arch = "aarch64")]
+            let scheduler_thread = {
+                let mut scheduler_thread = thread.clone();
+                // The scheduler owns the child's kernel stack so reclamation is
+                // protected by the two-epoch retirement grace, as it is for fork.
+                scheduler_thread.kernel_stack_allocation = thread.kernel_stack_allocation.take();
+                scheduler_thread
+            };
+            #[cfg(not(target_arch = "aarch64"))]
+            let scheduler_thread = thread.clone();
+
+            Some(Box::new(scheduler_thread))
         } else {
             None
         }

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -256,7 +256,16 @@ impl ProcessScheduler {
                     process.terminate_minimal(exit_code);
 
                     #[cfg(feature = "btrt")]
-                    crate::test_framework::btrt::on_process_exit(pid.as_u64(), exit_code);
+                    {
+                        // terminate_minimal() is a no-op on a repeat teardown pass (process.rs:320
+                        // early-returns without touching exit_code), so process.exit_code already
+                        // holds the first-recorded status here on every pass — report that, never
+                        // this pass's exit_code parameter, so a later pass with a different code
+                        // (e.g. a fault arriving after an earlier SIGKILL) can't overwrite what the
+                        // parent already reaped via waitpid.
+                        let reported_exit_code = process.exit_code.unwrap_or(exit_code);
+                        crate::test_framework::btrt::on_process_exit(pid.as_u64(), reported_exit_code);
+                    }
 
                     // Set SIGCHLD on parent and get parent thread ID for wakeup
                     let parent_tid = if let Some(parent_pid) = parent_pid {


### PR DESCRIPTION
Closes #433
Closes #481

## Summary

Three point-fixes from the R23 teardown follow-up round, merged after the round's own Parallels validation gate caught a real use-after-free in the GPU driver.

**1. `a2aa4359` fix(clone): preserve kernel stack retirement grace**
On aarch64, `sys_clone` cloned the scheduler-owned thread copy without transferring `kernel_stack_allocation` from the process-owned thread, unlike `fork`. That left the child's kernel stack owned by the process-side thread instead of the scheduler-side copy, so it was not protected by the two-epoch retirement grace and liveness checks that guard reclamation elsewhere. The fix transfers ownership to the scheduler-owned copy on aarch64 (`x86_64` behavior unchanged). Fixes #481.

**2. `6c3cf1be` fix(process): preserve first-recorded exit status**
Repeat teardown passes on the same process (e.g. a fault arriving after an earlier SIGKILL) now report the *first-recorded* exit status to `btrt`/waitpid consumers instead of the later pass's exit-code parameter, since `terminate_minimal` is a no-op on a repeat pass and `process.exit_code` already holds the correct value. SIGCHLD delivery, parent wakeup, and `btrt` reporting all stay unconditional on every pass — their consumers are idempotent, and a repeat pass can be the parent/test-framework's only notification. Note: an earlier round's proposal to *suppress* the repeat-pass `btrt` call entirely was investigated and **disproven** during review — `btrt::on_process_exit` has exactly one call site, so suppressing it would have dropped the only SIGCHLD-driven exit notification in some sequences. This commit keeps all notifications and only fixes which status value is reported. Fixes #433.

**3. `fa5bd98c` fix(gpu): do not free device-owned ctrlq DMA buffers on spurious signal interruption**
Found by this round's own Parallels gate, not by review. A dual Opus+Codex-Sol RCA converged on: a child's exit sets `SIGCHLD` pending on the compositor; the VirtIO-GPU ctrlq completion wait was interruptible, and `check_signals_for_eintr` ignores signal disposition, so the default-ignored `SIGCHLD` spuriously aborted the wait; the `?`-propagated early return then freed the heap-backed DMA buffers while the device still held live virtqueue descriptors pointing at them; the device's later DMA write of display geometry into the freed heap poisoned a `linked_list_allocator` `Hole.next` pointer; a later, unrelated free walked the poisoned list and took an EL1 `DATA_ABORT` in `HoleList::deallocate+0xf8`. Fix: switch the single ctrlq completion wait call site to the existing, documented `wait_timeout_uninterruptible` API, matching the AHCI precedent (`drivers/ahci/mod.rs`) for waits on already-issued device commands with live DMA. The 5s timeout remains the liveness backstop.

## Not included, still open

- **#464** (designated-init flag + panic-on-init-exit) — reverted after five review findings across three attempts (misattributed panic escalation, panic reachable under a DAIF-masked PM guard, PID-1/testing-build incoherence, userspace disagreement on failure path). Needs design-first work together with #471 (CLONE_VM thread-group sealing) rather than another point-fix attempt.
- **#448** (idle-path CoW-walk drain bound) — three separate bounded-drain designs were attempted across this round and each drew its own blocking review finding: a shared cap across sweeps broke fork's full-drain guarantee, a second design left drain coverage incomplete, and a third introduced a lock-inversion class (scheduler lock nested inside a DAIF-masked PM guard, plus a blocking `FRAME_METADATA` lock and `log::info!` under mask) via `sys_clone`'s new pre-drain call. Stays open; must be designed together with #492 (fault-drain latency), since both are instances of the same "unbounded/unsafely-bounded drain under masked interrupts" problem.
- **#471** (CLONE_VM thread-group sealing) — excluded from this round's scope from the start; separate design-first effort.

Three new issues filed from residuals surfaced during this round's review and RCA:
- #491 — SIGKILL teardown bypasses the hardened exit path (pre-existing eager-free UAF class in `send_signal_to_process`'s SIGKILL branch; a fix attempt in this round was reverted after it surfaced this defect rather than introducing it)
- #492 — Fault-exit deferred drain is unbounded under IRQ mask (pre-existing; `DEFERRED_FAULT_EXIT_BUFFERS` can replay up to 128 sequential `handle_thread_exit` passes in one `schedule_from_kernel` call under a fault storm)
- #493 — `check_signals_for_eintr` ignores signal disposition (the root cause of fix #3 above; default-ignored signals like SIGCHLD/SIGURG/SIGWINCH spuriously interrupt every kernel wait built on this helper — futex, epoll, `wait.rs`, AHCI, `socket.rs`, `time.rs` all share the same imprecise check and need audit once the disposition predicate is corrected)

## Gates

**Pre-fix Parallels run** (`logs/parallels-launcher-test/run-20260804-191216/`): Part 1 — 3/3 boots GOOD (cpu0 ticks 40000-55000, heartbeats present, zero fault markers). Part 2 launcher streak — attempt 1 PASS, attempt 2 PASS, attempt 3 **RED**: EL1 `DATA_ABORT` (FAR=0x3c000000508, ESR=0x96000004 DFSC=0x4) on cpu0 immediately after `blauncher exit(0)` + a `VirGL FAILED: GPU PCI command completion interrupted` compositor error. This is the fault RCA'd and fixed by commit `fa5bd98c` above; merge was held until the fix landed and re-passed gates.

**Post-fix QEMU**: x86_64 `testing` build — 0 warnings/errors. aarch64 plain — 0 warnings/errors. aarch64 `ec0_fault_inject` — 0 warnings/errors. 2 independent aarch64 SMP=4 boots — both clean (4 CPUs online, bsshd listening on 0.0.0.0:2222, heartbeats through ~12.8s uptime, zero crash markers). x86 `run-boot-parallel.sh` — 1/1 PASS. Frozen gold-master regions and all Tier-1 prohibited files confirmed byte-identical to `main` via `git diff`.

**Post-fix Parallels**: 10/10 consecutive clean `parallels-launcher-test` runs post-fix (`logs/parallels-launcher-test/run-20260804-204459` through `run-20260804-211308`), every run `RESULT: PASS`, `inject_retries=0`, zero kernel fault markers — this is the exact blauncher-exit → compositor-GPU-wait interaction that produced the original fault, now exercised 10 times clean in a row.

Standard attribution: commits co-authored by Ryan Breen and Claude Fable 5.
