### PR TITLE
docs: teardown-unification v2 — close all 7 Codex ratification conditions

### DIFF
--- a/docs/planning/teardown-unification/DESIGN.md
+++ b/docs/planning/teardown-unification/DESIGN.md
@@ -1,13 +1,42 @@
-# Teardown Unification — FINAL DESIGN (panel synthesis)
+# Teardown Unification — FINAL DESIGN v2 (panel synthesis, revised against ratification)
 
 **Status:** design-only proposal for operator ratification. No implementation performed, no runtime
 evidence claimed. Every build/QEMU/Parallels statement in this document is a *gate to be run*, never
 a result already obtained.
 
-**Base:** `main` @ `eebc8868` (anchors re-verified against the live tree during synthesis — see §0.3).
+**Base:** `main` @ `eebc8868` (anchors re-verified against the live tree during synthesis — see §0.3;
+re-verified again during the v2 revision at `main` @ `c9efdcc7`, which is v1 of these documents merged
+and no kernel change).
 **Scope:** #491 (spine), #464, #471. Acknowledges and does not foreclose #448, #492, #493.
 **Inputs:** design A (minimal-incremental, Opus), design B (Linux-fidelity, Codex Sol), design C
-(invariant-first, Codex Sol), two adversarial judge verdicts (Opus; Codex Sol).
+(invariant-first, Codex Sol), two adversarial judge verdicts (Opus; Codex Sol), and the **Codex Sol
+ratification refusal** (ENDORSE: NO — 2 fatal seams, 7 majors, 1 minor, 7 conditions).
+
+---
+
+## CHANGELOG — v2 deltas against the ratification conditions
+
+v1 was refused ratification (`ENDORSE: NO`) with two FATAL seam findings, seven MAJOR, one MINOR, and
+seven explicit conditions. This revision is **targeted**: everything the ratification did not
+criticise is preserved verbatim. Every change below is traceable to a numbered condition.
+
+| Cond | Condition (verbatim intent) | v2 closure | Where |
+|---|---|---|---|
+| **1** | Reorder so every wait-family PR has a real producer: request-only scheduler publication + victim-owned SIGKILL commit suppression move **before** the killable-wait subphases; re-derive the dependency graph honestly incl. the missing P3→P8 edge | Old P10 becomes **P9**; old P9a/b/c become **P10a/b/c**. P9 is independently implementable against P2 via the named `exit_request_is_boundary_reachable()` predicate with a **live, counted legacy remote-mark arm** for not-yet-migrated wait families; P10a/b/c each move one family into the reachable set; **P10c deletes the arm**. `#491 complete` therefore moves from P9 to **P10c** | §1.5, §2.1 Increment 2, §3 AC-10/AC-11, §6 R-2/R-16; PLAN §0 graph, P9, P10a/b/c |
+| **2** | Explicit `Pending→Claimed→Completed` state per obligation (or one exclusive redeemer), restoring what design C's single-worker serialization discharged; add the reap/tombstone retention gate **before** any phase ships row-resident resource bits | New **§1.6** defines the four-state obligation machine (`Absent/Pending/Claimed{claimer}/Completed`), PM as the sole serializer, the sole-redeemer invariant, and orphaned-claim recovery. New **retention rule**: `waitpid` no longer removes the row; it tombstones it. Shipped as **P6a (retention gate) before P6b (ledger)** | §1.4, **§1.6** (new), §3 AC-12, §4.3, §6 R-11/R-13/R-17; PLAN P6a/P6b |
+| **3** | P1's proof reads never hold the reclaim queue while acquiring scheduler or PM locks; the SIGKILL phase's retirement receipt is returned/enqueued only **after** the PM guard drops — no interim shape violating the no-overlapping-lock rule even temporarily | P1's drain becomes **detach → drop queue lock → prove → free-or-reinsert**; the under-queue-lock predicate stays epoch/shadow-only (lock-free atomics). P2 changes `exit_process` to **return** a `#[must_use] RetirementReceipt`; both existing PM-nested enqueue sites (`manager.rs:1152`, `process_task.rs:244`) are converted in P2 | §4.1, §4.3 (two new rows), §4.4; PLAN P1, P2 |
+| **4** | P8 must state explicitly how normal exit exercises the return-boundary hook in its own PR (no dormant hook) | §2.5 (new) gives the control flow: `sys_exit` publishes a self-request and returns; the **hook is the only entry to `do_exit_current`**, so every normal exit exercises it in the introducing PR. Also fills Codex's named P8 gaps: tombstone control flow and one-at-a-time FD acquisition | **§2.5** (new); PLAN P8 |
+| **5** | The fatal-signal convergence phase makes the delivery result **intent-only** and deletes the legacy Terminated-channel parent-notification action in the **same** PR | `DeliverResult::Terminated` (and its documented "caller MUST call notify") is **deleted**, replaced by `DeliverResult::FatalIntent{pid,tid,sig,code}` which is documented as performing no notification, no status write and no wake; notification is discharged solely by the P6b ledger | §2.1, §2.6 (new), §3 AC-12; PLAN P11 |
+| **6** | P0's counters wire into **named** existing teardown write-sites with at least one causally-paired nonzero defer/reclaim test; state the honest PR count; delete the false P2/P3/P4/P5 file-disjointness claim | PLAN P0 now names every write site with file:line and marks which counters are legitimately zero until a later phase; adds `fork_exit_defer_reclaim_pairing_test` (nonzero, per-pid paired). Honest count: **13 numbered phases / 16 PRs**. The parallel-merge claim is deleted; all phases merge sequentially | §7 OQ-8; PLAN P0, §0 graph, §0 PR ledger |
+| **7** | OQ-1 decided (coordinator-adopted): protected-init goes **Linux-faithful** — user-originated signals to designated init with no handler are **silently dropped, send returns success**, NOT `EPERM`; only init's own exit/exit_group or an unhandleable fatal fault is kernel-fatal | §2.2 death policy rewritten; §1.3 init row rewritten; §7 OQ-1 marked **DECIDED**; the `EPERM` claim (and its false "Linux-fidelity" label) is removed everywhere | §1.3, §2.2, §3 AC-2, §7 OQ-1; PLAN P12 |
+
+**Also folded in (Codex per-phase notes that named gaps, not conditions):** P8's hook-activation /
+tombstone / FD-acquisition control flow (§2.5); P7's statement that it does not supply P6's missing
+prerequisite (that is P6a's job); P2's UAF reduction restated with the receipt discipline.
+
+**Explicitly unchanged from v1** (not criticised, preserved verbatim): §0 adjudication in full, §1.1,
+§1.2, §1.5's rejection of `ExitPending`, §2.3 (#471 detach + seal), §2.4 (fault-victim attribution),
+§5 (scope cuts), §8 (lessons register) except for two added rows, and every residual not listed above.
 
 ---
 
@@ -66,13 +95,15 @@ Two consequences of the ruling are load-bearing and are honoured throughout §4:
 
 1. **The spine lands third, not eleventh.** #491's live eager-free UAF is closed in Phase 2 using
    only already-merged primitives (A's mechanism, hardened), and the *same call site* is then
-   progressively upgraded to B's victim-owned exit in Phases 8–10. We deliberately pay for the SIGKILL
+   progressively upgraded to B's victim-owned exit in Phases 8–10c. We deliberately pay for the SIGKILL
    arm twice rather than leave a confirmed UAF live behind ten PRs. This is the direct answer to
    Judge 1's fatal flaw against B, and it is why A's contribution is real even though A lost.
 2. **No phase ships dormant code.** Every new API has a live caller in the PR that introduces it
-   (`do_exit_current` ships with normal `exit` as its first consumer; each wait-family contract ships
-   with the SIGKILL-of-a-blocked-victim path it makes killable). No `#[allow(dead_code)]`, no
-   "activated later" phase.
+   (`do_exit_current` ships with normal `exit` as its first and *only* entry — §2.5; the request/wake
+   mechanism ships with the SIGKILL path as its live producer — §2.1). No `#[allow(dead_code)]`, no
+   "activated later" phase. *(v2 refinement, condition 1: where a phase ships a predicate with two
+   live arms — boundary-reachable vs legacy — **both** arms are exercised in that PR, and the legacy
+   arm is a ratcheted allowlist that shrinks to empty and is then deleted.)*
 
 ### 0.3 Anchors re-verified in the live tree during synthesis (not taken from the designs)
 
@@ -86,6 +117,33 @@ at `scheduler.rs:2599`. `exit_process` at `manager.rs:1120` carries `#[allow(dea
 performs the unconditional aarch64 grace-stamped defer. `Process::take_fd_entries` (`process.rs:335`)
 **returns an allocating `alloc::vec::Vec`** — confirming Judge 2's warning that it cannot be reused
 unchanged under PM. `init_shell.rs:1028` reads `getpid().map(|p| p.raw()).unwrap_or(0) != 1`.
+
+**v2 additions to the anchor set** (verified during the revision, needed by conditions 3 and 6):
+
+- `PENDING_PROCESS_RECLAIMS` is a `spin::Mutex<Vec<PendingProcessReclaim>>` at `process_task.rs:97`.
+  Its drain, `reclaim_deferred_process_resources` (`process_task.rs:375-392`), evaluates
+  `retirement_grace_elapsed(&reclaim.after_epoch) && !reclaim.root_is_live()` **while holding the
+  queue lock**. Both predicates are lock-free atomic reads today; P1's richer `RootProof` would add
+  scheduler-cached-root and live-row blockers, which take SCHEDULER and PM — that is the interim
+  violation condition 3 forbids, and §4.3 restructures the drain to prevent it.
+- There are exactly **two** `enqueue_process_reclaim` call sites, and **both are inside a live PM
+  guard**: `manager.rs:1152` (in `exit_process`) and `process_task.rs:244` (in `handle_thread_exit`
+  phase 1). Both take the reclaim-queue lock nested inside PM+DAIF-masked. Both are converted to
+  return-a-receipt in P2 (condition 3).
+- `terminate_process_threads` has five call sites: the four EL0 fault sites
+  (`arch_impl/aarch64/exception.rs:768,1135,1230,1333`) and, after P2, `syscall/signal.rs`.
+- `SGI_RESCHEDULE` is sent from `scheduler.rs:1857` and `:1886`; `SGI_RESCHEDULE = 0`
+  (`arch_impl/aarch64/constants.rs:85`); the handler dispatches at `exception.rs:1761`.
+- The `#492` overflow is `DeferredFaultExitBuffer::push` returning `false` at `process_task.rs:43`
+  (caller `defer_fault_sigsegv_exit`, `process_task.rs:352-360`) — dropped silently today.
+- `waitpid`'s reap physically removes the row: `syscall/wait.rs:385` calls
+  `manager.remove_process(child_pid)` → `manager.rs:1101-1104`. This is the row-lifetime seam
+  condition 2 closes with the tombstone gate.
+- `Process::terminate` (`process.rs:284`) calls `close_all_fds()` (`process.rs:294`, impl at `:347`);
+  `terminate_minimal` (`process.rs:320`) early-returns on a repeat pass;
+  `take_fd_entries` (`process.rs:335`) is the allocating extractor used at `process_task.rs:236`.
+- `retirement_grace_target`/`retirement_grace_elapsed` are `scheduler.rs:550`/`:563`;
+  `is_kernel_stack_slot_live` is `memory/kernel_stack.rs:283`.
 
 ---
 
@@ -108,29 +166,34 @@ the resource.
        │        counts disagreement and NEVER escalates fatally.
        ▼
  S1  REQUEST    ONE PM transaction. First status wins. Marks every live member of the
-       │        scope with one batch id; creates DURABLE work obligations in each row;
-       │        seals the group against clone/exec admission. Moves nothing, frees
-       │        nothing, allocates nothing, logs nothing, takes no second lock.
-       │        Returns #[must_use] ExitRequestResult + a preallocated fixed receipt.
+       │        scope with one batch id; creates DURABLE work obligations in each row
+       │        (Absent -> Pending, §1.6); seals the group against clone/exec admission.
+       │        Moves nothing, frees nothing, allocates nothing, logs nothing, takes no
+       │        second lock. Returns #[must_use] ExitRequestResult + a preallocated
+       │        fixed receipt.
        ▼
  S2  KICK       PM dropped. Scheduler transaction publishes the exit request onto each
        │        member's scheduler thread and readies proven-killable blocked victims
-       │        WITH their continuation intact. It NEVER sets a remote thread Terminated.
-       │        Returns ExitKickPlan. Then, holding NO lock: local need_resched +
-       │        BROADCAST SGI_RESCHEDULE to other online CPUs when the plan asks for it.
+       │        WITH their continuation intact. It NEVER sets a remote thread Terminated
+       │        once that member's wait family is migrated (§2.1 Increment 2). Returns
+       │        ExitKickPlan. Then, holding NO lock: local need_resched + BROADCAST
+       │        SGI_RESCHEDULE to other online CPUs when the plan asks for it.
        ▼
- S3  SELF-EXIT  Each victim runs do_exit_current() on ITSELF at its next safe boundary:
-       │        claim (atomic) → local TTBR0 leave (hardware first, shadows after) →
-       │        short PM commit (mark zombie, record first status, take own FDs, decide
+ S3  SELF-EXIT  Each victim runs do_exit_current() on ITSELF at its next safe boundary,
+       │        entered ONLY from the return-boundary hook (§2.5): claim (atomic) →
+       │        local TTBR0 leave (hardware first, shadows after) → short PM commit
+       │        (mark zombie, record first status, claim own obligations, decide
        │        last-reference, move root into a retirement receipt) → DROP PM → all slow
        │        work unlocked (one FD at a time, futex/clear_child_tid, bounded reparent
-       │        cursor, redeem the exactly-once notification receipt, enqueue receipt) →
-       │        pivot to neutral stack → mark ONLY SELF Terminated → schedule away.
+       │        cursor, redeem each claimed obligation and mark it Completed under a
+       │        fresh PM acquisition, enqueue receipt with PM dropped) → pivot to neutral
+       │        stack → mark ONLY SELF Terminated → schedule away.
        ▼
  S4  RETIRE     GRACE FIRST: RetirementFence (two epochs on every CPU in the captured
        │        online mask, acquire-ordered; an empty mask is INVALID, never "elapsed").
-       │        THEN RootProof + StackProof. Refusal records a per-blocker counter and
-       │        rotates. Physical free runs with NO PM and NO scheduler lock held.
+       │        THEN RootProof + StackProof, with NO queue lock held (§4.3). Refusal
+       │        records a per-blocker counter and rotates. Physical free runs with NO PM
+       │        and NO scheduler lock held. This gate also removes tombstoned rows (§1.6).
        ▼
  S5  ESCALATE   Init-death latch read in ordinary kernel context, all guards dropped,
                 DAIF restored, pre-panic lock/IRQ snapshot recorded, THEN panic.
@@ -140,11 +203,11 @@ the resource.
 
 | Path | S0 | S1 scope | S2 | S3 | Named variance |
 |---|---|---|---|---|---|
-| normal `exit(2)` | self TID | Member | no-op (self) | self | none |
+| normal `exit(2)` | self TID | Member | no-op (self) | self | S3 is entered from the return-boundary hook, never inline in the syscall body (§2.5) |
 | `exit_group` | self TID | ThreadGroup | kick siblings | each member | none |
 | EL0 fatal fault | faulting TID (CR3 cross-check) | ThreadGroup | kick siblings | **this** thread, via the fault site's existing mandatory redirect tail | S3 is entered from a redirect the fault site already performs unconditionally; the tail never branches on the teardown result |
-| SIGKILL / default-fatal signal | target PID | ThreadGroup | kick all | each member | sender never touches victim resources; `deliver_default_action` **returns** an intent instead of mutating under the PM borrow |
-| init death | committed PID only | as above | as above | as above | S1 latches; S5 escalates in ordinary context |
+| SIGKILL / default-fatal signal | target PID | ThreadGroup | kick all | each member | sender never touches victim resources; `deliver_default_action` **returns an intent only** and performs no notification (§2.6) |
+| init death | committed PID only | as above | as above | as above | **v2 (cond. 7):** user-originated fatal signals never reach S1 for the designated init — they are dropped at send and the send returns success. Only init's own `exit`/`exit_group` or an unhandleable fatal fault reaches S1, latches, and escalates at S5 |
 | CLONE_VM group member | member TID/PID | ThreadGroup (seal) | kick all | each member | seal is the same PM transaction as the mark — no snapshot ever leaves the lock |
 
 **The only structural asymmetry in the whole design** is that a killer cannot switch a remote CPU's
@@ -160,12 +223,23 @@ the *same* discharge the merged fault path already relies on for peer CPUs.
 // PM-owned. One lock, no second lock, no new global.
 ThreadGroupRecord { id, leader_pid, parent_pid, control: /*fixed, preallocated*/,
                     lifecycle: Open | ExecSealed{owner_tid, gen} | GroupExit{cause, gen},
-                    first_status, live_members, mm_owner_pid,
-                    notification: NotReady | Ready | Delivered | Reaped }
+                    first_status, live_members, mm_owner_pid }
 
 // Row-resident. The process row IS the work node — no collection grows during exit.
-ExitWorkBits { sigchld, parent_wake, report, reparent, fds, resources }  // durable obligations
-teardown_next: Option<ProcessId>                                        // intrusive link
+// v2 (condition 2): each obligation carries an explicit four-state lifecycle, not a bool.
+enum Obligation { Sigchld, ParentWake, Report, Reparent, Fds, Resources }   // 6 slots, fixed
+enum ObligationState {
+    Absent,                                   // never created for this row
+    Pending,                                  // created at first request; unowned
+    Claimed { claimer: ThreadId, at: RetirementFence },  // exactly one owner, in flight
+    Completed,                                // discharged; terminal
+}
+ExitLedger { state: [ObligationState; 6],     // fixed-size array; never allocates
+             first_status: Option<i32>, batch: GroupBatchId }
+
+// v2 (condition 2): row lifetime must outlive every obligation.
+RowState { Live, Zombie, Tombstone { reaped_by: ProcessId, status: i32 }, /* then removed */ }
+teardown_next: Option<ProcessId>              // intrusive link; no collection grows
 
 // Scheduler/boundary mirrors. Release/acquire. Carry NO ownership, authorize NO free.
 GroupExitWord { generation, cause, active }
@@ -177,9 +251,10 @@ RetirementSnapshot                       // proves Acquire loads + fence ran bef
 RootProof { blocked_epoch, blocked_hw, blocked_shadow, blocked_cached, blocked_live_row }
 ```
 
-`ExitWorkBits.resources` subsumes design A's proposed `ResourceState{Held,HandedOff}` — "the page
-table has left this row" is just another durable obligation, not a second parallel key. This is a
-real simplification the panel surfaced: A needed a separate field only because it had no ledger.
+`ExitLedger`'s `Resources` obligation subsumes design A's proposed `ResourceState{Held,HandedOff}` —
+"the page table has left this row" is just another durable obligation, not a second parallel key.
+This is a real simplification the panel surfaced: A needed a separate field only because it had no
+ledger.
 
 **Explicitly NOT added:** no `ExitPending` thread state (C's fatal flaw), no `ProcessGrave`, no
 graveyard stack, no `Arc<AddressSpace>` / mm-refcount conversion, no `ReclaimContext` capability
@@ -201,9 +276,99 @@ existing `finish_wait`/unregister path, and only then branches to the exit tramp
 never takes an external wait-queue lock and never discards a continuation.
 
 A wait primitive whose victim-owned cancellation path has not been audited and tested is classified
-**uninterruptible**: the request stays latched and the victim dies at its next natural safe boundary.
-This is a declared, counted, bounded-by-nothing delay (Residual R-2) — never a silent claim of
-killability, and never a free underneath a live stack.
+**uninterruptible**.
+
+> **v2 (condition 1) — what "uninterruptible" actually does, and why the sequence works.**
+> v1 said an uninterruptible victim "stays latched and dies at its next natural safe boundary". Under
+> the corrected phase order the request/wake mechanism (P9) ships *before* any wait family is
+> migrated (P10a/b/c), so at P9 **every** family is unmigrated — and "latch and hope" would be a kill-latency
+> regression against the P2 behaviour already merged. It is therefore replaced by an explicit,
+> named, two-armed predicate that ships with both arms live:
+>
+> ```rust
+> /// True iff this victim will demonstrably reach the return-boundary hook (§2.5)
+> /// without external help: it is runnable/running (EL0 or a preemptible kernel path),
+> /// or it is blocked in a wait family whose victim-owned cancellation has been
+> /// audited and tested (P10a/b/c).
+> fn exit_request_is_boundary_reachable(t: &SchedThread) -> bool
+> ```
+>
+> - **true** → publish `ThreadExitRequest`, **never** mark `Terminated` remotely; the victim commits
+>   its own exit at the hook.
+> - **false** → publish the request *and* fall back to the legacy remote mark + `exit_process` route,
+>   which is exactly the already-merged, already-gated P2 behaviour — no new mechanism, no new
+>   hazard, no latency regression. Counted per family as `EXIT_LEGACY_REMOTE_MARK{family}`.
+>
+> Each of P10a/b/c moves one family from the false set to the true set; the false set is a ratcheted
+> allowlist that **P10c drives to empty and then deletes along with the fallback arm**. This is the
+> same shrink-to-empty discipline the `\.terminate\(` allowlist already uses, and it is what makes
+> every wait-family PR a *consumer of a producer that already exists* rather than the reverse.
+> Residual R-2 is restated accordingly, and the new interim is disclosed as R-16.
+
+### 1.6 The exactly-once ledger — claim protocol and row retention *(v2, condition 2)*
+
+Design C discharged exactly-once notification with a **single-worker serialization**: one kthread was
+the only redeemer, so two producers could not both redeem. The synthesis dropped the worker (OQ-6,
+Tier-2 blast radius) and v1 did not replace what the worker was proving. Concurrent redeemers — the
+victim's own commit path and `handle_thread_exit` (which the fault-drain at `process_task.rs:369`
+and the syscall path at `handlers.rs:169` both reach) — were left mechanically unserialized. That was
+the second FATAL finding. This section supplies the replacement.
+
+**The serializer is the PM lock. There is no worker and no second lock.**
+
+Every state transition below happens **under the PM guard and nowhere else**, and no transition takes
+a second lock, allocates, or logs. Reading-then-writing the state within one PM acquisition is what
+makes the claim atomic; no CAS is required because PM already excludes.
+
+| # | Transition | Who may perform it | Rule |
+|---|---|---|---|
+| T1 | `Absent → Pending` | S1's request transaction only | Only on the **first** request for that row. A repeat request observes non-`Absent`, creates nothing, writes no second status, and returns the stored batch/status |
+| T2 | `Pending → Claimed{me, fence}` | any control path that will discharge it **immediately** | Claim and the start of work are in the same control path; `fence` is the retirement fence captured at claim time (used only by T4) |
+| T3 | `Claimed{me} → Completed` | **only** the claimer | Performed under a *fresh* PM acquisition after the work completed outside PM. `claimer == current_tid` is asserted; a mismatch bumps `LEDGER_CLAIM_MISMATCH`, which CI asserts is 0 |
+| T4 | `Claimed{dead} → Pending` | **only** the S4 retire/reap gate | Permitted only when the claimer is proven not live by P1's machinery (scheduler thread absent or `Terminated`) **and** the claim-time fence has elapsed. Bumps `LEDGER_CLAIM_ORPHANED` |
+
+**Sole-redeemer invariant (this is what replaces C's single worker):** *at most one control path is
+ever in `Claimed` for a given obligation, because every entry into `Claimed` reads the current state
+and writes the new one inside one PM acquisition.* Two producers racing to notify no longer both
+notify: whichever acquires PM first claims; the other observes `Claimed` or `Completed` and does
+nothing. The obligation is still **shared** — a later pass redeems it if the first never claimed it —
+so this is exactly-once, not suppression (the suppression theory was disproven in review and is not
+reopened; see §8).
+
+**Why a boolean is not sufficient.** A single "done" bit set at claim time is exactly-once but
+(a) cannot distinguish "in flight" from "discharged", which makes the AC-12 equality
+`SIGCHLD_FIRST_SET == PARENT_WAKE_COMPLETED == BTRT_EXIT_REPORTED == parented_first_commits`
+unassertable at any instant, and (b) cannot recover an abandoned claim, so a claimer that dies
+between claim and discharge loses the notification **permanently and silently**. The tri-state (plus
+`Absent`) costs one extra bit per obligation and makes both properties checkable. T4 is the recovery
+path; without it, exactly-once would be purchased with at-most-once.
+
+**Row retention — the reap/tombstone gate.** Obligations are row-resident, so the row must outlive
+every obligation. Today `waitpid` physically removes the row (`syscall/wait.rs:385` →
+`manager.rs:1101-1104 remove_process`), and the `Resources` obligation **by construction outlives
+reap** — grace and RootProof are not complete when the parent collects the status (that is R-13, and
+it is a property of the design, not an accident). Shipping row-resident resource bits before fixing
+row lifetime is the P6-before-P7 seam the ratification flagged. Therefore:
+
+> **Retention rule.** A row is removed from the process table only when (a) every obligation in its
+> ledger is `Completed` or `Absent`, **and** (b) its retirement receipt has been retired (grace
+> elapsed + RootProof passed) or was never created. `waitpid` no longer removes the row: it records
+> the reap and transitions `Zombie → Tombstone{reaped_by, status}`. A `Tombstone` row is invisible to
+> every lookup that means "a live process" — `find_process_by_pid/thread/cr3`, signal delivery, wait
+> scanning, procfs enumeration, and PID-reuse allocation — and visible only to the ledger and the
+> retire gate. The gate that finally removes it is the same S4 drain that retires resources.
+
+Two consequences, stated so they are not discovered later: PID reuse is delayed until the tombstone
+is removed (strictly safer than today, and bounded by the same grace the resources already wait on),
+and a leaked tombstone is a *visible* leak — `TOMBSTONE_RESIDENT` is a counter with a reader, asserted
+to return to zero at quiesce in every boot gate.
+
+**Phase consequence.** The retention gate ships as **P6a** and the tri-state ledger as **P6b**, in
+that order, and no phase before P6a makes any obligation row-resident that can outlive reap. P2's
+seed obligations (`Report`, `Sigchld`) are exempt and may ship first, because both are discharged no
+later than the zombie transition and a parent cannot reap a process that has not reached zombie —
+so they cannot outlive the row even under today's removal semantics. `Resources` is not exempt, and
+is the reason P6a exists.
 
 ---
 
@@ -225,14 +390,35 @@ function already contains a drop-before-scheduler precedent). Then:
 `with_scheduler(|s| s.terminate_process_threads(pid))` → **broadcast** `SGI_RESCHEDULE` to every
 other online CPU (no `cpu_state[].current_thread` predicate — see below) →
 `with_process_manager(|pm| pm.exit_process(pid, -9))`, which already performs the unconditional
-grace-stamped `defer_process_resources` + `enqueue_process_reclaim` on aarch64 **before**
-`terminate()` runs, so `cleanup_cow_frames()` walks a `None` page table and the CoW decref moves
-behind grace + RootProof. Plus the durable `report`/`sigchld` obligation seed (below).
+grace-stamped `defer_process_resources` on aarch64 **before** `terminate()` runs, so
+`cleanup_cow_frames()` walks a `None` page table and the CoW decref moves behind grace + RootProof.
+Plus the durable `report`/`sigchld` obligation seed (below).
+
+> **v2 (condition 3) — the receipt leaves PM before it is enqueued.** v1 relied on `exit_process`'s
+> existing body, which calls `enqueue_process_reclaim` at `manager.rs:1152` **inside the PM guard**,
+> nesting the reclaim-queue lock under PM+DAIF-masked. That is the A-style interim shape the adopted
+> no-overlapping-lock rule (§4.1) forbids and the B end-state must rip out — an interim violation is
+> still a violation. Phase 2 therefore changes the signature:
+>
+> ```rust
+> #[must_use]
+> pub fn exit_process(&mut self, pid: ProcessId, exit_code: i32) -> Option<RetirementReceipt>;
+> ```
+>
+> `exit_process` *stamps and takes* the root into the receipt under PM (as today) but **returns** it;
+> `with_process_manager(...)` yields the receipt to the caller, the PM guard drops, and only then does
+> the caller `enqueue_process_reclaim(receipt)` with no other lock live. The move is allocation-free:
+> `PendingProcessReclaim` is a fixed-size value and `core::mem::take(&mut process.pending_old_page_tables)`
+> leaves an empty `Vec` behind without allocating. The **other** PM-nested enqueue,
+> `handle_thread_exit` phase 1 at `process_task.rs:244`, is converted in the same PR by riding the
+> receipt out through the existing `phase1_result` value and enqueuing it in phase 2, where PM is
+> already dropped. After Phase 2, `RECLAIM_ENQUEUE_UNDER_PM == 0` is assertable and ratcheted.
 
 What Increment 1 does and does not buy, stated exactly:
 - **Removes** the eager CoW walk while the victim may be remote — the confirmed UAF class. *Strict
   reduction of work under PM+mask, not an addition:* today's SIGKILL does the full walk there.
 - **Adds** quarantine, expedite, and the missing SIGCHLD.
+- **Removes** (v2) both pre-existing reclaim-queue-under-PM nestings.
 - **Does not** yet make the exit victim-owned (still remote-marks), and **does not** yet move FD
   closure out of PM (`exit_process` → `terminate()` → `close_all_fds` is pre-existing at that
   convergence point; unchanged, not worsened; fixed in Phase 7).
@@ -243,17 +429,29 @@ Two defects the panel found in this exact mechanism are fixed *in Increment 1*, 
   decisive at Breenix's CPU count — a constant number of extra SGIs beats a fallible mask, and the
   SGI handler already does nothing but set `need_resched`. There is no stale read to be wrong about.
 - *Lost `btrt` report / parent wake* (Judge 2, fatal against A's AC-12): `btrt::on_process_exit` has
-  exactly one call site, inside `handle_thread_exit`, which a remotely-marked victim may never run.
-  Increment 1 therefore installs the **durable report obligation** at commit: a row work bit set once
-  at first commit and redeemed exactly once, outside PM, by whichever of {commit path,
-  `handle_thread_exit`} reaches it first. This is the seed that Phase 6 generalizes into the full
-  ledger. It is small, and it must land with the remote-kill path, not six phases later.
+  exactly one call site, inside `handle_thread_exit` (`process_task.rs:267`), which a remotely-marked
+  victim may never run. Increment 1 therefore installs the **durable report obligation** at commit: a
+  row obligation moved `Absent → Pending` once at first commit and redeemed exactly once, outside PM,
+  by whichever of {commit path, `handle_thread_exit`} **claims** it first (§1.6 T2/T3 — the seed
+  already uses the four-state machine, it is not a bool that P6b later upgrades). This is the seed
+  that Phase 6b generalizes into the full ledger. It is small, and it must land with the remote-kill
+  path, not six phases later.
 
-**Increment 2 (Phases 8–10) — make it victim-owned.** `terminate_process_threads` is redefined to
-*request and wake* (publish `ThreadExitRequest`, ready proven-killable blockers with continuations
-intact, return `ExitKickPlan`) and its remote-marking body is deleted in the same PR that removes
-its last remote-marking caller. SIGKILL then becomes a group-scoped `ExitIntent`, and every victim
-runs `do_exit_current` on itself. `Process::terminate` is deleted when its last caller goes.
+**Increment 2 (Phases 8 → 9 → 10a/b/c) — make it victim-owned.** *(v2, condition 1: the phase order
+here is the corrected one — the request/wake producer at P9 precedes every wait-family consumer.)*
+
+1. **P8** introduces `do_exit_current` and the return-boundary hook, with normal `exit(2)` as its
+   first and only entry (§2.5).
+2. **P9** redefines `terminate_process_threads` to *request and wake*: publish `ThreadExitRequest`,
+   return `ExitKickPlan`, and **suppress the remote `Terminated` commit for every boundary-reachable
+   victim** (§1.5). SIGKILL becomes a group-scoped `ExitIntent` and the group seal ships. Victims
+   blocked in a not-yet-migrated wait family take the counted legacy arm — the merged P2 behaviour,
+   unchanged.
+3. **P10a/b/c** migrate the wait families one per PR, each consuming the request/wake mechanism P9
+   already publishes and each proving deregistration-before-commit for its family. **P10c** empties
+   the legacy allowlist and deletes the remote-marking body; only then is #491 complete.
+4. **P11** deletes the last direct `Process::terminate` callers (§2.6), at which point
+   `Process::terminate` itself is deleted.
 
 `send_signal_to_all_processes` / `send_signal_to_caller_process_group` reach SIGKILL only through
 `send_signal_to_process`, so they are fixed by the same change.
@@ -285,10 +483,32 @@ so a build that never designates an init can never trip the policy.
   accessor. The three `test_userspace.rs` literals are creation-time setup, not teardown, and are
   named explicitly in the ratchet allowlist rather than silently ignored.
 
-**Death policy (Phase 12).** Recommended (Linux's protected-init intent, OQ-1):
-user-originated default-fatal signals — including SIGKILL — to the designated init are rejected with
-`EPERM` and set no group exit; a caught signal is handled normally; init's **own** `exit`/`exit_group`,
-an unhandleable synchronous fatal fault, or a nonviability invariant is kernel-fatal.
+**Death policy (Phase 12) — v2 (condition 7): Linux-faithful protected init, silent drop, no `EPERM`.**
+
+v1 recommended rejecting user-originated fatal signals to the designated init with `EPERM` and called
+that "Linux's protected-init intent". The ratification is correct that this is **not** what Linux
+does: Linux drops signals whose action would be the default fatal one when the target is protected
+(`SIGNAL_UNKILLABLE` / init in its namespace), and the **send path returns success** — `kill(1, SIGKILL)`
+from userspace returns 0 and nothing happens (`kernel/signal.c`, `prepare_signal`/`sig_task_ignore`
+region ~L79-117 and the `__send_signal`/`complete_signal` region ~L977-1083). The coordinator has
+**adopted the Linux-faithful behaviour**:
+
+> **Adopted policy.** A user-originated signal delivered to the **designated init** whose effective
+> disposition is the *default fatal action* and for which init has installed **no handler** is
+> **silently dropped**: it is never queued, never made pending, never delivered, and the sending
+> syscall **returns success (0)**. A signal init *has* a handler for is delivered and handled
+> normally — protection is disposition-scoped, not signal-scoped, exactly as in Linux. Only two
+> things are kernel-fatal: init's **own** `exit`/`exit_group`, and an **unhandleable** synchronous
+> fatal fault taken by init (or a nonviability invariant). Kernel-originated forced fatal signals are
+> not user-originated and are out of scope — Breenix has none targeting init today, and if one is
+> ever added it must be an explicit `force_sig`-equivalent that states its intent.
+
+Consequences that must not be discovered later, so they are stated here: `EPERM` is **not** returned,
+so no ABI divergence has to be documented and no test may assert `EPERM`; the drop is **counted**
+(`INIT_FATAL_SIGNAL_DROPPED`) so the behaviour is observable rather than invisible; and because the
+drop happens at send time, init's group is never sealed and `INIT_DEATH_LATCH` is never set by an
+external kill — the latch's only producers are init's own exit commit and the unhandleable-fault
+path, which is a strictly smaller and more auditable set than v1's.
 
 The fatal action never happens under a guard. S1 sets `INIT_DEATH_LATCH` (one relaxed store) **only
 for a committed, certainly-attributed victim** — an attribution miss or a TID/CR3 divergence can
@@ -318,7 +538,15 @@ space it never owned — no free, no refcount change. `thread_group_id`'s other 
 keying, `clear_child_tid` wake) all fall back to `pid` when `None`, which is exactly correct
 post-exec semantics.
 
-**The seal is the mark (Phase 3 admission + Phase 10 cutover).** There is no separate "snapshot then
+> **v2 (condition 4, second half) — why P3 is a hard prerequisite of P8, not just of P9.** P8's
+> victim commit makes the **last-reference decision** and builds the `RetirementReceipt` from the
+> row's own root plus `inherited_cr3`. A row that exec'd while still naming a stale `inherited_cr3`
+> would present a root it does not own to `RootProof`, which either blocks retirement forever
+> (`blocked_live_row` against a root nobody owns) or, worse, contributes a second claimant for one
+> root. Exec detach must therefore precede victim-owned exit, not merely precede group-scoped kill.
+> The dependency graph in the PLAN carries the `P3 → P8` edge explicitly; v1 omitted it.
+
+**The seal is the mark (Phase 3 admission + Phase 9 cutover).** There is no separate "snapshot then
 sweep". The group-exit PM transaction *is* the seal: it walks the process map once, marks every live
 row whose effective TGID matches with one batch id, and does nothing else. In the *same* PM lock
 discipline, `sys_clone` refuses to publish into a group that is not `Open`, and every user-thread
@@ -358,25 +586,122 @@ teardown result (grave-spec R8, adopted; A's rule, endorsed by Judge 2). Two ban
 `Option` that disabled the idle redirect); `#[must_use] ExitRequestResult` is for diagnostics and
 exhaustive matching, not control flow over mandatory work.
 
+### 2.5 The return-boundary hook — activation, tombstone, and FD acquisition *(v2, condition 4)*
+
+The ratification's fourth condition and its P8 note ("hook activation/tombstone/FD-acquisition need
+explicit control flow") are answered here rather than left to the implementation.
+
+**Activation — the hook is the ONLY entry into `do_exit_current`, so normal exit exercises it in the
+same PR that introduces it.** There is no second, inline call path that could let the hook lie
+dormant:
+
+```
+sys_exit(code)                                  [ordinary syscall context, no guard held]
+  └─ S1: one PM transaction on SELF — record first status, create obligations
+         (Absent -> Pending), mark row ExitRequested                      … PM dropped
+  └─ release-store ThreadExitRequest{state: Latched} on OWN scheduler thread
+  └─ return normally to the syscall return path            (no teardown work done here)
+
+<syscall/exception return path>
+  └─ existing PREEMPT_ACTIVE / nested-return gate                     (unchanged, first)
+  └─ HOOK: acquire-load of the per-thread exit-request word            (one load + branch)
+        └─ if Latched -> do_exit_current()   [preemptible kernel context, no guard held]
+```
+
+The hook is placed **after** the `PREEMPT_ACTIVE`/nested-return gate; it allocates nothing, locks
+nothing, walks nothing, drains nothing, and logs nothing. Because `sys_exit` performs *no* teardown
+inline, every normal `exit(2)` in the introducing PR — i.e. essentially every process the boot runs —
+traverses the hook. The gate asserts `EXIT_HOOK_ENTRIES > 0` and
+`EXIT_HOOK_ENTRIES == EXIT_COMMITS` on a normal boot; a dormant hook fails the phase.
+
+**Tombstone control flow at commit.** The victim never removes its own row and never decides its own
+reaping:
+
+```
+do_exit_current():
+  claim(atomic)                       -- one-shot; a second entry returns immediately
+  local TTBR0 leave                   -- hardware first, shadows after
+  PM #1 (short):  Live -> Zombie; first_status recorded; T2-claim {Fds, Resources,
+                  Sigchld, ParentWake, Report, Reparent} that THIS path will discharge;
+                  last-reference decision; root moved into RetirementReceipt      … drop PM
+  slow work, no guard held:  FD closes (below), futex / clear_child_tid,
+                  bounded reparent cursor (PM re-acquired per fixed batch),
+                  notification redemption; each obligation T3 -> Completed under its
+                  own fresh PM acquisition                                        … no overlap
+  enqueue RetirementReceipt           -- reclaim-queue lock only, PM already dropped
+  pivot to neutral stack; mark ONLY SELF Terminated; schedule away
+```
+
+The row then sits `Zombie` until a parent reaps it (`Zombie → Tombstone`, §1.6) and is removed by the
+S4 retire/reap gate once the ledger is fully `Completed` and the receipt has retired. Auto-reap cases
+(no parent, or the parent itself exiting) are handled by the reparent cursor re-parenting the child
+to the designated init before the parent's own row tombstones — the victim never short-circuits the
+gate.
+
+**FD acquisition control flow (P7's API, used here).** Exactly one descriptor crosses each PM
+acquisition, and the obligation states bracket the loop:
+
+```
+T2: Fds -> Claimed{me}                            [inside PM #1]
+loop {
+    let entry = with_process_manager(|pm| pm.take_next_for_exit(pid));   // PM held: move ONE
+    match entry { None => break, Some(e) => { /* PM dropped */ close(e); } }
+}                                                  // endpoint locks only, never with PM live
+T3: Fds -> Completed                              [fresh PM acquisition; table proven empty]
+```
+
+`take_next_for_exit` moves one `(fd, FileDescriptor)` out of the table into a fixed-size single-slot
+receipt; it never builds a `Vec`, which is why the allocating `Process::take_fd_entries()`
+(`process.rs:335`) is retired rather than reused. If the victim is preempted mid-loop the ledger
+still reads `Claimed{me}`, and T4 (orphan recovery) can only fire if `me` is proven dead — which
+cannot happen while `me` is the running victim.
+
+### 2.6 Fatal-signal delivery is intent-only *(v2, condition 5)*
+
+v1's Phase 11 carried the fatal outcome out of `deliver_default_action` through the **existing**
+`DeliverResult::Terminated` channel, whose documented contract is "caller MUST call notify after
+releasing the PM lock". But §1.6/P6b assigns notification to the ledger. Leaving both alive makes a
+duplicate notify reachable in exactly the window the round is trying to close. So:
+
+- `DeliverResult::Terminated` **and its caller-side notification action are deleted in the same PR**
+  that introduces the replacement. No overlap window exists, not even one phase wide.
+- The replacement is `DeliverResult::FatalIntent { pid, tid, sig, code }`, documented as
+  **intent-only**: *it performs no notification, no parent wake, no status write, no scheduler
+  mutation, and no resource work.* Its only legal use is to be handed to the S1 request transaction
+  after the PM borrow ends.
+- All notification for that death is discharged by the ledger obligations created in S1 and redeemed
+  by the victim's own commit — one producer, one claim, one redemption.
+- The P0 ratchet gains a rule for this: no notification/wake call may appear in any
+  `deliver_*`/`DeliverResult` consumer. The `Terminated` variant's absence is asserted by name so it
+  cannot be reintroduced by a later phase.
+
+This also preserves the three v1 wins of that phase, which the ratification did not dispute: the FD-closure
+loss that design A's `terminate_minimal` hand-off would have caused, the SCHEDULER-under-DAIF-masked-PM
+inversion at `scheduler.rs:3101-3109`, and a `log::info!` under mask all disappear with the two
+mutating blocks at `signal/delivery.rs:224-239` and `:258-269`.
+
 ---
 
 ## 3. Numbered traceability — all 13 acceptance criteria
 
+*(Rows whose mechanism changed in v2 are marked; unmarked rows are v1 verbatim. Phase numbers reflect
+the corrected order: old P10 → **P9**, old P9a/b/c → **P10a/b/c**, old P6 → **P6a + P6b**.)*
+
 | # | Criterion | Mechanism | Phase | Evidence that must be produced |
 |---|---|---|---|---|
 | **1** | Init designation only after creation fully succeeds; no phantom PIDs | Held-publication ticket: row inserted **and** non-runnable scheduler thread created before `designated_init` is committed under PM; PID 1 reserved off-table so a failed attempt leaves no row, no designation, and PID 1 retryable. Nothing in `create_*` touches designation. | 5 | Failure injection after PID selection at each fallible stage (page table, ELF, stack, publication): `designated_init() == None`, no row; retry succeeds as PID 1 |
-| **2** | No panic/fatal action while PM held with DAIF masked | S1 does **one relaxed store** to `INIT_DEATH_LATCH`. All fatal escalation is a receipt redeemed at S5 with PM and scheduler guards out of scope and DAIF restored; a pre-panic lock/IRQ snapshot is recorded first. No `#[cfg]`, so no build carries a differently-scoped variant. | 12 | `INIT_PANIC_WITH_LOCK == 0`; injected init death records PM owner `None`, scheduler owner `None`, IRQ state normal immediately before panic; the panic's serial output is **complete** (proving no lock was held) |
+| **2** *(v2 — cond. 7)* | No panic/fatal action while PM held with DAIF masked | S1 does **one relaxed store** to `INIT_DEATH_LATCH`. All fatal escalation is a receipt redeemed at S5 with PM and scheduler guards out of scope and DAIF restored; a pre-panic lock/IRQ snapshot is recorded first. No `#[cfg]`, so no build carries a differently-scoped variant. **The latch's producer set shrinks under the adopted Linux-faithful policy: external fatal signals to init are dropped at send and can never latch, so only init's own exit commit and an unhandleable fault remain.** | 12 | `INIT_PANIC_WITH_LOCK == 0`; injected init death records PM owner `None`, scheduler owner `None`, IRQ state normal immediately before panic; the panic's serial output is **complete** (proving no lock was held). **`kill(1, SIGKILL)` from userspace returns 0, `INIT_FATAL_SIGNAL_DROPPED` increments, init survives, `INIT_DEATH_LATCH == 0`; no test asserts `EPERM`** |
 | **3** | Victim attribution certain before fatal escalation; a heuristic CR3 miss must not panic | §2.4: TID-first, stack-slot cross-check, CR3 as root-consistency only, divergence counted and never fatal, `AttributionUncertain` → safe redirect + deferred intent. The latch keys on a **committed** victim, never on a resolution attempt. | 11 (attribution), 12 (escalation) | `clonevm_fault_test`: a CLONE_VM child faults → the **child** row dies, the parent survives, no refault loop. *This test fails on `main` today* — it is a live bug fixed, not a tautology. TID/CR3 mismatch injection bumps `EXIT_ATTRIBUTION_UNCERTAIN`, latches nothing, kills nobody |
 | **4** | One source of truth for init identity; no hardcoded PID 1 beside runtime designation | `ProcessManager::designated_init` is the sole authority; the three production literals (`manager.rs:1178`, `process_task.rs:226`, `:285`) and `signal.rs`'s `INIT_PID` become the accessor. `ProcessId::INIT` survives only as the ABI *validation* constant, never a lookup. | 5 | P0 ratchet fails on any new `ProcessId::new(1)` in production teardown/wait/signal/reparent code; the three `test_userspace.rs` sites are allowlisted **by name** |
 | **5** | Kernel and userspace init guards must agree (`init_shell` keys on `getpid()==1`) | Structural, not conventional: PID 1 is **reserved** for the explicit init constructor and production designation is **validated == PID 1 and refuses otherwise**. `init_shell.rs:1028` is not changed, so no second contract exists to drift. A non-PID-1 init would require an explicit userspace ABI change and is not silently supported. | 5 | Cross-tree source assertion + boot test: designated pid == 1 == the pid `init_shell` observes; a build with no real init leaves designation unset and does **not** treat whichever process got the low PID as init |
-| **6** | exec detaches `thread_group_id` **and** `inherited_cr3` | Both assignments at every exec commit point, after all fallible work, before PM release; both preserved on every failure; existing live-sibling guard retained. Both arches in one commit. | 3 | `clonevm_exec_test` extended: successful exec → both `None`, fresh root, effective TGID == pid, and a kill aimed at the **old** group cannot reach it; failed exec → both preserved byte-identical |
-| **7** | Group membership examined atomically; no snapshot stale across a PM drop | **No snapshot exists.** The group-exit PM transaction *is* the seal: mark every live effective-TGID member with one batch id inside one guard; `sys_clone` publication validates group lifecycle under the same lock; scheduler threads carry group id + generation and re-check before first dispatch; threads publish non-runnable until the row is published. | 3 (admission), 10 (cutover) | Deterministic clone-vs-seal barrier test: the child is either included in the batch or `sys_clone` returns `EAGAIN` — never a runnable unrequested member. Ratchet rejects any group PID `Vec` snapshot in teardown code |
-| **8** | Sibling kernel stacks freed ONLY behind two-epoch grace via scheduler ownership | All three creation paths — fork, CLONE_VM clone, **and spawn/direct-init/test-disk** — transfer `kernel_stack_allocation` to the scheduler-owned copy before the thread can run; a `Process` row can no longer synchronously drop a published stack (closing today's ungated free via `remove_process` at `waitpid` reap). No teardown path ever drops a stack directly: victims mark only themselves `Terminated`, and release requires grace + `!is_kernel_stack_slot_live`. | 4 | Ownership assertion after every creation path (exactly one owner, and it is the scheduler copy); 1000-iteration fork/clone/spawn exit stress with stack-pool accounting (allocated == freed) and an allocator assertion that never selects a live slot |
-| **9** | No N-member FD/resource teardown loop in one PM-locked, IRQ-masked section | Each victim takes and closes **only its own** descriptors, **one at a time**: `take_next_for_exit()` under PM → drop PM → close. The existing allocating `take_fd_entries() -> Vec` (`process.rs:335`) is retired, not reused. Group work under PM is bitmap/flag stores only. No sweep loops over members' FD tables. | 7 | `FD_CLOSES_UNDER_PM == 0`; 256-FD × large-group test measures bounded PM hold; ratchet forbids close/reclaim calls inside any request/commit transaction body |
-| **10** | No eager `cleanup_cow_frames` while the victim may run elsewhere; all kill paths grace-defer | Phase 2 routes SIGKILL through `exit_process`, whose aarch64 defer takes the page table into a grace-stamped receipt **before** `terminate()` runs (so the CoW walk becomes a `None`-walk). Phases 10–11 remove every direct `terminate` caller; resources stay in the row until the victim's own commit, and release requires grace + RootProof. `Process::terminate` is deleted with its last caller. | 2, 7, 10, 11 | Ratchet allowlist of `\.terminate\(` shrinks phase-by-phase to **empty**, asserted as an exact set; peer-CPU SIGKILL stress asserts zero reclaim before the fence elapses and a complete RootProof; `TEARDOWN_MASKED_FRAMES_WALKED == 0` for kill paths |
-| **11** | Killed threads quiesced in the scheduler AND expedited with the existing `SGI_RESCHEDULE` | Phase 2: quarantine via the proven `terminate_process_threads` + **broadcast** `SGI_RESCHEDULE` to other online CPUs (no residency predicate to go stale — this is the direct fix to the panel's fatal finding). Phases 9–10: scheduler *requests* instead of remote-marking, readies proven-killable blockers with continuations intact, returns `ExitKickPlan`; the SGI handler keeps doing only `need_resched`; the victim can never be re-dispatched to EL0 once the generation is observed. **No `ExitPending`.** | 2, 9, 10 | Victim spinning at EL0 pinned to a peer: `EXIT_SGI_SENT > 0`, target observes it, time-to-`Terminated` bounded by an SGI round trip rather than the victim's next natural tick; per-wait-family blocked-victim kill tests; unmigrated families explicitly reported as uninterruptible, not silently latched |
-| **12** | Exactly-once SIGCHLD/wake/report with **first-recorded** status, idempotent under repeat passes | Durable `ExitWorkBits` created at the **first** request and cleared only on completion; a repeat request returns the stored batch/status and creates no second obligation and no second status. Redemption happens once, outside PM, by whichever producer reaches it first — which is why the remote-kill path (Phase 2) carries the report obligation from day one rather than relying on `handle_thread_exit` (the single `btrt::on_process_exit` call site) being reached. **This does not reopen notification suppression** (disproven in review): the first transition creates one obligation *every* producer shares, so a later pass is never the only possible notifier — it redeems the same obligation, it does not skip it. | 2 (seed), 6 (ledger) | Matrix — exit→fault, SIGKILL→fault, fault→SIGKILL, repeat request/wait: exactly one SIGCHLD, one parent wake, one `btrt` report, and `waitpid` returns the **first** status; equality assertions `SIGCHLD_FIRST_SET == PARENT_WAKE_COMPLETED == BTRT_EXIT_REPORTED == parented_first_commits` |
-| **13** | New reclaim/drain respects lock ordering and is bounded on idle paths without throttling fork's drain | **No cap is added, no drain is moved, no drain is shared.** Fork's pre-allocation drain stays full/unbounded. The only addition to a return tail is an acquire-load + branch, placed **after** the `PREEMPT_ACTIVE`/nested-return gate — design A's insertion of quarantine work into the pre-gate deferred-fault drain (Judge 2's fatal finding, and a #448 regression) is **rejected and not adopted**. Every scheduler critical section is entered with **no PM guard live**, structurally: request/commit APIs take `pid`/`tid`, never `&mut Process`, so no caller can hold the guard across the call. No `FRAME_METADATA` and no `log::*` is added under any mask. Full analysis: §4. | all | Lock-depth/owner counters (with `try_manager()` instrumented — the r20 blind spot is not repeated); `RECLAIM_CONTEXT_VIOLATIONS == 0`; ratchet rejects scheduler-under-PM and any reclaim/close/walk in idle or exception tails; fork-pressure test proves a *full* eligible drain, not a capped one. **Declared partial:** this design does not fix #448's or #492's pre-existing boundedness; it must not make them worse, and §5 states the argument |
+| **6** | exec detaches `thread_group_id` **and** `inherited_cr3` | Both assignments at every exec commit point, after all fallible work, before PM release; both preserved on every failure; existing live-sibling guard retained. Both arches in one commit. **(v2: also a hard prerequisite of P8's last-reference decision — §2.3.)** | 3 | `clonevm_exec_test` extended: successful exec → both `None`, fresh root, effective TGID == pid, and a kill aimed at the **old** group cannot reach it; failed exec → both preserved byte-identical |
+| **7** | Group membership examined atomically; no snapshot stale across a PM drop | **No snapshot exists.** The group-exit PM transaction *is* the seal: mark every live effective-TGID member with one batch id inside one guard; `sys_clone` publication validates group lifecycle under the same lock; scheduler threads carry group id + generation and re-check before first dispatch; threads publish non-runnable until the row is published. | 3 (admission), **9** (cutover) | Deterministic clone-vs-seal barrier test: the child is either included in the batch or `sys_clone` returns `EAGAIN` — never a runnable unrequested member. Ratchet rejects any group PID `Vec` snapshot in teardown code |
+| **8** | Sibling kernel stacks freed ONLY behind two-epoch grace via scheduler ownership | All three creation paths — fork, CLONE_VM clone, **and spawn/direct-init/test-disk** — transfer `kernel_stack_allocation` to the scheduler-owned copy before the thread can run; a `Process` row can no longer synchronously drop a published stack. **(v2: the ungated free this closes was via `remove_process` at `waitpid` reap — that call site is itself replaced by the tombstone gate in P6a, so the two fixes meet rather than overlap.)** | 4 | Ownership assertion after every creation path (exactly one owner, and it is the scheduler copy); 1000-iteration fork/clone/spawn exit stress with stack-pool accounting (allocated == freed) and an allocator assertion that never selects a live slot |
+| **9** | No N-member FD/resource teardown loop in one PM-locked, IRQ-masked section | Each victim takes and closes **only its own** descriptors, **one at a time**: `take_next_for_exit()` under PM → drop PM → close (explicit control flow: §2.5). The existing allocating `take_fd_entries() -> Vec` (`process.rs:335`) is retired, not reused. Group work under PM is bitmap/flag stores only. No sweep loops over members' FD tables. | 7 | `FD_CLOSES_UNDER_PM == 0`; 256-FD × large-group test measures bounded PM hold; ratchet forbids close/reclaim calls inside any request/commit transaction body |
+| **10** *(v2 — cond. 1, 3)* | No eager `cleanup_cow_frames` while the victim may run elsewhere; all kill paths grace-defer | Phase 2 routes SIGKILL through `exit_process`, whose aarch64 defer takes the page table into a grace-stamped **receipt returned to the caller and enqueued only after PM drops** (§2.1), so the CoW walk becomes a `None`-walk and no queue lock nests under PM. Phases 9–11 remove every direct `terminate` caller; resources stay in the row until the victim's own commit, and release requires grace + RootProof. `Process::terminate` is deleted with its last caller. | 2, 7, **9**, 11 | Ratchet allowlist of `\.terminate\(` shrinks phase-by-phase to **empty**, asserted as an exact set; **`RECLAIM_ENQUEUE_UNDER_PM == 0` from P2 onward**; peer-CPU SIGKILL stress asserts zero reclaim before the fence elapses and a complete RootProof; `TEARDOWN_MASKED_FRAMES_WALKED == 0` for kill paths |
+| **11** *(v2 — cond. 1)* | Killed threads quiesced in the scheduler AND expedited with the existing `SGI_RESCHEDULE` | Phase 2: quarantine via the proven `terminate_process_threads` + **broadcast** `SGI_RESCHEDULE` to other online CPUs (no residency predicate to go stale). **Phase 9 (was 10): the scheduler *requests* instead of remote-marking for every boundary-reachable victim, returns `ExitKickPlan`, and takes the counted legacy arm only for not-yet-migrated wait families. Phases 10a/b/c migrate the families; P10c empties the legacy allowlist and deletes the remote-marking body — that is where AC-11 is fully discharged.** The SGI handler keeps doing only `need_resched`; the victim can never be re-dispatched to EL0 once the generation is observed. **No `ExitPending`.** | 2, **9, 10a/b/c** | Victim spinning at EL0 pinned to a peer: `EXIT_SGI_SENT > 0`, target observes it, time-to-`Terminated` bounded by an SGI round trip rather than the victim's next natural tick; per-wait-family blocked-victim kill tests; **`EXIT_LEGACY_REMOTE_MARK{family}` reported per family and asserted to reach 0 with the allowlist empty at P10c**; unmigrated families explicitly reported, never silently advertised as killable |
+| **12** *(v2 — cond. 2, 5)* | Exactly-once SIGCHLD/wake/report with **first-recorded** status, idempotent under repeat passes | **Four-state obligations (`Absent/Pending/Claimed{claimer}/Completed`, §1.6), all transitions under the PM lock, which is the sole serializer — this restores what design C's single-worker serialization discharged after the worker was dropped.** Created at the **first** request; a repeat request returns the stored batch/status and creates no second obligation and no second status. At most one control path is ever `Claimed`, so the commit path and `handle_thread_exit` cannot both redeem; an abandoned claim is recoverable (T4) rather than a silent permanent loss. **Row lifetime is extended by the tombstone gate (P6a) so no obligation can outlive its row.** **The legacy `DeliverResult::Terminated` notification action is deleted in P11, so no second notifier exists.** Still not suppression: the obligation is shared, so a later pass redeems it rather than skipping it. | 2 (seed), **6a (retention), 6b (ledger)**, 11 (legacy notifier deleted) | Matrix — exit→fault, SIGKILL→fault, fault→SIGKILL, repeat request/wait: exactly one SIGCHLD, one parent wake, one `btrt` report, and `waitpid` returns the **first** status; equalities `SIGCHLD_FIRST_SET == PARENT_WAKE_COMPLETED == BTRT_EXIT_REPORTED == parented_first_commits`; **`LEDGER_CLAIM_MISMATCH == 0`, `LEDGER_CLAIM_ORPHANED == 0` on a healthy boot, `TOMBSTONE_RESIDENT == 0` at quiesce**; forced-orphan injection proves T4 recovers the notification instead of losing it |
+| **13** *(v2 — cond. 3)* | New reclaim/drain respects lock ordering and is bounded on idle paths without throttling fork's drain | **No cap is added, no drain is moved, no drain is shared.** Fork's pre-allocation drain stays full/unbounded. The only addition to a return tail is an acquire-load + branch, placed **after** the `PREEMPT_ACTIVE`/nested-return gate. Every scheduler critical section is entered with **no PM guard live**, structurally: request/commit APIs take `pid`/`tid`, never `&mut Process`. **v2 adds two absolute rules: (i) P1's proof reads never hold `PENDING_PROCESS_RECLAIMS` while acquiring SCHEDULER or PM — the drain detaches a candidate under the queue lock, drops it, proves, then frees or re-inserts (§4.3); (ii) every retirement receipt is enqueued only after the PM guard drops, including in P2's interim shape.** No `FRAME_METADATA` and no `log::*` is added under any mask. Full analysis: §4. | all | Lock-depth/owner counters (with `try_manager()` instrumented — the r20 blind spot is not repeated); `RECLAIM_CONTEXT_VIOLATIONS == 0`; **`RECLAIM_ENQUEUE_UNDER_PM == 0` and `PROOF_UNDER_QUEUE_LOCK == 0`**; ratchet rejects scheduler-under-PM, queue-lock-then-PM/SCHEDULER, and any reclaim/close/walk in idle or exception tails; fork-pressure test proves a *full* eligible drain, not a capped one. **Declared partial:** this design does not fix #448's or #492's pre-existing boundedness; it must not make them worse, and §5 states the argument |
 
 ---
 
@@ -386,7 +711,7 @@ exhaustive matching, not control flow over mandatory work.
 
 Documented today: `SCHEDULER → PROCESS_MANAGER → endpoint locks`. Live teardown/signal/exec code
 does not honour it consistently (signal delivery and exec update scheduler state under PM; reclaim
-enqueue nests a queue op under PM).
+enqueue nests a queue op under PM at both `manager.rs:1152` and `process_task.rs:244`).
 
 **This design adopts a strictly stronger rule for all death-path code:**
 
@@ -394,10 +719,24 @@ enqueue nests a queue op under PM).
 > SERIAL are **never held simultaneously** by teardown, signal, exec, wait, or reparent code. State
 > moves between domains through fixed-size receipts and release/acquire atomics.
 
+**v2 (condition 3): the rule binds interim shapes too.** A phase may not adopt an overlapping-lock
+shape "temporarily" on the way to the end state. Two v1 shapes violated it and are corrected:
+
+1. **P1's proof under the queue lock.** `reclaim_deferred_process_resources` (`process_task.rs:375-392`)
+   evaluates its readiness predicate while holding `PENDING_PROCESS_RECLAIMS`. Today both terms are
+   lock-free atomic reads, so `main` is legal; P1's `RootProof` adds scheduler-cached-root and
+   live-row blockers, which would take SCHEDULER and PM **under the queue lock**. P1 restructures the
+   drain instead (§4.3, "P1 retire cycle"): the under-queue-lock predicate stays **epoch + shadow
+   only** (lock-free), the candidate is detached, the queue lock is dropped, and only then is the full
+   proof run.
+2. **P2's enqueue under PM.** `exit_process` returns a `#[must_use] RetirementReceipt` and the caller
+   enqueues it after the PM guard drops; the `handle_thread_exit` enqueue is moved into phase 2 of
+   that function, where PM is already released. Both conversions are in P2's PR.
+
 This makes both nesting directions impossible for teardown, so no ordering *cycle* can exist —
 rather than relying on everyone remembering which order is legal. It is enforced structurally
-(pid/tid-based APIs ⇒ no live `&mut Process` borrow ⇒ no live guard), by the P0 ratchet, and observed
-by counters — in that order of authority.
+(pid/tid-based APIs ⇒ no live `&mut Process` borrow ⇒ no live guard; receipts returned rather than
+consumed in place), by the P0 ratchet, and observed by counters — in that order of authority.
 
 ### 4.2 Lock inventory (aarch64)
 
@@ -405,7 +744,7 @@ by counters — in that order of authority.
 |---|---|---|
 | PM (`PROCESS_MANAGER`) | `manager()` masks **all** DAIF, then spin mutex | the hard one: everything under it is masked |
 | SCHEDULER | `with_scheduler` / `lock_for_context_switch` | |
-| `PENDING_PROCESS_RECLAIMS` | leaf; staging only | insertion moves a receipt; no walk under it |
+| `PENDING_PROCESS_RECLAIMS` | leaf; staging only | insertion moves a receipt; **no proof and no walk under it (v2)** |
 | `FRAME_METADATA` | blocking `spin::Mutex`; reached from CoW-fault context AND teardown | reclaimer pins preemption while held; no guard spans alloc/copy/unmap/map |
 | FRAME_ALLOCATOR | under `FRAME_METADATA` in decref paths | leaf |
 | SERIAL / framebuffer | any `log::*` | forbidden under any mask in this surface |
@@ -422,12 +761,16 @@ by counters — in that order of authority.
 | S3 commit transaction | **PM only** | short; single hold; no drop mid-transaction | none (fixed receipts preallocated) | none | O(1) per victim; one victim per transaction, always |
 | S3 FD close | PM only to `take_next_for_exit`; **then endpoint lock with PM dropped** | strict edge: PM released before any endpoint lock | none | none | one descriptor per PM acquisition |
 | S3 reparent cursor | **PM only**, fixed-size batch | PM dropped and DAIF restored between batches | none (`children` mirror not extended) | none | fixed batch (Residual R-4) |
-| S3 notification redemption | PM only to mark → drop → SCHEDULER only to wake → PM only to clear the bit | no overlap; serialized by the durable work bit | none | none | O(1) |
-| S3 receipt enqueue | reclaim queue only, **after** PM drop | leaf staging lock; no walk under it | none | none | O(1) |
-| S4 grace + RootProof (epochs/hardware/shadows) | **no lock** | pure ordered observation (`RetirementSnapshot`) | none | none | O(MAX_CPUS) |
-| S4 RootProof (cached roots) | SCHEDULER only | guard drops before PM revalidation | none | none | O(threads) |
+| **S3 ledger claim (T2)** *(v2)* | **PM only** | inside the commit transaction; read-then-write in one acquisition; no second lock | none | none | O(1) per obligation |
+| **S3 ledger completion (T3)** *(v2)* | **PM only**, fresh acquisition after the work | never overlaps the work it completes; no second lock | none | none | O(1) per obligation |
+| S3 notification redemption | PM only to claim → drop → SCHEDULER only to wake → PM only to mark `Completed` | no overlap at any point; serialized by the claim, not by lock nesting | none | none | O(1) |
+| **S3 receipt enqueue** *(v2 — cond. 3)* | reclaim queue only, **after** PM drop, including in P2's interim shape | leaf staging lock; no walk and no proof under it | none | none | O(1) |
+| **P1 retire cycle — detach** *(v2 — cond. 3)* | **reclaim queue only** | predicate under the queue lock is **epoch + shadow atomics only**; candidate is removed into a local fixed slot; lock dropped | none | none | O(queue length) scalar scan |
+| **P1 retire cycle — prove** *(v2 — cond. 3)* | fence/hardware/shadows: **no lock**; cached roots: **SCHEDULER only**; live rows: **PM only** | three sequential, non-overlapping acquisitions, **queue lock already dropped**; never nested | none | none | O(MAX_CPUS) + O(threads) + O(rows) |
+| **P1 retire cycle — free or re-insert** *(v2)* | free: **no lock**; re-insert: **reclaim queue only** | refusal bumps its blocker counter and rotates | frees only | none | per-victim |
 | S4 resource claim + physical free | PM only to `take` → **drop** → TLBI/CoW walk/frame free with no PM or scheduler held; preemption pinned across `FRAME_METADATA` | no heavy destructor under PM; no broadcast TLBI under PM/scheduler/IRQ-off | frees only | none | per-victim |
 | S4 stack release | SCHEDULER only to prove/detach → drop → stack-pool bitmap | allocator never acquired under scheduler | none | none | one thread per pass |
+| **S4 tombstone removal** *(v2 — cond. 2)* | **PM only**, after the ledger is proven `Completed` and the receipt retired | entered with no queue lock and no scheduler lock live | frees the row only | none | one row per pass |
 | S5 init escalation | **none** | all guards out of scope, DAIF restored | panic path may allocate — legal here | panic only | one atomic load |
 | Boundary hook (Tier-2) | **none** | acquire-load + branch, placed **after** the `PREEMPT_ACTIVE`/nested-return gate | none | none | O(1); no drain, no walk, no lock |
 
@@ -435,31 +778,34 @@ by counters — in that order of authority.
 
 Foreclosed: **SCHEDULER inside DAIF-masked PM** (the r23 revert class, three designs) — impossible
 because every request/quarantine API is pid/tid-based. **PM inside SCHEDULER** — S1/S2 are sequential
-statements, never nested closures. **`FRAME_METADATA` under PM+mask** — removed on the SIGKILL and
-fatal-signal paths in Phase 2/11, never added. **New heap allocation under PM+mask** — receipts are
-fixed-size and preallocated; the allocating `take_fd_entries()` is retired in Phase 7. **`log::*`
-under mask** — none added anywhere; all new diagnostics are `trace_count!`/`trace_event!` from the
-lock-free framework, with `raw_serial_char()` remaining the last resort at fault sites that already
-use it. **Heavy work before a safety gate** — the boundary hook goes after the `PREEMPT_ACTIVE` gate,
-and no drain is added to any tail.
+statements, never nested closures. **Reclaim queue inside PM** *(v2)* — receipts are returned, never
+enqueued in place; both pre-existing sites are converted in P2 and `RECLAIM_ENQUEUE_UNDER_PM` is
+asserted 0 thereafter. **SCHEDULER or PM inside the reclaim queue** *(v2)* — the drain detaches before
+proving; `PROOF_UNDER_QUEUE_LOCK` is asserted 0. **`FRAME_METADATA` under PM+mask** — removed on the
+SIGKILL and fatal-signal paths in Phase 2/11, never added. **New heap allocation under PM+mask** —
+receipts are fixed-size and preallocated; the allocating `take_fd_entries()` is retired in Phase 7.
+**`log::*` under mask** — none added anywhere; all new diagnostics are `trace_count!`/`trace_event!`
+from the lock-free framework, with `raw_serial_char()` remaining the last resort at fault sites that
+already use it. **Heavy work before a safety gate** — the boundary hook goes after the
+`PREEMPT_ACTIVE` gate, and no drain is added to any tail.
 
 **Honest limit.** The runtime lock-order detector compares against `PROCESS_MANAGER_OWNER_TID`, and
 that bookkeeping was *not* updated by `try_manager()` — blocking finding #8 in the parked branch's
 r20 review. This design requires `try_manager()` to participate in the same instrumentation, so the
 blind spot is closed for the detector — but the detector is still only a detector. **The actual
-guarantee is structural** (pid-based APIs + the ratchet), and the counters are asserted zero in CI so
-a regression is loud. No safety claim in this document rests on a release-stripped assertion, and no
-correctness argument rests on a counter.
+guarantee is structural** (pid-based APIs + returned receipts + the ratchet), and the counters are
+asserted zero in CI so a regression is loud. No safety claim in this document rests on a
+release-stripped assertion, and no correctness argument rests on a counter.
 
 ---
 
 ## 5. What this design deliberately does NOT solve
 
 1. **#492 — unbounded fault-exit deferred drain.** The 8×16 producer and its replay are untouched.
-   This design adds a readable `DEFERRED_FAULT_RING_DROPPED` counter (the overflow is invisible today)
-   and gives ring items a stable TID/generation, which makes a cursor/backpressure fix easier later.
-   **Not made worse:** certainly-attributed fatal faults do not consume the ring, and no SIGKILL or
-   group request depends on ring capacity.
+   This design adds a readable `DEFERRED_FAULT_RING_DROPPED` counter at the silent-drop site
+   (`process_task.rs:43`, `push()` returning `false`) and gives ring items a stable TID/generation,
+   which makes a cursor/backpressure fix easier later. **Not made worse:** certainly-attributed fatal
+   faults do not consume the ring, and no SIGKILL or group request depends on ring capacity.
 2. **#448 — idle-path CoW-walk latency under IRQ mask.** No drain is moved, no cap is added, no cap
    is shared with fork's full drain (the exact failure of the r23 round's first bounded design). The
    only addition to a return tail is an acquire-load + branch **after** the `PREEMPT_ACTIVE` gate.
@@ -470,7 +816,9 @@ correctness argument rests on a counter.
 3. **#493 — `check_signals_for_eintr` disposition.** Untouched. `has_deliverable_signals()` is not
    modified. Group exit is set only *after* the existing disposition code determines the effective
    action is terminate; the request API takes an already-resolved fatal intent, so a later
-   disposition fix sits *before* this machinery and needs no teardown change.
+   disposition fix sits *before* this machinery and needs no teardown change. *(v2 note: the adopted
+   protected-init policy is also a pure disposition-time rule — the drop happens where the effective
+   action is computed, so it composes with a future #493 fix instead of colliding with it.)*
 4. **The `children` mirror / parent-authority migration.** B's Phases 6–7 (remove the allocating
    `children` vector, subreaper selection) are **cut from the core round**: they are a wait/procfs/fork
    refactor whose blast radius is unrelated to the three chartered issues. The bounded reparent cursor
@@ -482,7 +830,8 @@ correctness argument rests on a counter.
    full drain + `schedule_from_kernel`). The receipt + intrusive-row-queue shape makes a bounded
    normal-context worker a drop-in later, which is where #448/#492 point — but a worker touches
    Tier-2 `kthread.rs`/`workqueue.rs` territory and the r20 attempt failed there (`log::warn!` inside
-   the reaper loop). OQ-6.
+   the reaper loop). OQ-6. *(v2: the worker's **serialization** role is not deferred — §1.6 replaces
+   it with the PM-serialized claim protocol, so dropping the worker no longer drops a proof.)*
 7. **The `retirement_grace_elapsed` all-zero-target short-circuit is FIXED here**, not deferred:
    Phase 1 makes an empty online mask invalid rather than trivially "elapsed".
 
@@ -505,12 +854,15 @@ property depends on the install ordering (name before install; publish `saved` a
 `next` last). That ordering is enforced for the writers this design touches; kernel-wide closure
 needs OQ-4. Until then the absolute claim is a *declared residual, not a stated fact*.
 
-**R-2. Uninterruptible waits delay death by an unbounded amount.** A victim in a wait family whose
-victim-owned cancellation path has not yet been audited stays latched and dies at its next natural
-safe boundary. The group stays sealed and its resources pinned rather than freed underneath it. This
-is a *safe* failure (leak/stall, never early free) and is counted per family, but a genuinely stuck
-wait blocks reaping indefinitely. Breenix has no killable-wait taxonomy today; building one is
-Phase 9's whole job and it is honestly incomplete until every family lands.
+**R-2. Uninterruptible waits delay death — bounded differently in v2.** *(revised, condition 1.)* A
+victim in a wait family whose victim-owned cancellation path has not yet been audited does **not**
+simply latch: from P9 it takes the explicit legacy remote-mark arm (§1.5), i.e. exactly the merged P2
+behaviour, so kill latency for those victims is unchanged from what has already shipped. What remains
+residual is that such a victim is torn down **remotely** rather than by itself until its family lands
+in P10a/b/c, and that a family with a genuinely stuck wait still blocks *prompt* victim-owned death.
+The group stays sealed and its resources pinned rather than freed underneath it — a *safe* failure
+(leak/stall, never early free) — and it is counted per family. Breenix has no killable-wait taxonomy
+today; building one is P10's whole job and it is honestly incomplete until every family lands.
 
 **R-3. O(group-size) fatal marking under PM with DAIF masked.** Bitmap/scalar stores only — no
 allocation, no FD, no resource work — but interrupt masking scales with group size. Accepted at
@@ -519,7 +871,9 @@ preserving atomic sealing.
 
 **R-4. O(process-count) PM scans.** The group seal and the reparent cursor both scan the process map
 because the `children` mirror is retained (see §5.4). Scalar, non-allocating, and batched, but not
-O(1). Removing the mirror later fixes it.
+O(1). Removing the mirror later fixes it. *(v2: tombstone rows are skipped by the "live process"
+predicate but still occupy map entries until the retire gate removes them, so the scan constant grows
+slightly under burst — see R-13.)*
 
 **R-5. FD closure is only moved out of PM at Phase 7.** Between Phase 2 and Phase 7 the SIGKILL path
 closes descriptors inside `exit_process` → `terminate()` under PM+mask. That is *unchanged from
@@ -548,18 +902,26 @@ method escapes it — the r20 review found exactly this evasion (`set_terminated
 spelling of the same forbidden transition"). It raises the cost of a regression; it does not make one
 impossible.
 
-**R-11. Receipt durability is an implementation obligation, not a proof.** Receipts must be
-fixed-size, preallocated, non-droppable, and either redeemed synchronously outside PM or stored in
-authoritative row state. An implementation that routed notification through the bounded fault ring
-would violate this design. Likewise, group-control/receipt destruction must never occur under PM or
-the scheduler lock — invariant plus source test, not a proof.
+**R-11. Receipt durability is an implementation obligation, not a proof.** *(revised, condition 2.)*
+Receipts must be fixed-size, preallocated, non-droppable, and either redeemed synchronously outside PM
+or stored in authoritative row state. An implementation that routed notification through the bounded
+fault ring would violate this design. Likewise, group-control/receipt destruction must never occur
+under PM or the scheduler lock — invariant plus source test, not a proof. **The claim protocol (§1.6)
+narrows but does not eliminate this residual: it makes a lost obligation *detectable* (a `Claimed`
+state with a dead claimer, recovered by T4 and counted) rather than silent, but the guarantee that
+every claimed obligation is eventually completed still rests on the claimer being a kernel control
+path that runs to completion, not on a scheduler-enforced property.**
 
 **R-12. aarch64 panic is not stop-the-world.** Init-death panic parks the panicking CPU; peers are
 not actively stopped by today's panic handler. Recorded, not fixed (OQ-1b).
 
-**R-13. `waitpid` may return before physical retirement.** The logical corpse can be reaped while a
-lightweight `ReapedPendingRetirement` record awaits grace. Unobservable except through kernel
-diagnostics and resource pressure.
+**R-13. `waitpid` returns before physical retirement, and the row now outlives the reap.**
+*(revised, condition 2.)* The logical corpse is reaped while the retirement receipt awaits grace; in
+v2 the row itself is retained as a `Tombstone` until the ledger is `Completed` and the receipt has
+retired. Consequences: PID reuse is delayed by the same grace (strictly safer than today), the process
+map holds a bounded number of extra entries under burst (R-4), and a stuck obligation manifests as a
+resident tombstone rather than as a freed-too-early row. `TOMBSTONE_RESIDENT` has a reader and is
+asserted to return to zero at quiesce, so the failure is loud rather than silent.
 
 **R-14. Nonleader exec keeps its PID (Linux transplants the leader's).** Observably different for
 programs comparing thread IDs across exec. Transplant would require a registry-wide rekey audit
@@ -568,23 +930,45 @@ programs comparing thread IDs across exec. Transplant would require a registry-w
 **R-15. This is a design-only artifact.** No build, QEMU, or Parallels evidence exists yet. Every
 gate below is a requirement on the implementation, not a result.
 
+**R-16. The legacy remote-mark arm is live from P9 until P10c.** *(new, condition 1.)* Between the
+request/wake cutover and the last wait-family migration, two teardown shapes coexist for SIGKILL:
+victim-owned for boundary-reachable victims, and the merged P2 remote-mark for the rest. This is a
+deliberate, counted, ratcheted interim — both arms are exercised in every PR that ships them, the
+false set is an explicit allowlist that only shrinks, and P10c deletes the arm — but during that
+window two paths must both be correct, and a review of any P10x PR must check both. The alternative
+(migrate every family in one PR) is the 15-phase big bang Judge 1 found fatal.
+
+**R-17. Orphaned-claim recovery depends on the same liveness machinery it protects.** *(new,
+condition 2.)* T4 (`Claimed{dead} → Pending`) uses P1's proof (`scheduler thread absent or
+Terminated` + claim-time fence elapsed) to decide that a claimer is dead. If that proof is wrong in
+the *unsafe* direction — declaring a live claimer dead — two paths could redeem one obligation. The
+mitigation is that T4 is gated on the *same* two-epoch fence that gates physical free, so a claimer
+that could still run cannot be declared dead without also making a use-after-free reachable, which the
+existing gates already test for. It is a shared dependency, not an independent proof, and is recorded
+as such.
+
 ---
 
 ## 7. Open questions — operator decisions only
 
-**OQ-1. Init death policy.** Recommended (Linux protected-init): user-originated default-fatal
-signals to designated init → `EPERM`, no group exit; init's own `exit`/`exit_group` or an
-unhandleable fatal fault → kernel-fatal panic. Alternative: treat an authorized `SIGKILL(1)` as a
-deliberate shutdown/panic. **OQ-1b:** accept today's non-stop-the-world panic (recommended; file
-`smp_send_stop` separately), or add an SMP stop broadcast in this round?
+**OQ-1. Init death policy — DECIDED (coordinator-adopted at v2, condition 7).** **Linux-faithful
+protected init:** a user-originated signal to the designated init whose effective disposition is the
+default fatal action and for which init has no handler is **silently dropped and the send returns
+success (0)** — not `EPERM`. Handled signals are delivered normally. Only init's own `exit`/`exit_group`
+or an unhandleable synchronous fatal fault (or a nonviability invariant) is kernel-fatal. v1's `EPERM`
+recommendation is withdrawn: the ratification is right that `EPERM` is a deliberate ABI divergence and
+was mislabelled as fidelity, and rather than document a divergence we take the faithful behaviour.
+**OQ-1b (still open):** accept today's non-stop-the-world panic (recommended; file `smp_send_stop`
+separately), or add an SMP stop broadcast in this round?
 
 **OQ-2. PID-1 reservation.** Reserve PID 1 for the explicit init constructor and start ordinary/test
 allocation at 2 (all four `next_pid.fetch_add` sites)? Recommended **yes** — it is what converts AC-5
 from convention into structure and makes a failed init creation deterministically retryable.
+*(Ratification: AGREE.)*
 
 **OQ-3. Exit scope split.** Confirm `exit(2)` = member, and `exit_group`/SIGKILL/default-fatal
 signal/fatal user fault = thread group (Linux). Recommended **yes**; today's collapsed
-`Exit | ExitGroup` would undermine #471's group semantics.
+`Exit | ExitGroup` would undermine #471's group semantics. *(Ratification: AGREE.)*
 
 **OQ-4. Tier-1 approval — `kernel/src/syscall/time.rs`.** Approve routing its raw TTBR0 writer
 through the constrained helper? Recommended **yes eventually, not required by any phase here**.
@@ -596,24 +980,37 @@ two-line edit there lacked signoff.
 the aarch64 exception/syscall return path and `interrupts/context_switch.rs`, placed after the
 `PREEMPT_ACTIVE`/nested-return gate, with all real work in a normal preemptible context? **Without
 this approval the design stops at Phase 7** — victim-owned exit is impossible, and #491 ships only at
-Increment-1 strength (still a real UAF fix, but the remote-mark model survives).
+Increment-1 strength (still a real UAF fix, but the remote-mark model survives). **v2 correction to
+v1's blast radius: refusal parks P8 *through P12*, not just P8.** Under the corrected order the group
+seal lives in P9 (which needs P8's hook) and the init-death latch's only producers are P8's own-exit
+commit and P11's unhandleable-fault path, so a refusal leaves #464 identity-complete but death-policy
+parked and #471 with exec detach (P3) but no seal. v1's claim that "#464 and #471 ship complete"
+without OQ-5 was wrong and is withdrawn. *(Ratification:
+AGREE, strictly under the stated constraints: post-gate, acquire-load + branch only, preemptible-context
+work, no logging. §2.5 now states the activation control flow those constraints apply to.)*
 
 **OQ-6. Bounded reclaim worker.** In this round, or deferred with #448/#492? Recommended **deferred**
 — the receipt/queue shape makes it a drop-in, it touches Tier-2 kthread surface, and the r20 attempt
-failed there. Judge 2 endorsed grafting it; this synthesis defers it and says so rather than smuggling
-it in.
+failed there. *(v2: deferring the worker no longer defers a proof — §1.6 supplies the serialization the
+worker used to provide.)*
 
 **OQ-7. Scope cuts.** Confirm that group-wide exec cull, `children`-mirror removal / subreaper
 selection, and nonleader PID transplant are all **out** of this round. Recommended **yes** — each is a
-separate blast radius, and #471 as filed is satisfied by detach + seal.
+separate blast radius, and #471 as filed is satisfied by detach + seal. *(Ratification: AGREE.)*
 
-**OQ-8. Phase count.** This plan is 13 phases / 13 PRs at ≤ ~230 changed lines and ≤5 production
-files each (PR #418's 236-line, 5-file diff is the ceiling). That is a lot of review cycles, and it is
-the deliberate price of Judge 1's fatal finding against a 15-phase big bang. Accept, or batch adjacent
-phases and accept larger review surface per PR?
+**OQ-8. Phase count — CORRECTED (condition 6).** v1 claimed "13 phases / 13 PRs", which the
+ratification correctly called a contradiction with the split phases. The honest figure is
+**13 numbered phases / 16 PRs**: P6 splits into P6a + P6b (condition 2) and P10 into P10a + P10b + P10c
+(the wait families), while every other phase is one PR. Each PR targets ≤ ~230 changed non-generated
+lines across ≤ 5 production files (PR #418's 236-line, 5-file diff is the ceiling). The full PR ledger
+is enumerated in PLAN §0. That is a lot of review cycles, and it is the deliberate price of Judge 1's
+fatal finding against a 15-phase big bang. **Open decision: accept 16 PRs, or batch adjacent phases and
+accept larger review surface per PR?**
 
 **OQ-9. x86_64 rollout.** Land shared semantics now with no SMP proof (recommended), or gate the
-victim-owned path to aarch64 and keep an explicitly audited synchronous x86 hook?
+victim-owned path to aarch64 and keep an explicitly audited synchronous x86 hook? *(Ratification:
+AGREE, conditioned on proving every x86 user-return path reaches the common hook and halting for
+approval if one is found to bypass it — that proof is a named P8 gate item.)*
 
 ---
 
@@ -623,11 +1020,14 @@ victim-owned path to aarch64 and keep an explicitly audited synchronous x86 hook
 |---|---|---|
 | `#[cfg(not(feature = "testing"))]`-scoped init panic (×4 reverted) | **No** | Designation is runtime data. No feature gate exists anywhere, so `interactive = ["testing"]` cannot invert anything |
 | Panic under a DAIF-masked PM guard | **No** | S1 stores one atomic; S5 panics with no guard live and records a pre-panic lock/IRQ snapshot first |
-| Fatal escalation on heuristic victim resolution | **No** | The latch keys on a **committed** victim; TID/CR3 divergence is counted and never fatal; `AttributionUncertain` kills nobody |
+| Fatal escalation on heuristic victim resolution | **No** | The latch keys on a **committed** victim; TID/CR3 divergence is counted and never fatal; `AttributionUncertain` kills nobody. *(v2: the latch's producer set shrinks further — an external kill of init can no longer reach S1 at all)* |
 | CLONE_VM group sweep (4 blocking defects) | **Reshaped, not reopened** | All four defects are structurally unrepresentable: exec detach lands first (Phase 3); no snapshot ever leaves PM (the mark *is* the seal); stacks are only ever self-marked and grace-released; no N-member FD loop exists because each victim closes its own FDs one at a time outside PM. Group-wide **exec cull** is still out (OQ-7) |
 | Bounded drains (×3 reverted) | **No** | No cap added, no drain moved, no cap shared with fork, no new pre-drain in `sys_clone`, and no scheduler lock is ever entered with a PM guard live |
-| Suppressing repeat-pass `btrt::on_process_exit` (disproven) | **No** | The obligation is created once and *shared by every producer*; a later pass redeems the same obligation rather than being skipped. `btrt`'s single call site is exactly why Phase 2 carries the report obligation on the remote-kill path |
-| `ReclaimContext` capability token (r20) | **No** | Replaced by pid/tid-based APIs (structural) + the source ratchet; `try_manager()` is instrumented so the r20 detector blind spot is closed, and §4.4 states the detector's limits instead of claiming proof |
+| Suppressing repeat-pass `btrt::on_process_exit` (disproven) | **No** | The obligation is created once and *shared by every producer*; a later pass **claims and redeems** the same obligation rather than being skipped. `btrt`'s single call site (`process_task.rs:267`) is exactly why Phase 2 carries the report obligation on the remote-kill path |
+| `ReclaimContext` capability token (r20) | **No** | Replaced by pid/tid-based APIs and returned receipts (structural) + the source ratchet; `try_manager()` is instrumented so the r20 detector blind spot is closed, and §4.4 states the detector's limits instead of claiming proof |
 | `ThreadState::ExitPending` (r20 finalization deadlock) | **No — explicitly rejected from design C** | A victim is made *runnable* so it can run its own continuation, unregister its own wait, and terminate itself; it is never dequeued while its own liveness evidence stands |
-| `kreclaimd` worker (r20: logging in the reaper, Tier-2 surface) | **No** | Reclaim stays at the two existing drain sites; a worker is OQ-6, not a phase |
+| `kreclaimd` worker (r20: logging in the reaper, Tier-2 surface) | **No** | Reclaim stays at the two existing drain sites; a worker is OQ-6, not a phase. *(v2: the worker's serialization role is replaced by the PM-serialized claim protocol, §1.6 — it is not silently missing)* |
 | Large coherent design accumulating unreviewed surface before validation (the r20 grave failure, and Judge 1's fatal finding against B) | **No** | The spine's live UAF closes in Phase 2 of 13; every phase ships, is revertable alone, and has a live caller for its new code; stopping the round at *any* phase boundary leaves the tree strictly better than `main` |
+| **Interim shapes that violate the end-state lock rule "temporarily"** *(new, v2 — condition 3)* | **No** | v1 let P1 prove under the reclaim-queue lock and P2 enqueue under PM. Both are corrected at the phase that introduces them: the drain detaches before proving, and receipts are returned and enqueued after PM drops. `PROOF_UNDER_QUEUE_LOCK` and `RECLAIM_ENQUEUE_UNDER_PM` are asserted 0 from the phase that creates them onward |
+| **A wait-family contract shipping before its producer exists** *(new, v2 — condition 1)* | **No** | The request/wake publication and victim-owned commit suppression now land in P9, before every P10x consumer; each family PR is a consumer of an already-merged producer, and the interim legacy arm is explicit, counted and ratcheted rather than implied |
+| **A second notification path surviving alongside the ledger** *(new, v2 — condition 5)* | **No** | `DeliverResult::Terminated` and its caller-side notify action are deleted in the same PR that introduces the intent-only `FatalIntent`; the ratchet asserts the variant's absence by name |

--- a/docs/planning/teardown-unification/PLAN.md
+++ b/docs/planning/teardown-unification/PLAN.md
@@ -1,9 +1,30 @@
-# Teardown Unification — PHASED IMPLEMENTATION PLAN
+# Teardown Unification — PHASED IMPLEMENTATION PLAN v2 (revised against ratification)
 
-Companion to `teardown-unification-DESIGN.md`. Design-only: nothing below has been implemented and no
-gate result is claimed.
+Companion to `teardown-unification-DESIGN-v2.md`. Design-only: nothing below has been implemented and
+no gate result is claimed.
 
-**Base:** `main` @ `eebc8868`. **Issues:** #491 (spine), #464, #471.
+**Base:** `main` @ `eebc8868` (docs re-verified at `main` @ `c9efdcc7`). **Issues:** #491 (spine), #464, #471.
+
+---
+
+## CHANGELOG — v2 deltas against the ratification conditions
+
+The Codex Sol ratification refused endorsement (`ENDORSE: NO`) with 2 FATAL seams, 7 MAJOR, 1 MINOR and
+7 conditions. This is a **targeted** revision: phases and text the ratification did not criticise are
+preserved verbatim.
+
+| Cond | What changed in this PLAN | Where |
+|---|---|---|
+| **1** | **Phase reorder.** Old P10 (request-only scheduler publication + victim-owned SIGKILL commit suppression + group cutover) becomes **P9**; old P9a/b/c (killable-wait families) become **P10a/b/c**. P9 is independently implementable against P2 via the named `exit_request_is_boundary_reachable()` predicate with a live, counted legacy remote-mark arm; each P10x migrates one family; **P10c empties the allowlist and deletes the arm**, which is where #491 becomes complete. Dependency graph fully re-derived, including the **missing `P3 → P8` edge** | §0 graph, P9, P10a/b/c, §1 |
+| **2** | **New P6a** (reap/tombstone retention gate) ships **before** **P6b** (the ledger), because the `Resources` obligation outlives reap while today's `waitpid` physically removes the row. P6b's bits become the four-state `Absent/Pending/Claimed{claimer}/Completed` machine with PM as sole serializer | P6a, P6b |
+| **3** | **P1** restructures the reclaim drain to *detach → drop queue lock → prove → free-or-reinsert*; the under-queue-lock predicate stays lock-free. **P2** changes `exit_process` to return a `#[must_use] RetirementReceipt` and converts **both** existing PM-nested `enqueue_process_reclaim` sites | P1, P2 |
+| **4** | **P8** now states the hook-activation control flow explicitly (the hook is the *only* entry to `do_exit_current`, so normal exit exercises it in this PR), plus the tombstone and one-at-a-time FD-acquisition control flow Codex's P8 note called for | P8 |
+| **5** | **P11** deletes `DeliverResult::Terminated` **and** its caller-side parent-notification action in the same PR, replacing it with intent-only `DeliverResult::FatalIntent` | P11 |
+| **6** | **P0** names every existing teardown write-site (file:line) each counter attaches to, marks which counters are legitimately zero until a later phase, and adds a **nonzero causally-paired** defer/reclaim test. The **honest PR count is 13 numbered phases / 16 PRs**, enumerated below. The false "P3/P4/P5 are file-disjoint from P2, so they can merge in parallel" claim is **deleted** — the file lists overlap and all phases merge sequentially | P0, §0 PR ledger, §0 graph |
+| **7** | **P12** implements the coordinator-adopted Linux-faithful protected-init policy: user-originated default-fatal signals to designated init with no handler are **silently dropped and the send returns 0**. All `EPERM` language and its test assertion are removed | P12 |
+
+**Unchanged from v1:** the five phasing rules (with one refinement noted in rule 2), the standard gate,
+P3, P4, P5, P7 (except an honesty note), the merge discipline, and the round-level stop rule.
 
 ---
 
@@ -17,15 +38,43 @@ class (r23: fixed 3, introduced 4).
 1. **Strictly better, always.** Stopping the round at *any* phase boundary must leave the tree
    strictly better than `main`. No phase depends on a later phase for its safety argument.
 2. **No dormant code.** Every new API has a live caller in the PR that introduces it. No
-   `#[allow(dead_code)]`, no "activated in a later phase". *(This is Judge 1's second fatal finding
-   against design B, cured structurally.)*
+   `#[allow(dead_code)]`, no "activated in a later phase". *(v2 refinement, condition 1: where a phase
+   ships a predicate with two arms — e.g. P9's boundary-reachable vs legacy remote-mark — **both arms
+   must be exercised by that PR's own tests**, and the arm destined for deletion must be a ratcheted
+   allowlist that only shrinks. A branch that no test in its own PR can reach is dormant code wearing
+   a different hat.)*
 3. **Spine first.** #491's confirmed-live UAF closes in **Phase 2 of 13**, using only already-merged
-   primitives — not behind ten prerequisite PRs. *(Judge 1's first fatal finding against B.)*
+   primitives — not behind ten prerequisite PRs.
 4. **Hard size ceiling.** PR #418 measured **5 files / 166 insertions / 70 deletions = 236 lines**.
-   Each phase targets **≤ ~230 changed non-generated lines across ≤ 5 production files**. Crossing it
+   Each PR targets **≤ ~230 changed non-generated lines across ≤ 5 production files**. Crossing it
    means splitting at the named seam *before* review, not merging anyway. The ceiling is a gate.
 5. **One revert story per phase**, written in the PR body before merge, and the phase's code must
    actually be revertable alone (verified by `git revert` dry run on the merge commit).
+
+### The honest PR ledger — 13 numbered phases, **16 PRs** *(condition 6)*
+
+v1 claimed "13 phases / 13 PRs" while splitting P9 into three; the ratification counted 15 and called
+the contradiction a MAJOR. With P6 also split (condition 2) the true figure is **16 PRs**. Every one
+is listed; there are no others.
+
+| # | PR | Phase | Ceiling estimate |
+|---|---|---|---|
+| 1 | Teardown observability + call-site ratchet | P0 | ~200 lines / 3 files |
+| 2 | Retirement fence + RootProof taxonomy + drain restructure | P1 | ~190 lines / 5 files |
+| 3 | SPINE-1: SIGKILL stops eager-freeing (+ receipt-after-PM-drop) | P2 | ~210 lines / 5 files |
+| 4 | exec detach + clone/exec admission | P3 | ~150 lines / 4 files |
+| 5 | Kernel-stack ownership parity | P4 | ~150 lines / 5 files |
+| 6 | Runtime init designation (identity only) | P5 | ~180 lines / 5 files |
+| 7 | Reap/tombstone retention gate | **P6a** | ~170 lines / 5 files |
+| 8 | Exactly-once ledger (four-state obligations) | **P6b** | ~190 lines / 5 files |
+| 9 | FD closure leaves the PM lock | P7 | ~160 lines / 5 files |
+| 10 | Victim-owned `do_exit_current` + boundary hook | P8 | ~220 lines / 5 files |
+| 11 | Request-only scheduler termination + group cutover | **P9** (was P10) | ~220 lines / 5 files |
+| 12 | Killable wait: futex | **P10a** (was P9a) | ~150 lines / 4 files |
+| 13 | Killable wait: `WaitQueueHead` + stdin/TTY readers | **P10b** (was P9b) | ~150 lines / 4 files |
+| 14 | Killable wait: child-wait + timer/nanosleep + completion/I-O; **delete the legacy arm** | **P10c** (was P9c) | ~180 lines / 5 files |
+| 15 | Fatal-signal + fault convergence (intent-only delivery) | P11 | ~220 lines / 5 files |
+| 16 | Init death policy | P12 | ~120 lines / 4 files |
 
 ### Standard gate — run on EVERY phase, no exceptions
 
@@ -38,31 +87,75 @@ class (r23: fixed 3, introduced 4).
    the behaviour under test is never accepted as evidence. **QEMU concurrency capped at 4** per
    standing operator rule (batch 4 and 4, never 8+).
 3. **Phase-specific assertions** below — every one an observed outcome (counter equality, actual
-   `waitpid` status, zero fault markers). "The process was created" is never evidence.
+   `waitpid` status, zero fault markers). "The process was created" is never evidence, and **a
+   counter equality that holds at zero is never evidence** (condition 6): every equality gate names
+   the workload that drives it nonzero, or declares explicitly why that counter is legitimately zero
+   until a named later phase.
 4. **Parallels launcher streak:** 10 consecutive PASS with `inject_retries=0`, ≤15 attempts, fresh
    epoch-named VM via `./run.sh --parallels`, `prlctl stop --kill` after each.
-5. **Soak** on any phase that changes kill timing or retention (2, 6, 7, 8, 10, 11): 30-min minimum,
-   plus the retention measurement where noted.
+5. **Soak** on any phase that changes kill timing or retention (2, 6a, 6b, 7, 8, 9, 10c, 11): 30-min
+   minimum, plus the retention measurement where noted.
 6. **Frozen-region hash gate:** all six gold-master regions byte-identical vs `main`; all five Tier-1
    files byte-identical unless OQ-4 has been granted in writing.
 7. **Cleanup:** all Parallels VMs stopped, all stray QEMU killed, before reporting the phase done.
 
-### Dependency graph (the only hard edges)
+### Dependency graph — re-derived *(condition 1)*
+
+Every edge below is a **hard** edge: the target phase's safety argument or its "no dormant code"
+obligation is unsatisfiable without the source.
 
 ```
-P0 ──> everything (evidence)
-P1 ──> P2, P8, P10, P11        (fence/proof must precede wider grace reliance)
-P2 ──> P6, P7, P10             (the live SIGKILL call site is the thing later phases upgrade)
-P3 ──> P10                     (exec detach before any group-scoped kill)
-P4 ──> P8, P10                 (all stacks scheduler-owned before victim-owned exit)
-P5 ──> P12                     (identity before policy — never bundled)
-P6 ──> P8, P11                 (ledger before more producers exist)
-P7 ──> P8
-P8 ──> P9a/b/c ──> P10 ──> P11 ──> P12
+P0  ──> everything                      (evidence + ratchet; every later gate cites its counters)
+
+P1  ──> P2                              (grace-stamped receipt must be provably ordered before
+    ──> P6a                              the tombstone-removal gate reuses grace+RootProof)
+    ──> P8, P9, P11                     (wider grace reliance)
+
+P2  ──> P6b                             (P2's seed obligation is what the ledger generalizes)
+    ──> P7                              (P2's SIGKILL commit is one of P7's FD convergence points)
+    ──> P9                              (the live SIGKILL call site is the thing P9 upgrades, and
+                                         P9's legacy arm IS P2's behaviour)
+
+P3  ──> P8   *** MISSING IN v1 ***      (P8's last-reference decision and RootProof read the row's
+                                         own root + inherited_cr3; a stale inherited_cr3 after exec
+                                         presents a root the row does not own — DESIGN §2.3)
+    ──> P9                              (exec detach before any group-scoped kill)
+
+P4  ──> P8, P9                          (all stacks scheduler-owned before any victim-owned exit or
+                                         request-only termination)
+
+P5  ──> P12                             (identity before policy — never bundled)
+
+P6a ──> P6b   *** NEW ***               (row must outlive obligations before Resources becomes
+                                         row-resident — DESIGN §1.6)
+P6b ──> P8                              (the victim commit claims ledger obligations)
+    ──> P11                             (P11 deletes the legacy notifier and relies on the ledger)
+
+P7  ──> P8                              (one-at-a-time FD acquisition is what the commit uses)
+
+P8  ──> P9                              (the hook + do_exit_current are what a published request
+                                         resolves to)
+    ──> P12                             (init's own exit commit is a latch producer)
+
+P9  ──> P10a, P10b, P10c   *** REORDERED ***
+                                        (every wait-family PR consumes the request/wake mechanism;
+                                         v1 had this edge backwards)
+    ──> P11                             (the terminate() allowlist cannot reach empty until SIGKILL
+                                         has left the exit_process/terminate route)
+
+P10c ──> (no successor is blocked; it is the completion point for #491 and AC-11)
+
+P11 ──> P12                             (the unhandleable-fault latch producer lives here)
 ```
 
-Everything else is independent and can be reordered or dropped. **P3, P4, P5 can run in parallel with
-P2** (disjoint files) if review bandwidth allows.
+**No parallel-merge path is claimed.** *(condition 6 — v1's "P3, P4, P5 can run in parallel with P2
+(disjoint files)" was false and is deleted.)* The production file lists overlap materially:
+`process/manager.rs` appears in P2, P3, P5, P6a, P6b, P7, P8, P9; `task/scheduler.rs` in P1, P2, P3,
+P4, P9, P10a/b/c; `syscall/signal.rs` in P2, P5, P9, P12; `task/process_task.rs` in P1, P2, P4, P6a,
+P6b, P7, P8. There is no pair of phases in this plan whose production files are disjoint enough to
+merge concurrently without rebasing the other, so **phases merge strictly sequentially in the order
+listed**. Reordering is permitted only where the graph above has no edge, and only one phase is in
+flight at a time.
 
 ---
 
@@ -71,27 +164,56 @@ P2** (disjoint files) if review bandwidth allows.
 **Scope.** Lock-free counters with a normal-context reader, and a source-structure ratchet that pins
 the *exact current* bypass surface so any regression fails CI immediately.
 
-Counters (all `trace_count!`, all with a reader — no write-only counters):
-`TEARDOWN_ENTRY{exit,fault,signal,group}`, `EXIT_FIRST_REQUESTS`, `EXIT_REPEAT_REQUESTS`,
-`EXIT_ATTRIBUTION_UNCERTAIN`, `TEARDOWN_QUARANTINE`, `EXIT_SGI_SENT`, `TEARDOWN_DEFER`,
-`TEARDOWN_RECLAIM`, `TEARDOWN_VICTIM_DIVERGENCE`, `TEARDOWN_CR3_MISS`,
-`TEARDOWN_MASKED_FRAMES_WALKED`, `FD_CLOSES_UNDER_PM`, `RECLAIM_CONTEXT_VIOLATIONS`,
-`TEARDOWN_LOCK_ORDER_SUSPECT`, `DEFERRED_FAULT_RING_DROPPED` (#492's overflow is invisible today).
+> **v2 (condition 6): every counter names the existing write-site it attaches to.** v1 listed counter
+> names only, so the equality gate could pass vacuously at zero. The table below is the complete
+> wiring plan against `main`'s live code; a counter with no site named here is not in P0.
+
+| Counter | Existing write-site(s) wired in P0 | Nonzero on a normal boot? |
+|---|---|---|
+| `TEARDOWN_ENTRY{exit}` | `task/process_task.rs:218 handle_thread_exit` (callers `syscall/handlers.rs:169`, `arch_impl/aarch64/syscall_entry.rs:377`) | **yes** — every process exit |
+| `TEARDOWN_ENTRY{fault}` | `task/process_task.rs:369` (`handle_thread_exit(tid, -11)` inside `drain_deferred_fault_sigsegv_exits`, `:363`) + the four EL0 fault sites `arch_impl/aarch64/exception.rs:768,1135,1230,1333` | yes under the fault tests |
+| `TEARDOWN_ENTRY{signal}` | `syscall/signal.rs:162`, `signal/delivery.rs:224`, `:258` | yes under the signal tests |
+| `TEARDOWN_ENTRY{group}` | *(no group path exists on `main`)* | **declared zero until P9** — not part of any equality gate before then |
+| `EXIT_FIRST_REQUESTS` / `EXIT_REPEAT_REQUESTS` | the `already_terminated` reads at `process/manager.rs:1121` and `task/process_task.rs:222`, plus `Process::terminate_minimal`'s repeat early-return (`process/process.rs:320`) | yes (first); repeat is exercised by the P0 repeat test |
+| `TEARDOWN_QUARANTINE` | `task/scheduler.rs:2599 terminate_process_threads` (five call sites: `exception.rs:768,1135,1230,1333`, and `signal.rs` from P2) | yes under the fault tests |
+| `EXIT_SGI_SENT` | the `SGI_RESCHEDULE` sends at `task/scheduler.rs:1857` and `:1886` | yes |
+| `TEARDOWN_DEFER` | `task/process_task.rs:129 defer_process_resources` (reached from `:125 defer_live_process_resources` and `process/manager.rs:1151`) | **yes** — every aarch64 exit |
+| `TEARDOWN_RECLAIM` | `task/process_task.rs:388` (`reclaim.reclaim()` inside `reclaim_deferred_process_resources`, `:375`) | **yes** |
+| `TEARDOWN_MASKED_FRAMES_WALKED` | `task/process_task.rs:100 release_process_resources` → `cleanup_cow_frames()`, incremented only when the PM-owner instrumentation says a PM guard is live (call sites `manager.rs:1156`, `process_task.rs:247`, `:250`) | yes on `main` (that is the defect P2/P7/P11 drive to 0) |
+| `FD_CLOSES_UNDER_PM` | `process/process.rs:347 close_all_fds` reached under PM via `Process::terminate` (`:284`, `:294`) from `manager.rs:1161`, `signal.rs:162`, `delivery.rs:224`, `:258`, `interrupts/context_switch.rs:1021`; plus `take_fd_entries` (`process.rs:335`) at `process_task.rs:236` | yes on `main` (driven to 0 by P7) |
+| `TEARDOWN_VICTIM_DIVERGENCE` / `TEARDOWN_CR3_MISS` | `process/manager.rs:1313-1335 find_process_by_cr3_mut` vs the TID-derived owner at the four EL0 sites | zero on a clean boot; **driven nonzero by the P11 `clonevm_fault_test`**, declared until then |
+| `EXIT_ATTRIBUTION_UNCERTAIN` | the total-resolution-failure branch at the four EL0 sites | declared zero until injected |
+| `DEFERRED_FAULT_RING_DROPPED` | `task/process_task.rs:43` — `DeferredFaultExitBuffer::push` returning `false` (caller `defer_fault_sigsegv_exit`, `:352`) | zero normally; **P0 ships a 17-deep injection that drives it nonzero**, proving the counter is real (#492's overflow is invisible today) |
+| `RECLAIM_ENQUEUE_UNDER_PM` *(new, cond. 3)* | `task/process_task.rs:140 enqueue_process_reclaim`, incremented when the PM-owner instrumentation says PM is live — true today at **both** call sites (`manager.rs:1152`, `process_task.rs:244`) | **yes on `main`** — this is the pre-existing violation P2 drives to 0 |
+| `PROOF_UNDER_QUEUE_LOCK` *(new, cond. 3)* | `task/process_task.rs:375-392`, incremented if SCHEDULER or PM is acquired while `PENDING_PROCESS_RECLAIMS` is held | zero on `main` (both predicates are lock-free); P1 must keep it zero |
+| `RECLAIM_CONTEXT_VIOLATIONS`, `TEARDOWN_LOCK_ORDER_SUSPECT` | the lock-depth/owner instrumentation, **including `try_manager()`** (the r20 detector blind spot) | zero; asserted |
 
 Ratchet (`tests/teardown_structure.rs`) asserts the exact current sets of: `\.terminate\(` /
 `terminate_minimal\(` call sites; production `ProcessId::new(1)` sites (with the three
 `test_userspace.rs` sites allowlisted **by name**); `terminate_process_threads` call sites;
-`kernel_stack_allocation` mutation sites. It passes on `main` unchanged; later phases shrink the
-allowlist, and any *new* bypass fails on arrival.
+`kernel_stack_allocation` mutation sites; **`enqueue_process_reclaim` call sites** (v2). It passes on
+`main` unchanged; later phases shrink the allowlists, and any *new* bypass fails on arrival.
 
 **Files.** `kernel/src/tracing/providers/teardown.rs` (new), tracing registration,
 `tests/teardown_structure.rs` (new). **~200 lines, 2 commits.**
 
-**Gate extras.** Boot test asserts `TEARDOWN_DEFER == TEARDOWN_RECLAIM` at quiesce,
-`TEARDOWN_LOCK_ORDER_SUSPECT == 0`, and that every counter has a reader (no write-only counters).
+**Gate extras.** *(v2 — condition 6: no vacuous zero-baseline gate.)*
+1. **`fork_exit_defer_reclaim_pairing_test` (the causally-paired nonzero gate).** Fork and exit **64**
+   children in a loop, then quiesce. Assert (a) `TEARDOWN_ENTRY{exit} >= 64`; (b) `TEARDOWN_DEFER >= 64`;
+   (c) after the drain, `TEARDOWN_DEFER == TEARDOWN_RECLAIM` **at a value ≥ 64** — the equality is only
+   accepted at a nonzero, workload-explained value; (d) **per-pid pairing**: each deferred pid recorded
+   by a `trace_event!` payload appears exactly once in a later reclaim event, so the equality cannot be
+   satisfied by two unrelated streams that happen to have equal totals.
+2. Ring-overflow injection drives `DEFERRED_FAULT_RING_DROPPED` nonzero and back to a quiescent read.
+3. Baseline snapshot of `TEARDOWN_MASKED_FRAMES_WALKED`, `FD_CLOSES_UNDER_PM` and
+   `RECLAIM_ENQUEUE_UNDER_PM` on `main` — these are **expected nonzero** and are the pre-existing
+   defects later phases drive to zero; recording the baseline is what makes those later gates meaningful.
+4. `TEARDOWN_LOCK_ORDER_SUSPECT == 0`, `PROOF_UNDER_QUEUE_LOCK == 0`, and every counter has a reader
+   (no write-only counters).
 
 **Strictly better.** Every later phase's evidence becomes a counter equality instead of a log-reading
-exercise, and the bypass surface can only shrink. #492's silent drops become visible.
+exercise, and the bypass surface can only shrink. #492's silent drops become visible, and two
+pre-existing lock violations become measurable before anyone tries to fix them.
 
 **Revert.** Delete two files + their registration. Zero coupling.
 
@@ -108,19 +230,47 @@ Replace the boolean root-liveness answer with `RootProof`'s blocker taxonomy: lo
 scheduler cached roots, live/creating rows — each with its own counter. Adapt today's two reclaim
 users. Grace is still checked **first**.
 
+> **v2 (condition 3) — the drain is restructured so no proof ever runs under the reclaim-queue lock.**
+> `reclaim_deferred_process_resources` (`task/process_task.rs:375-392`) currently evaluates
+> `retirement_grace_elapsed(&reclaim.after_epoch) && !reclaim.root_is_live()` **while holding**
+> `PENDING_PROCESS_RECLAIMS`. Both terms are lock-free atomic reads today, so `main` is legal — but
+> `RootProof` adds *scheduler cached roots* and *live rows*, which take SCHEDULER and PM. Acquiring
+> either under the queue lock is the overlapping-lock violation the design forbids, and "it's only
+> until P8" is not an exemption. P1 therefore ships the cycle as:
+>
+> ```
+> 1. QUEUE LOCK ONLY:  scan for a candidate whose fence has elapsed AND whose
+>                      lock-free blockers (hardware/shadow) are clear; swap_remove it
+>                      into a local fixed slot.                        -> DROP QUEUE LOCK
+> 2. NO LOCK:          RetirementSnapshot (acquire fence) + hardware/shadow re-read.
+> 3. SCHEDULER ONLY:   cached-root blocker.                            -> DROP
+> 4. PM ONLY:          live/creating-row blocker.                      -> DROP
+> 5. proof passed  -> free with NO lock held.
+>    proof refused -> bump that blocker's counter, re-acquire the QUEUE LOCK ALONE,
+>                     re-insert, rotate.
+> ```
+>
+> The under-queue-lock predicate is permanently restricted to lock-free reads; `PROOF_UNDER_QUEUE_LOCK`
+> (P0) asserts it. A candidate detached and then refused is re-inserted, never dropped — the
+> re-insertion path is part of this PR's tests, not a later phase's.
+
 **Files.** `kernel/src/task/scheduler.rs`, `kernel/src/task/process_task.rs`,
-`kernel/src/arch_impl/aarch64/ttbr0.rs`, tracing provider, targeted tests. **~170 lines, 2 commits.**
+`kernel/src/arch_impl/aarch64/ttbr0.rs`, tracing provider, targeted tests. **~190 lines, 2 commits.**
 
 **Gate extras.** Unit injection with a zero online mask refuses reclaim; wrap-safe epoch comparison
 test; the existing epoch-before-stack-liveness ordering becomes a structural test; every refusal in a
-normal boot is attributable to exactly one blocker.
+normal boot is attributable to exactly one blocker. **v2:** `PROOF_UNDER_QUEUE_LOCK == 0` with the
+richer proof live; a forced refusal at each of the four blocker classes proves the detach/re-insert
+cycle preserves the entry (queue length returns to its prior value, the same receipt is retried and
+eventually retires) — asserted at a **nonzero** refusal count, not at zero.
 
 **Strictly better.** Grace can no longer elapse on an unordered or empty observation; reclaim
 refusals stop being a single opaque boolean; the local hardware register enters the proof (closing the
-local half of the shadow/hardware gap `main` has today).
+local half of the shadow/hardware gap `main` has today); the drain stops being a place where a future
+proof could nest locks.
 
-**Revert.** Restore the bare arrays and the boolean predicate; counters in P0 go unused but harmless
-(they are read by the reader, not dead).
+**Revert.** Restore the bare arrays, the boolean predicate and the in-lock scan; counters in P0 go
+unused but harmless (they are read by the reader, not dead).
 
 ---
 
@@ -133,29 +283,53 @@ other online CPU (no `cpu_state[].current_thread` residency predicate — that r
 was a fatal panel finding); then `with_process_manager(|pm| pm.exit_process(pid, -9))`, whose
 merged aarch64 path already grace-defers the page table **before** `terminate()` runs. Keep the
 existing `set_need_resched()` tail. Additionally install the **durable report/SIGCHLD obligation seed**:
-one row work bit set at first commit, redeemed exactly once outside PM by whichever of
-{commit path, `handle_thread_exit`} reaches it first — because `btrt::on_process_exit` has exactly one
-call site inside `handle_thread_exit`, which a remotely-marked victim may never run.
+one row obligation moved `Absent → Pending` at first commit and redeemed exactly once outside PM by
+whichever of {commit path, `handle_thread_exit`} **claims** it first (the four-state machine of
+DESIGN §1.6 — the seed uses it from day one; P6b generalizes it, it does not upgrade a bool) — because
+`btrt::on_process_exit` has exactly one call site at `task/process_task.rs:267` inside
+`handle_thread_exit`, which a remotely-marked victim may never run.
+
+> **v2 (condition 3) — the retirement receipt is enqueued only after the PM guard drops.**
+> `exit_process` becomes:
+>
+> ```rust
+> #[must_use]
+> pub fn exit_process(&mut self, pid: ProcessId, exit_code: i32) -> Option<RetirementReceipt>
+> ```
+>
+> It still stamps the grace epoch and takes the root under PM, but **returns** the receipt instead of
+> calling `enqueue_process_reclaim` at `manager.rs:1152`. The caller enqueues after
+> `with_process_manager(...)` returns, with no guard live. The move allocates nothing
+> (`core::mem::take` on the existing `pending_old_page_tables` `Vec` leaves it empty without
+> allocating). The **second** PM-nested enqueue, `handle_thread_exit` phase 1 at
+> `task/process_task.rs:244`, is converted in the same PR: the receipt rides out through the existing
+> `phase1_result` value and is enqueued in phase 2, where PM is already dropped. Both `#[allow(dead_code)]`
+> markers on `exit_process` come off — P2 is its first live caller.
 
 **Files.** `kernel/src/syscall/signal.rs`, `kernel/src/process/manager.rs`,
-`kernel/src/task/scheduler.rs`, `kernel/src/task/process_task.rs`, tests. **~180 lines, 3 commits.**
+`kernel/src/task/scheduler.rs`, `kernel/src/task/process_task.rs`, tests. **~210 lines, 3 commits —
+seam for splitting if it crosses the ceiling is {receipt-return refactor} / {SIGKILL arm + seed}.**
 
 **Gate extras.** New `sigkill_teardown_test` (userspace): parent forks a child spinning at EL0;
 parent `kill(child, SIGKILL)`. Assert (a) `waitpid` reaps **-9**; (b) SIGCHLD arrived at kill time
 (parent's `pause()` returns); (c) `TEARDOWN_QUARANTINE`/`TEARDOWN_DEFER`/`TEARDOWN_RECLAIM` all
-increment for that pid; (d) `TEARDOWN_MASKED_FRAMES_WALKED == 0`; (e) `EXIT_SGI_SENT > 0` and the
-peer observes it; (f) exactly one `btrt` report; (g) zero fault markers over the 10-boot Parallels
-streak. Repeat with the child inside a CLONE_VM group — the **sibling must survive** (this phase does
-not sweep the group). Repeat as self-kill `kill(getpid(), SIGKILL)`. **Soak + retention measurement.**
+increment for that pid; (d) `TEARDOWN_MASKED_FRAMES_WALKED == 0` **for kill paths** (the baseline
+recorded in P0 must drop, not merely stay flat); (e) `EXIT_SGI_SENT > 0` and the peer observes it;
+(f) exactly one `btrt` report; (g) zero fault markers over the 10-boot Parallels streak; **(h)
+`RECLAIM_ENQUEUE_UNDER_PM == 0` — the P0 baseline was nonzero at both sites, so this is a measured
+drop, not a vacuous zero.** Repeat with the child inside a CLONE_VM group — the **sibling must
+survive** (this phase does not sweep the group). Repeat as self-kill `kill(getpid(), SIGKILL)`.
+**Soak + retention measurement.**
 
 **Strictly better.** The confirmed-live eager `cleanup_cow_frames`-while-remote-runs UAF class is
-gone; quarantine, expedited reschedule, and SIGCHLD arrive for the first time on this path. *Honest
-bound:* the exit is still remotely marked (upgraded in P8–P10), and FD closure still happens inside
-`exit_process` under PM — unchanged from today's SIGKILL, which does that **plus** the full CoW walk.
-Not a regression; not yet a fix. Fixed in P7.
+gone; quarantine, expedited reschedule, and SIGCHLD arrive for the first time on this path; and both
+pre-existing reclaim-queue-under-PM nestings are removed. *Honest bound:* the exit is still remotely
+marked (upgraded in P8/P9/P10a-c), and FD closure still happens inside `exit_process` under PM —
+unchanged from today's SIGKILL, which does that **plus** the full CoW walk. Not a regression; not yet
+a fix. Fixed in P7.
 
-**Revert.** Restore the four-line `process.terminate(-9)` arm and drop the work bit. The exact
-pre-image is preserved in the commit body.
+**Revert.** Restore the four-line `process.terminate(-9)` arm, the in-PM enqueues and the `void`
+return; drop the obligation. The exact pre-image is preserved in the commit body.
 
 ---
 
@@ -180,6 +354,11 @@ falls back to pid — `futex.rs` is the main consumer). Deterministic clone-vs-e
 **Strictly better.** Closes the wrong-victim-after-exec defect that was one of the four blockers
 which killed PR #418's group sweep — *before* any group-scoped kill exists to trip over it.
 
+**Dependency note (v2, condition 4).** This phase is a hard prerequisite of **P8**, not only of P9:
+P8's last-reference decision and `RootProof` read the row's own root *and* `inherited_cr3`, so a row
+carrying a stale `inherited_cr3` past an exec would present a root it does not own (DESIGN §2.3). The
+`P3 → P8` edge is now in the graph; v1 omitted it.
+
 **Revert.** Delete the two assignments + the admission check; ~15 lines.
 
 ---
@@ -190,8 +369,8 @@ which killed PR #418's group sweep — *before* any group-scoped kill exists to 
 scheduler copy", then apply it to the paths that never got it: fresh spawn (`creation.rs` ×2),
 direct init, `boot/test_disk.rs`, alongside the already-fixed fork and clone. A `Process` row can no
 longer synchronously drop a published stack — today the original thread's stack is freed ungated by
-`remove_process` at `waitpid` reap. Drop PM before every scheduler registration (removing the existing
-PM→scheduler nesting in the spawn/test-disk paths).
+`remove_process` at `waitpid` reap (`syscall/wait.rs:385` → `manager.rs:1101-1104`). Drop PM before
+every scheduler registration (removing the existing PM→scheduler nesting in the spawn/test-disk paths).
 
 **Files.** `kernel/src/process/creation.rs`, `kernel/src/main_aarch64.rs`,
 `kernel/src/boot/test_disk.rs`, `kernel/src/arch_impl/aarch64/syscall_entry.rs`,
@@ -205,6 +384,9 @@ an allocator assertion that never selects a live slot. P0 ratchet extended: no
 **Strictly better.** Closes the third and last un-graced stack case; removes a PM→scheduler nesting.
 *Honesty note:* the input package reports the spawn asymmetry as **fact, not a diagnosed bug** — this
 phase closes it because uniformity is cheap and it is an AC, not because a UAF was demonstrated.
+*(v2:* the `remove_process` call site this phase protects against is itself replaced by P6a's
+tombstone gate; the two fixes meet at the same call site and P6a's gate extras re-run this phase's
+stack-accounting assertion.*)*
 
 **Revert.** Per-site; each call site is independent.
 
@@ -240,29 +422,90 @@ death — deliberately, because bundling identity with policy is what killed fou
 
 ---
 
-## Phase 6 — Exactly-once ledger: durable work bits + first status *(AC-12)*
+## Phase 6a — Reap/tombstone retention gate *(NEW in v2 — condition 2)*
 
-**Scope.** Generalize Phase 2's report-obligation seed into row-resident
-`ExitWorkBits { sigchld, parent_wake, report, reparent, fds, resources }`, created at the **first**
-request and cleared only on completion. A repeat request returns the stored batch/status and creates
-no second obligation and no second status write. `ExitWorkBits.resources` subsumes design A's proposed
-separate `ResourceState{Held,HandedOff}` field — "the page table has left this row" is one more durable
-obligation, not a parallel key. Both already-terminated branches (`manager.rs:1137`,
-`process_task.rs:234`) re-key onto the work bit.
+**Scope.** Make a process row outlive its reap so that row-resident obligations cannot be destroyed
+before they are discharged. Today `waitpid`'s `complete_wait` physically removes the row
+(`kernel/src/syscall/wait.rs:385` → `ProcessManager::remove_process`, `manager.rs:1101-1104`), which
+is exactly the seam the ratification flagged: P6b's `Resources` obligation **by construction outlives
+reap** (grace + RootProof are still pending when the parent collects the status — R-13).
+
+- Add `RowState { Live, Zombie, Tombstone { reaped_by, status } }` to the process row.
+- `complete_wait` no longer calls `remove_process`; it records the reap and transitions
+  `Zombie → Tombstone`. The parent's `children` retain is unchanged.
+- A `Tombstone` row is **invisible** to every "live process" query: `find_process_by_pid/thread/cr3`,
+  signal delivery, wait scanning, procfs enumeration, and PID allocation reuse. Each of those call
+  sites is enumerated in the PR body and covered by a ratchet rule (`no raw self.processes.get*` in
+  teardown/wait/signal code without the liveness predicate).
+- Removal moves to the S4 retire gate: a tombstone is removed only when its retirement receipt has
+  retired (grace elapsed + RootProof passed) or was never created. In P6a there are no ledger bits
+  yet, so the gate's ledger term is vacuously true and is asserted to become live in P6b.
+- `TOMBSTONE_RESIDENT` (gauge with a reader) and `TOMBSTONE_REMOVED` counters.
+
+**Files.** `kernel/src/syscall/wait.rs`, `kernel/src/process/manager.rs`,
+`kernel/src/process/process.rs`, `kernel/src/task/process_task.rs`, tests. **~170 lines, 2 commits.**
+
+**Gate extras.** (a) `waitpid` still returns the correct status and the parent's `children` list is
+still pruned — existing wait/orphan tests green unchanged. (b) `TOMBSTONE_RESIDENT` returns to **0**
+at quiesce after a 64-child fork/exit/reap workload, having been **observably nonzero mid-run** (both
+halves asserted — a gauge that is always zero proves nothing). (c) A pid whose row is tombstoned is
+not returned by any live-process lookup: negative tests for `kill(pid)` → `ESRCH`, `waitpid` repeat →
+`ECHILD`, and procfs absence. (d) PID reuse does not hand out a tombstoned pid. (e) P4's stack-pool
+accounting re-run (allocated == freed) now that reap no longer drops the row. **Soak + retention
+measurement** (this phase changes retention by construction).
+
+**Strictly better.** Row lifetime stops being shorter than the lifetime of the work the row owns — the
+precondition every later phase's row-resident state depends on. It also converts today's "reap frees
+the row and whatever is still attached to it" into a proof-gated removal, which is the same discipline
+already applied to page tables and stacks.
+
+**Revert.** Restore the `remove_process` call in `complete_wait` and delete `RowState::Tombstone`;
+P6b is not yet merged, so nothing depends on it.
+
+---
+
+## Phase 6b — Exactly-once ledger: four-state obligations + first status *(AC-12)*
+
+**Scope.** Generalize Phase 2's obligation seed into the row-resident `ExitLedger` of DESIGN §1.6:
+six obligations (`Sigchld, ParentWake, Report, Reparent, Fds, Resources`), each carrying
+`Absent | Pending | Claimed{claimer, at} | Completed` in a fixed-size array — **not booleans**.
+
+> **v2 (condition 2) — this is the replacement for design C's single-worker serialization.** All four
+> transitions happen under the PM guard and nowhere else, take no second lock, allocate nothing and
+> log nothing: **T1** `Absent→Pending` in S1's first request only; **T2** `Pending→Claimed{me}` by a
+> control path that will discharge it immediately; **T3** `Claimed{me}→Completed` by the claimer only,
+> under a fresh PM acquisition after the work finished outside PM; **T4** `Claimed{dead}→Pending` by
+> the S4 retire gate only, when the claimer is proven not live and the claim-time fence has elapsed.
+> The sole-redeemer invariant — at most one control path is ever `Claimed` — falls out of read-then-write
+> inside one PM acquisition, so the commit path and `handle_thread_exit` can no longer both redeem.
+
+A repeat request returns the stored batch/status and creates no second obligation and no second status
+write. `ExitLedger`'s `Resources` obligation subsumes design A's proposed separate
+`ResourceState{Held,HandedOff}` field. Both already-terminated branches (`manager.rs:1137`,
+`process_task.rs:234`) re-key onto the ledger state.
 
 **Files.** `kernel/src/process/process.rs`, `kernel/src/process/manager.rs`,
-`kernel/src/task/process_task.rs`, tracing provider, tests. **~180 lines, 2 commits.**
+`kernel/src/task/process_task.rs`, tracing provider, tests. **~190 lines, 2 commits.**
 
 **Gate extras.** Repeat matrix — exit→fault, SIGKILL→fault, fault→SIGKILL, repeated request/wait:
 exactly one SIGCHLD, one parent wake, one `btrt` report, and `waitpid` returns the **first** status.
-Equalities: `SIGCHLD_FIRST_SET == PARENT_WAKE_COMPLETED == BTRT_EXIT_REPORTED == parented_first_commits`.
-CoW frame accounting unchanged vs P5 for the same workload.
+Equalities: `SIGCHLD_FIRST_SET == PARENT_WAKE_COMPLETED == BTRT_EXIT_REPORTED == parented_first_commits`,
+**asserted at the nonzero value the 64-child workload produces**. `LEDGER_CLAIM_MISMATCH == 0`.
+**Two-producer race test:** force `handle_thread_exit` and the commit path to contend for the same
+row's `Report` obligation; assert exactly one `btrt` report and that the loser observed
+`Claimed`/`Completed` (counter `LEDGER_CLAIM_LOST_RACE > 0` — the race must actually be exercised,
+not assumed). **Orphan-recovery test:** inject a claimer that dies between T2 and T3; assert
+`LEDGER_CLAIM_ORPHANED == 1`, the obligation returns to `Pending`, and the notification is ultimately
+delivered exactly once rather than lost. `TOMBSTONE_RESIDENT` still returns to 0 at quiesce with the
+ledger term of the removal gate now live. CoW frame accounting unchanged vs P5 for the same workload.
 
 **Strictly better.** Closes PR #418's own declared follow-up ("duplicate SIGCHLD / stale exit code on
-the already-terminated path"). Explicitly **not** notification suppression (disproven in review): the
-obligation is shared by every producer, so a later pass redeems it rather than being skipped.
+the already-terminated path") **with a mechanism, not a convention**. Explicitly **not** notification
+suppression (disproven in review): the obligation is shared by every producer, so a later pass claims
+and redeems it rather than being skipped.
 
-**Revert.** Re-key the two branches onto `is_terminated()` and drop the bits.
+**Revert.** Re-key the two branches onto `is_terminated()` and drop the ledger; P6a's tombstone gate
+survives independently (its ledger term becomes vacuously true again).
 
 ---
 
@@ -271,19 +514,24 @@ obligation is shared by every producer, so a later pass redeems it rather than b
 **Scope.** Add `FdTable::take_next_for_exit()` — take exactly **one** descriptor under PM, drop PM,
 close it, repeat. Retire the existing allocating `Process::take_fd_entries() -> alloc::vec::Vec`
 (`process.rs:335`) rather than reusing it. Apply at both convergence points and at Phase 2's SIGKILL
-commit.
+commit. The `Fds` obligation brackets the loop (`T2` before the first take, `T3` when the table is
+proven empty under PM) — the explicit control flow is in DESIGN §2.5.
 
 **Files.** `kernel/src/ipc/fd.rs`, `kernel/src/process/process.rs`,
 `kernel/src/process/manager.rs`, `kernel/src/task/process_task.rs`, tests.
 **~160 lines, 2 commits.**
 
-**Gate extras.** `FD_CLOSES_UNDER_PM == 0`. 256-FD test with a large process set: measure and assert a
-bounded PM hold. P0 ratchet forbids any close/reclaim call inside a request/commit transaction body.
-Soak.
+**Gate extras.** `FD_CLOSES_UNDER_PM == 0` — a **measured drop** from the nonzero P0 baseline, not a
+zero that was always zero. 256-FD test with a large process set: measure and assert a bounded PM hold
+(one descriptor per acquisition). P0 ratchet forbids any close/reclaim call inside a request/commit
+transaction body. Soak.
 
 **Strictly better.** Removes the pipe/PTY/TCP endpoint locks *and* a heap allocation from under
 PM+DAIF-masked on **every** exit path — a pre-existing violation on `main` that predates all of this
 work, and the last one Phase 2 knowingly left standing.
+
+*Honest scope note (v2, folding the ratification's P7 remark):* P7 matches the end state but does
+**not** supply P6b's row-lifetime prerequisite — that is P6a's job, and P6a is sequenced before both.
 
 **Revert.** Restore the `Vec` path; the one-at-a-time API is additive.
 
@@ -292,24 +540,49 @@ work, and the last one Phase 2 knowingly left standing.
 ## Phase 8 — Victim-owned `do_exit_current`, normal exit as first consumer *(Tier-2; needs OQ-5)*
 
 **Scope.** The exit trampoline and one-shot victim transaction: claim (atomic) → local TTBR0 leave
-(hardware first, shadows after) → short PM commit (mark zombie, first status, take own FDs via P7,
-decide last-reference, move root into a retirement receipt) → drop PM → all slow work unlocked
-(one-FD closes, futex/`clear_child_tid`, bounded reparent cursor with PM dropped and DAIF restored
-between batches, redeem the P6 notification receipt, enqueue the receipt) → pivot to neutral stack →
-mark **only self** `Terminated` → schedule away. **Normal `exit(2)` is routed through it in this same
-PR** — the API is never dormant. The boundary hook is an acquire-load + branch **after** the
-`PREEMPT_ACTIVE`/nested-return gate; it allocates nothing, locks nothing, walks nothing, drains
-nothing.
+(hardware first, shadows after) → short PM commit (mark zombie, first status, T2-claim the ledger
+obligations this path will discharge, take own FDs via P7, decide last-reference, move root into a
+retirement receipt) → drop PM → all slow work unlocked (one-FD closes, futex/`clear_child_tid`,
+bounded reparent cursor with PM dropped and DAIF restored between batches, redeem each obligation and
+T3-complete it under its own fresh PM acquisition, enqueue the receipt **with PM already dropped**) →
+pivot to neutral stack → mark **only self** `Terminated` → schedule away.
+
+> **v2 (condition 4) — how normal exit exercises the return-boundary hook in THIS PR.** The hook is
+> not an optional accelerator that P9 later starts using; it is the **only** entry into
+> `do_exit_current`, so it is exercised by every process that exits in this PR:
+>
+> ```
+> sys_exit(code)
+>   └─ S1 on SELF under PM (first status, obligations Absent->Pending, row ExitRequested)  … PM dropped
+>   └─ release-store ThreadExitRequest{Latched} on OWN scheduler thread
+>   └─ return normally to the syscall return path      (NO teardown work inline — this is the point)
+> <syscall/exception return path>
+>   └─ existing PREEMPT_ACTIVE / nested-return gate                              (unchanged, first)
+>   └─ HOOK: acquire-load of the exit-request word -> if Latched, call do_exit_current()
+> ```
+>
+> `sys_exit` performing no teardown inline is what makes the hook load-bearing rather than dormant.
+> **Tombstone control flow:** the victim marks its row `Zombie` and never removes it; `Zombie →
+> Tombstone` is the parent's reap (P6a) and removal is the retire gate's. **FD-acquisition control
+> flow:** `T2: Fds→Claimed` inside the commit, then `take_next_for_exit()` one descriptor per PM
+> acquisition with every close performed PM-dropped, then `T3: Fds→Completed` under a fresh
+> acquisition once the table is proven empty (DESIGN §2.5).
 
 **Files.** new `kernel/src/task/teardown.rs`; `kernel/src/task/process_task.rs`,
 `kernel/src/arch_impl/aarch64/context_switch.rs` (Tier-2), `kernel/src/arch_impl/aarch64/syscall_entry.rs`,
 `kernel/src/process/manager.rs`. **~220 lines, 3 commits — at the ceiling; seam for splitting is
 {trampoline + commit} / {boundary hook + normal-exit routing}.**
 
-**Gate extras.** Repeated/nested exit injection produces one status, one SIGCHLD, one parent wake,
-one report; FD closes and reclaim enqueue observed with PM unlocked. Disassembly review of the hook
-proving no logging, allocation, page-table walk, or contended lock on the return tail (Tier-2
-requirement). Soak. Frozen-region hashes unchanged (the hook is *outside* every frozen block).
+**Gate extras.** **Hook liveness (the anti-dormancy gate): `EXIT_HOOK_ENTRIES > 0` and
+`EXIT_HOOK_ENTRIES == EXIT_COMMITS` on a normal boot** — if any exit reached `do_exit_current` without
+traversing the hook, or the hook never fired, the phase fails. Repeated/nested exit injection produces
+one status, one SIGCHLD, one parent wake, one report; FD closes and reclaim enqueue observed with PM
+unlocked (`FD_CLOSES_UNDER_PM == 0`, `RECLAIM_ENQUEUE_UNDER_PM == 0` still). Disassembly review of the
+hook proving no logging, allocation, page-table walk, or contended lock on the return tail (Tier-2
+requirement). **x86_64 user-return audit (OQ-9): enumerate every user-return path and prove each
+reaches the common hook; if one bypasses it, halt and escalate for operator approval rather than
+patching Tier-1 syscall entry.** Soak. Frozen-region hashes unchanged (the hook is *outside* every
+frozen block).
 
 **Strictly better.** The exit path becomes victim-owned for the most common death; a `Process` row
 never drops a published stack; slow work leaves the masked section on every normal exit.
@@ -317,67 +590,111 @@ never drops a published stack; slow work leaves the masked section on every norm
 **Revert.** Route normal exit back to `handle_thread_exit`'s current two-phase body and delete the
 hook; single-file revert plus the hook removal.
 
-**Blocked on OQ-5.** Without Tier-2 approval the plan **stops at Phase 7**: #491 ships at
-Increment-1 strength (a real UAF fix), #464 and #471 ship complete, and P8–P12 park.
+**Blocked on OQ-5.** Without Tier-2 approval the plan **stops at Phase 7**, and — correcting v1 —
+that parks **P8 through P12 entirely**, not just P8. Concretely: #491 ships at Increment-1 strength
+(a real UAF fix, remote-mark model surviving); #464 ships **identity only**, because under the
+corrected order P12's only latch producers are P8's own-exit commit and P11's unhandleable-fault
+path; #471 ships **exec detach only** (P3), because the group seal now lives in P9, which is
+unreachable without P8's hook. v1's claim that "#464 and #471 ship complete" without OQ-5 was wrong
+and is withdrawn.
 
 ---
 
-## Phase 9 (a/b/c) — Killable-wait contract, one family per PR
+## Phase 9 — Request-only scheduler termination + group-scope cutover *(was Phase 10; #491 near-complete, #471 part 2)*
 
-**Scope.** 9a futex; 9b `WaitQueueHead` + stdin/TTY readers; 9c child-wait + timer/nanosleep +
-completion/I-O. Each sub-phase: on a fatal request the victim is made **runnable with its saved
-continuation and `blocked_in_syscall` intact**; the resumed continuation gives the latched fatal
-request priority over ordinary success, unregisters itself through the existing `finish_wait`/
-unregister path, then branches to the trampoline. **No `ExitPending` state** — dequeuing a victim
-whose saved resume SP is still live evidence is the banked r20 finalization deadlock, and design C's
-version of it was the panel's fatal finding against C.
-
-**Each sub-phase immediately upgrades the already-live SIGKILL path for victims in that family** — so
-nothing dormant lands, and the concrete acceptance test is "SIGKILL a victim blocked in *this*
-family". The live futex loop is the named hazard: today an unrelated wake can take the success branch
-before the signal check and leave the TID registered; the resumed loop must be reordered.
-
-**Files (per sub-phase).** the family's own file(s) + `kernel/src/task/scheduler.rs` +
-`kernel/src/task/teardown.rs` + its test. **~150 lines each, 1-2 commits each.**
-
-**Gate extras.** Per family: inject an exit request and prove the registry/heap no longer contains the
-TID **before** the exit commit; SIGKILL of a victim blocked in that family reaps the right status.
-Families not yet migrated are **reported as uninterruptible** by a counter — never silently advertised
-as killable.
-
-**Strictly better.** Each family converts from "dies at its next natural boundary, whenever that is"
-to "dies promptly, with its wait registration cleanly removed". Unmigrated families are unchanged, and
-are visible.
-
-**Revert.** Per family, independently.
-
----
-
-## Phase 10 — Request-only scheduler termination + group-scope cutover *(#491 complete, #471 part 2)*
+> **v2 (condition 1): this phase moved AHEAD of the killable-wait families.** The ratification's first
+> FATAL was that v1's wait-family PRs (old P9a/b/c) consumed a request/wake mechanism that did not
+> exist until old P10 — no producer. The order is inverted here: P9 publishes the mechanism and
+> suppresses the victim-owned commit's remote counterpart; P10a/b/c consume it, one family per PR.
 
 **Scope.** `terminate_process_threads` is redefined to **request and wake**: publish
-`ThreadExitRequest` on each member's scheduler thread, ready proven-killable blockers (P9) with
-continuations intact, **never** set a remote thread `Terminated`, return `ExitKickPlan`. Its old
-remote-marking body is **deleted in this same PR** — no parallel API is left behind. SIGKILL and
-`exit_group` become group-scoped `ExitIntent`s; the group-exit PM transaction marks every live
-effective-TGID member with one batch id and *is* the seal (no snapshot ever leaves the lock);
-`sys_clone` fails `EAGAIN` into a non-`Open` group. SGIs are sent after all locks are dropped.
+`ThreadExitRequest` on each member's scheduler thread, return `ExitKickPlan`, and **never set a remote
+thread `Terminated` for a boundary-reachable victim**. SIGKILL and `exit_group` become group-scoped
+`ExitIntent`s; the group-exit PM transaction marks every live effective-TGID member with one batch id
+and *is* the seal (no snapshot ever leaves the lock); `sys_clone` fails `EAGAIN` into a non-`Open`
+group. SGIs are sent after all locks are dropped.
+
+**The two-armed predicate (both arms live in this PR).**
+
+```rust
+/// True iff the victim will demonstrably reach the P8 return-boundary hook without help:
+/// runnable/running (EL0 or a preemptible kernel path), or blocked in a wait family whose
+/// victim-owned cancellation has been audited and tested (P10a/b/c).
+fn exit_request_is_boundary_reachable(t: &SchedThread) -> bool
+```
+
+- **true** → publish the request only; the victim runs `do_exit_current` on itself. Counted
+  `EXIT_VICTIM_OWNED`.
+- **false** → publish the request **and** take the legacy remote-mark + `exit_process` route, which is
+  byte-for-byte the behaviour merged in P2 — no new mechanism, no new hazard, and no kill-latency
+  regression for blocked victims. Counted `EXIT_LEGACY_REMOTE_MARK{family}`.
+
+At P9 the "false" set is **every wait family** (none is migrated yet); it is a named allowlist in the
+P0 ratchet that may only shrink. P10a/b/c shrink it; **P10c empties it and deletes the arm.** Both
+arms are exercised by this PR's own tests (rule 2), so nothing dormant lands.
 
 **Files.** `kernel/src/task/scheduler.rs`, `kernel/src/syscall/signal.rs`,
 `kernel/src/task/teardown.rs`, `kernel/src/process/manager.rs`, `kernel/src/syscall/clone.rs`.
-**~220 lines, 3 commits — at the ceiling; seam is {request API + kick plan} / {group scope + seal}.**
+**~220 lines, 3 commits — at the ceiling; seam is {request API + kick plan + predicate} / {group
+scope + seal}.**
 
 **Gate extras.** Two-CPU aarch64: kill a thread running remotely at EL0 and prove **its own TID**
-executes the exit commit, with zero post-request EL0 trace for the victim. Deterministic clone-vs-seal
-barrier: the child is either in the batch or `sys_clone` returns `EAGAIN` — never a runnable
-unrequested member. No resource claim before the batch commits. Blocked and userspace victims both
-die. Soak.
+executes the exit commit, with zero post-request EL0 trace for the victim and `EXIT_VICTIM_OWNED > 0`.
+Kill a thread blocked in an (unmigrated) futex wait and prove it still dies with the correct status
+via the legacy arm, `EXIT_LEGACY_REMOTE_MARK{futex} > 0` — **the fallback is tested, not assumed**.
+Deterministic clone-vs-seal barrier: the child is either in the batch or `sys_clone` returns `EAGAIN`
+— never a runnable unrequested member. No resource claim before the batch commits. Soak.
 
-**Strictly better.** #491 reaches full strength: nothing is torn down remotely; group membership is
-atomic by construction. #471's seal ships.
+**Strictly better.** Nothing that can reach a return boundary is torn down remotely any more; group
+membership is atomic by construction; #471's seal ships. *Honest bound (R-16):* victims blocked in
+unmigrated wait families are still torn down remotely — that is P10's job, it is counted per family,
+and it is unchanged from what P2 already shipped rather than a new regression.
 
 **Revert.** Restore the remote-marking body and pid-scoped SIGKILL — i.e. fall back to Phase 2's
 already-safe behaviour, not to `main`.
+
+---
+
+## Phase 10 (a/b/c) — Killable-wait contract, one family per PR *(was Phase 9)*
+
+**Scope.** 10a futex; 10b `WaitQueueHead` + stdin/TTY readers; 10c child-wait + timer/nanosleep +
+completion/I-O. Each sub-phase: on a fatal request the victim is made **runnable with its saved
+continuation and `blocked_in_syscall` intact**; the resumed continuation gives the latched fatal
+request priority over ordinary success, unregisters itself through the existing `finish_wait`/
+unregister path, and only then branches to the trampoline. **No `ExitPending` state** — dequeuing a
+victim whose saved resume SP is still live evidence is the banked r20 finalization deadlock, and
+design C's version of it was the panel's fatal finding against C.
+
+**Each sub-phase consumes the request/wake mechanism P9 already publishes** — it moves its family from
+the `exit_request_is_boundary_reachable() == false` allowlist into the `true` set, so the concrete,
+already-live acceptance test "SIGKILL a victim blocked in *this* family" changes from *legacy remote
+mark* to *victim-owned exit* in the same PR. The live futex loop is the named hazard: today an
+unrelated wake can take the success branch before the signal check and leave the TID registered; the
+resumed loop must be reordered.
+
+**10c additionally deletes the legacy arm**: with the allowlist empty, `exit_request_is_boundary_reachable`
+becomes total, the remote-marking body of `terminate_process_threads` is deleted, and
+`EXIT_LEGACY_REMOTE_MARK` must read 0 for a full run. **This is where #491 is complete and AC-11 is
+fully discharged** — v1 claimed that at the cutover phase, which was premature.
+
+**Files (per sub-phase).** the family's own file(s) + `kernel/src/task/scheduler.rs` +
+`kernel/src/task/teardown.rs` + its test. **~150 lines each (10c ~180), 1-2 commits each.**
+
+**Gate extras.** Per family: inject an exit request and prove the family's registry/heap **no longer
+contains the TID before the exit commit runs** (deregistration-before-commit is the load-bearing
+assertion the ratification asked for); SIGKILL of a victim blocked in that family reaps the right
+status; `EXIT_VICTIM_OWNED` increments for that family and `EXIT_LEGACY_REMOTE_MARK{family}` drops to
+0 while remaining nonzero for families not yet migrated (both halves asserted). Families not yet
+migrated are **reported by counter** — never silently advertised as killable. **10c only:** allowlist
+empty asserted as an exact set, `EXIT_LEGACY_REMOTE_MARK == 0` over a full run including the group and
+CLONE_VM stress, and the ratchet asserts the remote-marking body is gone by name. Soak on 10c.
+
+**Strictly better.** Each family converts from "torn down remotely by the legacy arm" to "dies
+promptly, on its own thread, with its wait registration cleanly removed". Unmigrated families are
+unchanged and visible.
+
+**Revert.** Per family, independently: return the family to the allowlist (10a/10b), or restore the
+legacy arm plus the family (10c).
 
 ---
 
@@ -385,16 +702,30 @@ already-safe behaviour, not to `main`.
 
 **Scope.** `deliver_default_action` **returns a fatal intent** instead of mutating anything under the
 PM borrow — delete both `process.terminate(...)` + `with_thread_mut(...)` blocks at
-`signal/delivery.rs:224-239` and `:258-269` and carry `(pid, code, sig)` out through the existing
-`DeliverResult::Terminated` channel, whose documented contract is already "caller MUST call notify
-after releasing the PM lock". This single change kills three problems at once: the FD-closure loss
-that design A's `terminate_minimal` hand-off would have caused, the retained
+`signal/delivery.rs:224-239` and `:258-269`.
+
+> **v2 (condition 5) — the result is INTENT-ONLY and the legacy notifier dies in this same PR.**
+> v1 carried `(pid, code, sig)` out through the **existing** `DeliverResult::Terminated` channel,
+> whose documented contract is "caller MUST call notify after releasing the PM lock" — while P6b
+> assigns notification to the ledger. That is a duplicate-notify window, so:
+> - **Delete `DeliverResult::Terminated` and its caller-side parent-notification action** in this PR.
+> - Introduce `DeliverResult::FatalIntent { pid, tid, sig, code }`, documented as performing **no
+>   notification, no parent wake, no status write, no scheduler mutation and no resource work**; its
+>   only legal use is to be handed to the S1 request transaction after the PM borrow ends.
+> - Notification is discharged solely by the ledger obligations created in S1 and redeemed by the
+>   victim's own commit.
+> - The P0 ratchet gains: no notify/wake call in any `deliver_*`/`DeliverResult` consumer, and the
+>   `Terminated` variant is asserted absent **by name** so a later phase cannot reintroduce it.
+
+This single change also kills the three problems v1 named and the ratification did not dispute: the
+FD-closure loss that design A's `terminate_minimal` hand-off would have caused, the retained
 SCHEDULER-under-DAIF-masked-PM inversion (`with_thread_mut` takes SCHEDULER at `scheduler.rs:3101-3109`
-while the PM guard is live), and a `log::info!` under mask. The four EL0 fault sites collapse to one
-TID-attributed adapter (§2.4 of the design): TID first, stack-slot cross-check, CR3 as
-root-consistency only, divergence counted and never fatal, `AttributionUncertain` → safe redirect,
-mandatory tails always unconditional. `interrupts/context_switch.rs:1021` (x86_64) converges.
-**`Process::terminate` is deleted** with its last caller.
+while the PM guard is live), and a `log::info!` under mask. The four EL0 fault sites
+(`exception.rs:768,1135,1230,1333`) collapse to one TID-attributed adapter (DESIGN §2.4): TID first,
+stack-slot cross-check, CR3 as root-consistency only, divergence counted and never fatal,
+`AttributionUncertain` → safe redirect, mandatory tails always unconditional.
+`interrupts/context_switch.rs:1021` (x86_64) converges. **`Process::terminate` is deleted** with its
+last caller.
 
 **Files.** `kernel/src/signal/delivery.rs`, `kernel/src/arch_impl/aarch64/exception.rs`,
 `kernel/src/arch_impl/aarch64/context_switch.rs`, `kernel/src/interrupts/context_switch.rs` (Tier-2),
@@ -404,42 +735,62 @@ mandatory tails always unconditional. `interrupts/context_switch.rs:1021` (x86_6
 parent survives, `TEARDOWN_VICTIM_DIVERGENCE == 1`, no refault loop. **This test fails on `main`
 today** — it is a live wrong-victim livelock, so the test is meaningful rather than tautological.
 `sigsegv_default_action_test`: status `-11` reaped exactly once, CoW accounting balanced,
-`TEARDOWN_MASKED_FRAMES_WALKED == 0`. Explicit x86 regression run (two prior rounds shipped accidental
-x86 divergences). P0 ratchet's `\.terminate\(` allowlist must now be **empty**, asserted as an exact
-set. Soak.
+`TEARDOWN_MASKED_FRAMES_WALKED == 0`. **Duplicate-notify negative test: a fatal signal delivered to a
+process that is concurrently faulting produces exactly one SIGCHLD and one `btrt` report** (the
+window the deleted `Terminated` action would have opened). Explicit x86 regression run (two prior
+rounds shipped accidental x86 divergences). P0 ratchet's `\.terminate\(` allowlist must now be
+**empty**, asserted as an exact set, and `DeliverResult::Terminated` asserted absent by name. Soak.
 
 **Strictly better.** Every death path in the kernel now runs the same state machine; the last eager
-teardown-under-PM-borrow is gone; a live wrong-victim livelock is fixed.
+teardown-under-PM-borrow is gone; a live wrong-victim livelock is fixed; and there is exactly one
+notifier in the kernel.
 
-**Revert.** Restore the two delivery blocks and the four inlined fault bodies (preserved in the commit
-bodies); `Process::terminate` returns.
+**Revert.** Restore the two delivery blocks, the `Terminated` variant with its notify action, and the
+four inlined fault bodies (preserved in the commit bodies); `Process::terminate` returns.
 
 ---
 
 ## Phase 12 — Init death policy *(#464 part 2 — separate PR by construction)*
 
-**Scope.** Policy per OQ-1 (recommended: user-originated default-fatal signals to designated init →
-`EPERM`, no group exit; init's own `exit`/`exit_group` or an unhandleable fatal fault → kernel-fatal).
-S1 sets `INIT_DEATH_LATCH` with one relaxed store, **only** for a committed, certainly-attributed
-victim. S5 reads it in ordinary kernel context with all guards out of scope and DAIF restored, records
-a pre-panic lock/IRQ snapshot, then panics. **No `#[cfg]` gate** — designation is runtime data, so a
-build that never designates an init can never trip the policy, and `interactive = ["testing"]` cannot
-invert anything.
+**Scope — v2 (condition 7): Linux-faithful protected init. No `EPERM`.**
 
-**Files.** `kernel/src/task/teardown.rs`, `kernel/src/process/manager.rs`,
-`kernel/src/syscall/signal.rs`, tracing reader, tests. **~120 lines, 2 commits.**
+- A **user-originated** signal to the designated init whose effective disposition is the default fatal
+  action, and for which init has installed **no handler**, is **silently dropped**: never queued,
+  never made pending, never delivered, and the sending syscall **returns success (0)**. This is what
+  Linux does for a protected init (`kernel/signal.c`, `prepare_signal`/`sig_task_ignore` region
+  ~L79-117 and `__send_signal`/`complete_signal` ~L977-1083). Counted `INIT_FATAL_SIGNAL_DROPPED`.
+- A signal init **has a handler for** is delivered and handled normally — protection is
+  disposition-scoped, not signal-scoped.
+- Kernel-fatal, and only these: init's **own** `exit`/`exit_group`, an **unhandleable** synchronous
+  fatal fault taken by init, or a nonviability invariant.
+- S1 sets `INIT_DEATH_LATCH` with one relaxed store, **only** for a committed, certainly-attributed
+  victim. Because external kills are dropped at send, the latch's only producers are init's own exit
+  commit (P8) and the unhandleable-fault path (P11) — a strictly smaller producer set than v1's.
+- S5 reads the latch in ordinary kernel context with all guards out of scope and DAIF restored,
+  records a pre-panic lock/IRQ snapshot, then panics. **No `#[cfg]` gate** — designation is runtime
+  data, so a build that never designates an init can never trip the policy, and
+  `interactive = ["testing"]` cannot invert anything.
 
-**Gate extras.** Deliberate init-kill test asserts the panic message **and that the panic reports
-completely** on serial (proving no lock was held), with the snapshot showing PM owner `None`,
-scheduler owner `None`, normal IRQ state. `INIT_PANIC_WITH_LOCK == 0`. A normal boot asserts the latch
-stays 0 for the whole run **including the `smoke_hello_time` harness** — the exact build all four
-prior attempts broke. A test-build PID-1 process that is *not* designated exits normally.
-`kill(1, SIGKILL)` from userspace returns `EPERM` and init survives.
+**Files.** `kernel/src/syscall/signal.rs`, `kernel/src/signal/delivery.rs`,
+`kernel/src/task/teardown.rs`, `kernel/src/process/manager.rs`, tracing reader, tests.
+**~120 lines, 2 commits.**
+
+**Gate extras.** `kill(1, SIGKILL)` from userspace **returns 0**, init survives, its pending signal
+set is unchanged, `INIT_FATAL_SIGNAL_DROPPED == 1`, and `INIT_DEATH_LATCH == 0`. **No test asserts
+`EPERM`** — the v1 assertion is deleted, not inverted. A signal init *does* handle is delivered
+normally (handler runs, counter does not increment). Deliberate init-death test (init calls
+`exit_group`) asserts the panic message **and that the panic reports completely** on serial (proving
+no lock was held), with the snapshot showing PM owner `None`, scheduler owner `None`, normal IRQ
+state. `INIT_PANIC_WITH_LOCK == 0`. A normal boot asserts the latch stays 0 for the whole run
+**including the `smoke_hello_time` harness** — the exact build all four prior attempts broke. A
+test-build PID-1 process that is *not* designated exits normally.
 
 **Strictly better.** Closes #464 with the runtime flag the issue asked for, on the fifth attempt,
-without the cfg landmine that killed the first four.
+without the cfg landmine that killed the first four — and with Linux's actual semantics rather than an
+undocumented ABI divergence.
 
-**Revert.** Delete the latch + the escalation call; identity (P5) survives independently.
+**Revert.** Delete the latch, the drop rule and the escalation call; identity (P5) survives
+independently.
 
 ---
 
@@ -447,23 +798,27 @@ without the cfg landmine that killed the first four.
 
 | Stop after | #491 | #464 | #471 | Net vs `main` |
 |---|---|---|---|---|
-| P0 | — | — | — | Bypass surface pinned; #492 overflow visible |
-| P1 | — | — | — | + grace cannot elapse unordered/empty; refusals attributable |
-| **P2** | **live UAF closed** (remote-mark strength) | — | — | + quarantine, expedite, SIGCHLD on kill |
+| P0 | — | — | — | Bypass surface pinned; #492 overflow visible; two pre-existing lock violations measured |
+| P1 | — | — | — | + grace cannot elapse unordered/empty; refusals attributable; no proof under the queue lock |
+| **P2** | **live UAF closed** (remote-mark strength) | — | — | + quarantine, expedite, SIGCHLD on kill; + no reclaim enqueue under PM |
 | P3 | ↑ | — | **detach done** | + wrong-victim-after-exec impossible |
 | P4 | ↑ | — | ↑ | + all three creation paths grace-protected |
 | P5 | ↑ | **identity done** | ↑ | + AC-1/4/5 structural |
-| P6 | ↑ | ↑ | ↑ | + exactly-once notification (#418's own follow-up) |
+| **P6a** | ↑ | ↑ | ↑ | + a row outlives its reap; removal is proof-gated |
+| P6b | ↑ | ↑ | ↑ | + exactly-once notification with a claim protocol (#418's own follow-up) |
 | P7 | ↑ | ↑ | ↑ | + no FD/endpoint lock or alloc under PM on any exit |
-| P8 (needs OQ-5) | ↑ | ↑ | ↑ | + normal exit is victim-owned |
-| P9a/b/c | ↑ | ↑ | ↑ | + each wait family becomes promptly killable |
-| **P10** | **complete** | ↑ | **seal done** | + nothing torn down remotely; atomic membership |
-| P11 | ↑ | ↑ | ↑ | + one machine for all five paths; live livelock fixed |
-| P12 | ↑ | **complete** | ↑ | + init death policy without the cfg landmine |
+| P8 (needs OQ-5) | ↑ | ↑ | ↑ | + normal exit is victim-owned, through the boundary hook |
+| **P9** | **nothing boundary-reachable dies remotely** | ↑ | **seal done** | + atomic group membership; legacy arm counted per family |
+| P10a/b/c | **complete at 10c** | ↑ | ↑ | + each wait family becomes promptly killable; legacy arm deleted at 10c |
+| P11 | ↑ | ↑ | ↑ | + one machine for all five paths; one notifier; live livelock fixed |
+| P12 | ↑ | **complete** | ↑ | + Linux-faithful init protection without the cfg landmine |
 
-Stopping anywhere is a shippable, defensible state. **P2, P3, P5, P10, P12 are the five points where
-an issue's headline claim actually changes** — those are the PR bodies that must be written most
-carefully, and the ones where an overstated commit message would be a blocking finding.
+Stopping anywhere is a shippable, defensible state. **P2, P3, P5, P9, P10c, P12 are the six points
+where an issue's headline claim actually changes** — those are the PR bodies that must be written most
+carefully, and the ones where an overstated commit message would be a blocking finding. *(v2: #491's
+"complete" milestone moved from the cutover phase to P10c, because the legacy remote-mark arm is still
+live until then. Claiming completion at P9 would be exactly the kind of overstatement the round-level
+stop rule exists to catch.)*
 
 ## 2. Merge discipline
 
@@ -478,3 +833,8 @@ held.
 consecutive** fix rounds, or a fix round is net-negative (closes N, introduces ≥N), that is a
 divergence signal — **hard stop and escalate to the operator** rather than a third round. The r23
 round proved a third round on a diverging phase costs more than it closes.
+
+**Ratification gate (condition 7 of the refusal).** These revised documents must obtain a **new
+ratification pass** before implementation begins. No phase — including P0 and P1, which the reviewer
+called "the correct first two behaviour-preserving PRs" once the conditions are incorporated — is
+cleared for build until that pass returns.


### PR DESCRIPTION
## Summary

Revision v2 of the teardown-unification design, addressing the Codex Sol
**ratification refusal** on v1 (`ENDORSE: NO` — 2 fatal seams, 7 majors, 1
minor, **7 explicit conditions**). This is a targeted revision: everything
the ratification did not criticise is preserved verbatim; every change
below is traceable to a numbered condition.

## The 7 conditions closed

1. **Phase reorder / real producer for wait-family PRs** — request-only
   scheduler publication + victim-owned SIGKILL commit suppression move
   *before* the killable-wait subphases; old P10 → **P9**, old P9a/b/c →
   **P10a/b/c**, with a live counted legacy remote-mark arm until P10c
   deletes it. `#491 complete` moves from P9 to P10c.
2. **Explicit per-obligation state machine** — new §1.6 defines the
   four-state `Absent/Pending/Claimed{claimer}/Completed` machine, PM as
   sole serializer, sole-redeemer invariant, orphaned-claim recovery, plus
   a retention gate (tombstone, not remove) shipped as **P6a before P6b**.
3. **No interim lock-ordering violations** — P1's drain becomes
   detach → drop queue lock → prove → free-or-reinsert; P2's
   `exit_process` returns a `#[must_use] RetirementReceipt` enqueued only
   after the PM guard drops.
4. **P8 states explicitly how normal exit exercises the return-boundary
   hook** in its own PR (no dormant hook) — new §2.5 with control flow,
   tombstone handling, and one-at-a-time FD acquisition.
5. **Fatal-signal delivery made intent-only** — `DeliverResult::Terminated`
   deleted, replaced by `DeliverResult::FatalIntent{...}` (no notify/status
   write/wake); notification discharged solely by the P6b ledger, in the
   same PR (P11).
6. **P0 counters wired to named write-sites** with a causally-paired
   nonzero defer/reclaim test; honest count corrected to **13 numbered
   phases / 16 PRs**; the false parallel-merge/file-disjointness claim
   deleted (all phases merge sequentially).
7. **OQ-1 decided** — protected-init goes Linux-faithful: user-originated
   signals to designated init with no handler are silently dropped (send
   returns success, not `EPERM`); only init's own exit or an unhandleable
   fatal fault is kernel-fatal.

## Scope

Design-only; no implementation performed, no runtime evidence claimed.
Base: `main` @ `eebc8868`, anchors re-verified against the live tree at
`main` @ `c9efdcc7` (v1 merged, no kernel change). Covers #491 (spine),
#464, #471; acknowledges and does not foreclose #448, #492, #493.

## Files changed

- `docs/planning/teardown-unification/DESIGN.md`
- `docs/planning/teardown-unification/PLAN.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
