### PR TITLE
docs: teardown-unification v3 — tranche-ratification model + design-debt register

### DIFF
--- a/docs/planning/teardown-unification/DESIGN.md
+++ b/docs/planning/teardown-unification/DESIGN.md
@@ -1,24 +1,137 @@
-# Teardown Unification — FINAL DESIGN v2 (panel synthesis, revised against ratification)
+# Teardown Unification — FINAL DESIGN v3 (panel synthesis, revised against two ratification passes)
 
-**Status:** design-only proposal for operator ratification. No implementation performed, no runtime
+**Status:** **Tranche-ratified document. Tranche 1 (P0+P1+P2): submitted for ratification. Later phases: design-debt register applies; sections may change before their tranche ratifies.**
+Design-only proposal for operator ratification. No implementation performed, no runtime
 evidence claimed. Every build/QEMU/Parallels statement in this document is a *gate to be run*, never
 a result already obtained.
 
 **Base:** `main` @ `eebc8868` (anchors re-verified against the live tree during synthesis — see §0.3;
-re-verified again during the v2 revision at `main` @ `c9efdcc7`, which is v1 of these documents merged
-and no kernel change).
+re-verified during the v2 revision at `main` @ `c9efdcc7`; re-verified again for **v3** at
+`main` @ `985881a6` — v2 of these documents merged, no kernel change. Every file:line in this
+document was read out of the tree at `985881a6`, and five v2 anchors that had drifted
+are corrected in §0.3).
 **Scope:** #491 (spine), #464, #471. Acknowledges and does not foreclose #448, #492, #493.
 **Inputs:** design A (minimal-incremental, Opus), design B (Linux-fidelity, Codex Sol), design C
-(invariant-first, Codex Sol), two adversarial judge verdicts (Opus; Codex Sol), and the **Codex Sol
-ratification refusal** (ENDORSE: NO — 2 fatal seams, 7 majors, 1 minor, 7 conditions).
+(invariant-first, Codex Sol), two adversarial judge verdicts (Opus; Codex Sol), the **first Codex Sol
+ratification refusal** (ENDORSE: NO — 2 fatal seams, 7 majors, 1 minor, 7 conditions), and the
+**second (re-)ratification refusal against v2** (ENDORSE: NO — conditions 1, 2, 3, 7 NOT-CLOSED;
+5 new FATAL, 3 MAJOR, 1 MINOR).
 
 ---
 
-## CHANGELOG — v2 deltas against the ratification conditions
+## DESIGN-DEBT REGISTER
+
+*(New in the v3 tranche pass. This section is normative: it is the complete list of open items that
+these documents do **not** close, each bound to the phase that owns its closure.)*
+
+**Why this exists.** Two full ratification passes and two pre-checks refused this design as a whole
+document. The whole-document bar is replaced by **tranche ratification**: a tranche of phases is
+submitted, pre-checked and ratified on its own, and the items a later phase owns are recorded here as
+numbered debts instead of blocking the tranche in front of them. Nothing is being waved through — a
+debt is an obligation with a named owner and a written acceptance condition, and the rule below makes
+it un-skippable.
+
+> **RULE (binding).** **A tranche containing a debt's owner phase CANNOT be ratified until that
+> debt's closure is written into these documents and has passed a pre-check.** Writing the closure is
+> not enough; it must survive the same adversarial pre-check that produced the debt. A tranche may be
+> submitted while debts owned by *later* phases remain open, and only while that is true.
+>
+> **Tranche 1 = P0 + P1 + P2. It owns none of the six debts below** (their owners are P6a, P6b, P7,
+> P9, P10 and P12), which is precisely why it is submitted for ratification now.
+
+| Debt | Owner phase | What must be true before that phase's tranche can ratify | Source finding |
+|---|---|---|---|
+| **DEBT-1 — `Report` exactly-once is not achieved; it degrades to at-most-once in one window** | **P6b** | Two things, together. **(a) The R-19 window.** When an effect marker reads `started == 1 && finished == 0`, T4 cannot tell whether `record_exit` landed; the current ruling is `→ Completed` + `LEDGER_EFFECT_AMBIGUOUS{report}`, i.e. a *possibly missing* report. P6b must either close the window with a mechanism that makes the record step itself recoverable, **or** carry an explicit operator acceptance that this is the round's single at-most-once obligation, with the counter asserted `0` on every healthy boot and moved only by deliberate injection. A silent third option — restating exactly-once while shipping at-most-once — is what the pre-check rejected twice and is not available. **(b) `on_process_exit` split phasing.** The split into `claim_exit_slot` (pure atomics, PM-callable) + `record_exit` (reaches SERIAL via `finalize()` → `ktap::emit_summary`) must be shown not to reorder the registry-slot clear relative to the serial emission, and must land in the **same PR** as T4 — a recovery rule and the marker it reads must never be separated by a merge boundary | v3 pre-check and re-check, item **B NOT-CLOSED** (both passes, verbatim unchanged): *"R-19 permits missing report when `started==1 && finished==0`"*. DESIGN §1.6 (class-B `Report`), §6 R-19; PLAN P6b |
+| **DEBT-2 — `Fds` close replay safety needs a PER-DESCRIPTOR token; the endpoint-CAS `CloseTicket` design is REJECTED** | **P7** | The v3 repair made `endpoint_hangup` idempotent by a **CAS on the shared endpoint**. The re-check's new FATAL is that live close accounting in the pipe/PTY/TCP endpoints is **per-descriptor**: a `dup`'d descriptor is a second, legitimate decrement on the *same* endpoint, and an endpoint-level CAS would suppress it — trading a double-close for a leaked endpoint that never hangs up. **P7 must not implement the CAS as specified.** It must carry a replay token that is unique to the `(row, fd)` pair being closed and that survives the unlocked window, so that a *replayed exit-close of the same descriptor* is suppressed while a *legitimate close of a different descriptor on the same endpoint* still decrements. DESIGN §1.4/§1.6/§2.5 and PLAN P6b/P7 must be rewritten to that mechanism before P7's tranche is submitted, and P7's gate must include a `dup`-then-close-both workload that fails by construction under an endpoint CAS | v3 re-check, **NEW FATAL**: *"the CloseTicket repair assumes endpoint-level CAS idempotence despite current close accounting being per-descriptor; duplicated descriptors make the CAS unsafe and would suppress legitimate closes"*; re-check item **1 NOT-CLOSED**. Also flagged by the repair pass itself as unreviewed (*"nobody has checked the current endpoints can satisfy it"*) |
+| **DEBT-3 — the blocking-primitive inventory is NOT closed at nine** | **P9** | The no-new-block admission interlock is what makes the boundary-reachability classification a one-way door, and it is specified as living inside "the exact nine" primitives. Two live paths are outside that set: **`kernel/src/syscall/futex.rs:115`**, which publishes `ThreadState::Blocked` **directly**, bypassing every `Scheduler::block_current*` entry point, and **`kernel/src/task/scheduler.rs:2175-2194`**, which publishes I/O blocking through a primitive the inventory does not list. Either is enough for a victim to block *after* its exit request is published, which is exactly the hole the interlock exists to close. Before P9's tranche: each path is brought under the interlock **or** proven unreachable once a request is latched; P0's ratchet rule 2 (*"the blocking-primitive set is exactly the nine above"*) is restated to the corrected inventory; and DESIGN §1.5's one-way-door claim and §0.3's "inventory is declared CLOSED at four families" are restated to match | v3 pre-check and re-check, item **D NOT-CLOSED** (both passes, verbatim unchanged). DESIGN §0.3 (closure D), §1.5; PLAN P0 rule 2, P9 |
+| **DEBT-4 — the x86 reap path bypasses the tombstone gate** | **P6a** | P6a's whole claim is that a row is removed only by the **two-event join** (`reaped` ∧ `retired`, whichever writer sees the other flag set performs the removal). **`kernel/src/syscall/handlers.rs:3101` removes the row directly on the live x86 reap path**, so the join is not the only remover and the retention gate can pass on aarch64 while x86 still frees a row out from under an un-retired receipt. Before P6a's tranche: that site routes through the join, **or** P6a's retention gate is honestly re-scoped to aarch64 with the x86 divergence named in AC-12's evidence column, a ratchet pinning `handlers.rs:3101` by name, and a stated phase that closes it. Scoping the gate narrowly to avoid tripping on it, without naming it, is not available | v3 pre-check and re-check, item **B NOT-CLOSED** (second half, both passes): *"P6a omits the live x86 reap at `kernel/src/syscall/handlers.rs:3101`, which still removes the row directly"*. PLAN P6a |
+| **DEBT-5 — `EXIT_BLOCK_REFUSED` post-migration semantics: it is NEVER asserted to zero** | **P10** *(a/b/c/d)* | The admission interlock is **permanent**, not scaffolding. Migration changes only the fate of a victim *already* blocked; it does not change the refusal owed to an already-latched victim trying to **enter** a migrated wait — which must stay refused, or migration manufactures cancellation work and reopens a lost-wakeup window between block and cancel. Therefore: **no gate anywhere may assert `EXIT_BLOCK_REFUSED{family} == 0`**, before or after migration. `EXIT_BLOCK_REFUSED{family}` is asserted **nonzero** in P9's own admission-race test and **re-asserted nonzero** in each of P10a-d; the migration evidence is the *pair* `EXIT_LEGACY_REMOTE_MARK{family} → 0` and `EXIT_WAIT_CANCELLED{family} → nonzero`. This debt is **repaired in the v3 text**; it is registered because it is a standing guard that a later phase can silently break, and because the failure mode (a "tidy-up" that asserts the counter to zero once migration is done) reads like cleanup | v3 pre-check, MAJOR item 5: *"P10's requirement that `EXIT_BLOCK_REFUSED{family}` hits zero post-migration contradicts the permanent admission interlock"*. DESIGN §1.5, §3 AC-11; PLAN P0 counter table, P9, P10a-d |
+| **DEBT-6 — P12's group-membership drop is scoped to EXTERNALLY-ORIGINATED signals only** | **P12** | The S1 group-seal check drops a fatal request when the designated init is a member of the **target group**. That drop applies to **`ExitIntent.origin == Signal` only** — sender-agnostic (a self-directed `kill(getpid())`/`raise` is still a signal and is still dropped, matching Linux's `sig_task_ignore`, which consults `SIGNAL_UNKILLABLE` and disposition and never the sender). **`ExitSyscall`** (init's own `exit_group`, or the exit of its last member) **and `FatalFault` BYPASS the membership test entirely**, so init's own exit still seals, latches and reaches the kernel-fatal panic. An unscoped check makes that panic path unreachable and the system hangs with init alive — a silent inversion of the policy. P12's gate must include the negative (a deliberate init `exit_group` still panics; a `FatalFault` injection still panics; an ordinary group kill still works) and record the unscoped-check pre-image. This debt is **repaired in the v3 text** and is registered because the failure is silent | v3 pre-check, MAJOR item 6: *"P12's group-membership signal drop isn't scoped to externally-originated signals; as written it would also suppress init's own `exit_group`, contradicting the required panic path"*. DESIGN §2.2 (End 2); PLAN P12 |
+
+**Not in this register, and why.** Items the pre-checks raised that are *closed in the v3 text* and
+carry no further obligation are recorded in the changelogs, not here: the seven-vs-nine caller count
+(closed by the three-class taxonomy — DESIGN §1.7), the reversed P6a join gates, the Report-marker
+phasing contradiction, and `parked_at` freshness. The design's *accepted* risks live in DESIGN §6 as
+residuals R-1…R-21; a residual is a risk taken with eyes open, a **debt is an unfinished argument**,
+and the two are deliberately kept in separate lists.
+
+---
+
+## CHANGELOG
+
+Three revisions are recorded here. **The v3 tranche pass is the current one**; the v3 and v2 tables
+below it are retained so the provenance of every mechanism stays readable. Every revision is
+**targeted**: everything a ratification pass did not criticise is preserved verbatim.
+
+### v3 tranche pass — acceptance model changed, three tranche-1 items closed, six debts registered *(current revision)*
+
+**The acceptance model changed, and that is the headline.** The whole-document ratification bar is
+**replaced by TRANCHE ratification**. A tranche of phases is submitted, pre-checked and ratified on
+its own; items owned by later phases are recorded as numbered debts in the **DESIGN-DEBT REGISTER**
+above rather than blocking the tranche in front of them. **Tranche 1 = P0 + P1 + P2**, and it is
+submitted for ratification now. The register's binding rule: *a tranche containing a debt's owner
+phase cannot be ratified until that debt's closure is written and pre-checked.* Tranche 1 owns none
+of the six registered debts (owners: P6a, P6b, P7, P9, P10, P12).
+
+This pass is **surgical**. It fixes exactly the three tranche-1-relevant items the v3 pre-check and
+re-check left open, adds the register and the status header, and changes nothing else.
+
+| # | Tranche-1 item | What was wrong | What this pass wrote |
+|---|---|---|---|
+| **i** | **The seven-vs-nine caller count contradicted itself across the two documents** | The v3 repair correctly pinned P0's baseline at **seven** `exit_process` callers, but did not propagate: DESIGN §1.7 and PLAN P2's gate still demanded that "all NINE adapted sites call `exit_process_and_retire`", asserted as an exact set. `handle_thread_exit` (`task/process_task.rs:244`) routes its receipt through `phase1_result` and never calls the wrapper, so that gate was **unsatisfiable by construction** — the docs were half-updated | One live-verified taxonomy, stated once in **DESIGN §1.7** and mirrored verbatim in **PLAN P0 rule 1** and **P2's call-site table** (which gains a `Class` column). **Three disjoint classes: 7 `exit_process` callers + 1 new SIGKILL arm + 1 PM-nested enqueue = 9 ADAPTED SITES.** Callers and enqueue sites are never conflated again. The post-P2 gate becomes **three exact sets — 8 / 1 / 3** (`exit_process_and_retire` call sites / `exit_process_locked` callers / PM-free `enqueue_process_reclaim` sites), because one set cannot express three shapes. Verified by `git grep` at `main` @ `985881a6` |
+| **ii** | **P2's victim-attributed observation was a placeholder** | Closure F gated AC-11 on per-victim-PID pairing, but `EXIT_REQUEST_OBSERVED{pid}` is written by the return-boundary hook, which does not exist until **P8**, and the live SGI receiver (`arch_impl/aarch64/exception.rs:1761-1768`) carries only an interrupt id — no pid, no batch. The docs said "the P2-era proxy described in their own gates"; the gates pointed back at the counter table. Nothing specified the mechanism, so P2's pairing gate was vacuous | **The mechanism is chosen and written** (option: specify, not downgrade). **DESIGN §2.7** gains the `EXIT_KICK` bucket table: a fixed `[KickSlot; 64]` of three atomics, **published** by `send_exit_expedite_sgi(victim_pid, batch)` before the broadcast (`pid`/`at` Relaxed, `seq.fetch_add(2, Release)`), **consumed** by one `compare_exchange` at the peer scheduler pass that declines to dispatch the quarantined victim — lock-free, no allocation, no new per-thread field. Counters `EXIT_KICK_PUBLISHED{bucket}` / `EXIT_KICK_OBSERVED{pid}` / `EXIT_KICK_BUCKET_COLLISION` added to P0's table, declared zero until P2 and **deleted in P8**. The proxy's weaker claim is written into the gate rather than overclaimed, and its two limits are **residual R-21** |
+| **iii** | **Parked receipts: "fresh" was under-specified and the age backstop had no unit** | The repair said `ParkRecord` captures a "freshly captured fence", which still permits reusing the `RetirementSnapshot` the same drain cycle took at step 2 — stale by exactly the interval that caused the park. And the age arm was `now - parked_at_tick` "exceeds the park backstop", with the backstop never defined, while gate 3(c) required completion "within the stated backstop" | **`parked_at` captures a FRESH `RetirementSnapshot` taken AT PARK TIME** — never `reclaim.after_epoch`, never the cycle's earlier snapshot — with a **second negative gate** (P1 gate 5(b)) that an earlier-snapshot implementation fails while passing the first. **The age backstop gets a concrete unit: `PARK_AGE_BACKSTOP_EPOCHS = 64` SCHEDULING EPOCHS, summed over `fence_at_park.online_mask` — not wall time.** `parked_at_tick` is deleted; the key is derived from the captured fence, so `ParkRecord` carries no timestamp. P1 gate 3(c) becomes checkable (fires at a sum advance of 64, still parked at 63) |
+
+**Everything else is byte-stable.** No phase was added, split, reordered or renumbered; the ledger is
+still **13 phases / 17 PRs**; no dependency edge changed; no acceptance criterion changed except the
+evidence columns of AC-10, AC-11 and AC-13, which were made consistent with the three fixes above.
+
+### v3 deltas — the seven required closures from the re-ratification refusal
+
+v2 was re-ratified and refused again (`ENDORSE: NO`): conditions **1, 2, 3 and 7 NOT-CLOSED**
+(4, 5, 6 CLOSED and are not reopened here), plus five new FATAL findings, three MAJOR and one MINOR.
+v3 closes them as seven lettered items.
+
+| Closure | What the refusal said | v3 mechanism | Where |
+|---|---|---|---|
+| **A** | *FATAL — returned receipts can bypass retirement* (cond 3 unclosed): P2 makes every `exit_process` call a receipt producer but adapts only two callers; the other seven can discard the receipt after PM drops and destruct a root with no grace/RootProof. `#[must_use]` is advice, not a mechanism | **Receipt custody**: `RetirementReceipt` becomes crate-private with **no public constructor**; `exit_process_locked(pm, …) -> Option<RetirementReceipt>` is `pub(crate)` and callable **only** from the single public wrapper `exit_process_and_retire(pid, code)`, which takes PM, drops the guard, then enqueues. A receipt therefore never exists in any caller's hands. Its `Drop` impl **re-enqueues rather than frees** and bumps `RECEIPT_DROPPED_UNRETIRED` (CI-asserted 0), so even an unreachable drop cannot free a root. **All nine ADAPTED sites enumerated and adapted in P2**, in three classes — seven `exit_process` callers + the new SIGKILL arm (both call the wrapper) + `handle_thread_exit`'s PM-nested enqueue (routes its receipt through `phase1_result`, does **not** call the wrapper) | **§1.7** (new); PLAN P2 call-site table |
+| **B** | *FATAL — T4 orphan recovery is at-least-once* + *MAJOR — tombstone retirement has no two-event join* (cond 2 unclosed) | Obligations are split into **class A** (effect is PM-owned: `Sigchld`, `ParentWake`, `Reparent`, and the take-half of `Resources`) where the effect and `→ Completed` happen in **one PM acquisition** so `Claimed` is never observable and T4 is unreachable; and **class B** (effect must leave PM: `Fds`, `Report`) where a **per-obligation effect marker written by the effect itself** lets T4 distinguish performed-but-unrecorded from unperformed, with the winning side stated per obligation. Row removal gains an explicit **two-event join**: the row carries `reaped` and `retired`, and whichever writer observes the other flag already set performs the removal **in that same PM acquisition** — both orders specified and both gated | **§1.6** (rewritten), §1.4; PLAN P6a, P6b |
+| **C** | *FATAL — P1's refusal path can livelock the drain*: v2 re-inserts and "rotates" a refused candidate with no cursor or exclusion rule, so one receipt can be selected forever | The drain becomes a **bounded pass**: every entry carries `last_pass`, the scan skips entries already examined in the current pass (**no candidate can be selected twice in one pass**), and an entry that fails its live-row/cached-root proof `K = 3` times is **parked on a side list** with the fence it was parked at, invisible to the scan until a **scheduling-epoch advance** on every CPU in the captured online mask — the only event that can change the blocker's answer | **§1.8** (new); PLAN P1 |
+| **D** | *FATAL — P9's reachability predicate is neither exhaustive nor stable*: no admission interlock, and the wait inventory omits the live `BlockedOnSignal` family while P10c claims the allowlist empties | **No-new-block admission interlock**: every blocking primitive (the eight `Scheduler::block_current*` entries and `WaitQueueHead::prepare_to_wait`) gains a pre-block acquire-load of the caller's exit-request word and **refuses to block** (caller maps to `EINTR`/its cancel path) when it is latched — shipped **in P9**, which makes "boundary-reachable" a one-way door. **`BlockedOnSignal` (`pause`/`sigsuspend`) is added to the inventory as its own subphase P10c**, and the deleting subphase is relabelled **P10d**; the missing hard edges are added | **§1.5** (extended), §2.7; PLAN P9, P10a-d, §0 graph |
+| **E** | *FATAL — protected init can be killed through a group sibling*: P9 makes fatal signals group-scoped while P12 drops only signals aimed at the init row | Closed **structurally at both ends**: (i) **clone admission refuses** `CLONE_VM` into the designated init's thread group (`EINVAL`, deliberate and documented) so init can never acquire a sibling — ships in **P5** with the designation authority; (ii) **S1's group-seal check tests designated-init membership of the whole target group** and drops the request silently (send returns 0) if init is a member — ships in **P12** as defence in depth. A ratchet rule pins the single production `thread_group_id = Some(…)` write site | §2.2; PLAN P5, P12 |
+| **F** | *MAJOR — P0's SGI evidence is not teardown-causal*: `EXIT_SGI_SENT` wired to the generic scheduler send sites, so unrelated reschedules satisfy the gate | The counter is **re-wired to a teardown-only helper** `send_exit_expedite_sgi(victim_pid, batch)` that does not exist until P2 — so P0 **declares it zero until P2** — and it is **per-victim-PID paired** with an observation event recorded when the victim's CPU observes it can no longer dispatch the victim, mirroring the defer/reclaim pairing. *(v3 tranche pass: the observation half at P2 is now a specified mechanism — the lock-free `EXIT_KICK` bucket table of §2.7, published by the helper and CAS-consumed at the peer's next scheduler pass — because `EXIT_REQUEST_OBSERVED` does not exist until P8 and the live SGI receiver carries no pid. P8 replaces the proxy and deletes the table; residual R-21.)* Generic `send_resched_ipi`/`send_resched_ipi_to_cpu` are explicitly **not** wired | **§2.7** (new); PLAN P0, P2, P9 |
+| **G** | *MINOR — acceptance-contract drift*: both changelogs substituted the OQ-1 decision for the actual seventh condition | Condition 7 is restated correctly as **"close conditions 1-6 and obtain a NEW ratification pass before implementation begins"** and is tracked as an open gate, not a closed row. The OQ-1 adoption is recorded separately as a **coordinator decision**, not a ratification condition | this table's cond-7 row below, §7 OQ-1, PLAN §2 |
+
+**New residuals disclosed by these closures rather than hidden:** R-18 (init-sibling belt-and-braces),
+R-19 (the one irreducible `Report` ambiguity window and why the ruling is "do not re-run"), R-20
+(parked receipts are a bounded, counted, visible stall rather than a silent one).
+
+### v3 repair — seven gaps closed against the v3 pre-check *(this revision; nothing else changed)*
+
+A pre-implementation check of v3 found two FATAL and five MAJOR defects **inside the v3 closures
+themselves**. Each is repaired in place, marked "v3 repair" at the point of change, and nothing the
+check did not name has been touched.
+
+| # | Sev | Defect in v3 as written | Repair | Where |
+|---|---|---|---|---|
+| 1 | **FATAL** | **`Fds` custody is impossible as specified.** `take_next_for_exit` was required to *retain* the descriptor in `fd_in_flight` (the recovery marker) **and** return that same value for an unlocked close. A slot cannot do both, and cloning to satisfy both is exactly the second copy the "double close is unrepresentable" argument rests on not existing — reopening double-close / endpoint-refcount corruption | The operation splits in three: `begin_fd_close` **[PM]** takes into the row's slot (sole owner) and mints a **non-owning `CloseTicket`** (a clone of the *endpoint handle*, with no close operation on it); `endpoint_hangup(&ticket)` **[no lock]** does the only lock-needing step and is idempotent by CAS; `finish_fd_close` **[PM]** drops the owning descriptor and clears the slot in one acquisition. The descriptor never leaves the row | §1.4, §1.6 (class-B `Fds`), §2.5, §3 AC-9/AC-12, §4.3; PLAN P6b, P7 |
+| 2 | **FATAL** | **Report-marker phasing self-contradicts.** §1.6 said P2 ships `claim_exit_slot`/`record_exit` "from day one" while the PLAN keeps `on_process_exit` intact until P6b — so P2 would ship a class-B obligation *claiming* a recovery marker it does not have | The PLAN's sequencing holds and the reason is written down: P2 ships the seed's **shape** (T1/T2/T3, never a bool) but no marker, because **T4 does not exist until P6b** and a never-recovered obligation needs no marker. Exactly-once at P2 rests on the sole-redeemer invariant alone; the one lost-report window is identical to `main`'s behaviour today and is stated. **P6b introduces T4 and the btrt split in the same PR** | §1.6 (phase consequence); PLAN P2, P6b, P0 rule 5 |
+| 3 | MAJOR | **P0's "exact nine `exit_process` callers" ratchet is false on `985881a6`** — there are **seven**; `manager.rs:1152` and `process_task.rs:244` are `enqueue_process_reclaim` sites, so the ratchet as written could not pass | "Nine" is restated as what it always was — the count of sites **P2 adapts** (seven callers + one PM-nested enqueue + the new SIGKILL arm). The P0 rule pins **seven** `exit_process` call sites; the two enqueue sites stay on their own existing ratchet set | §1.7; PLAN P0 rule 1 + gate 6, changelog |
+| 4 | MAJOR | **P6a's two join gates are reversed.** Prompt-reap-before-grace makes *retirement* the second writer (`retire_second`); delayed-reap-after-retirement makes the *reap* second (`reap_second`). v3 asserted the opposite pairing | The two workloads are swapped onto the counters the pseudocode actually increments; both still asserted nonzero in one run | §1.6 (two-event join); PLAN P6a gates (f)/(g) |
+| 5 | MAJOR | **"`EXIT_BLOCK_REFUSED{family}` reaches zero post-migration" contradicts the permanent admission interlock** — an already-latched victim must still be refused admission to a *migrated* family | The interlock is permanent and its counter is asserted **nonzero before and after** migration. The migration evidence becomes `EXIT_LEGACY_REMOTE_MARK{family}` → 0 and the new `EXIT_WAIT_CANCELLED{family}` → nonzero | §1.5, §3 AC-11; PLAN P0 table, P9, P10a-d |
+| 6 | MAJOR | **P12's group-membership drop is unscoped** — as written it would also swallow init's own `exit_group`, making the required panic path unreachable | `ExitIntent` carries an explicit `origin`; the drop applies to **`Signal` only** (sender-agnostic, Linux-faithful). `ExitSyscall` and `FatalFault` bypass the membership test entirely, preserving the kernel-fatal path by construction | §2.2 End 2; PLAN P12 + gates |
+| 7 | MAJOR | **`parked_at` was ambiguous and the unpark trigger incomplete.** Reusing the receipt's retirement fence makes the unpark predicate true at the instant of parking (the drain only selects entries whose fence has elapsed); and a `blocked_live_row` blocker can clear under PM with no scheduling-epoch advance anywhere | `ParkRecord` captures a fence built from a **`RetirementSnapshot` taken AT PARK TIME** (`RECLAIM_PARK_IMMEDIATE_UNPARK` asserted 0), and unpark becomes a three-armed disjunction — epoch, `ROW_REMOVAL_EPOCH` bump (one relaxed increment inside the PM acquisition that already removes the row), and an age backstop. *(v3 tranche pass: "fresh" is stated as a fresh **snapshot**, ruling out reuse of the cycle's earlier snapshot as well as of `reclaim.after_epoch`; and the age backstop is given its unit — `PARK_AGE_BACKSTOP_EPOCHS = 64` **scheduling epochs** summed over the captured online mask, never wall time.)* | §1.4, §1.8, §3 AC-13, §4.3, §4.4, §6 R-20; PLAN P0 table, P1 |
+
+### v2 deltas against the first ratification's conditions *(retained)*
 
 v1 was refused ratification (`ENDORSE: NO`) with two FATAL seam findings, seven MAJOR, one MINOR, and
-seven explicit conditions. This revision is **targeted**: everything the ratification did not
-criticise is preserved verbatim. Every change below is traceable to a numbered condition.
+seven explicit conditions. Every change below is traceable to a numbered condition.
+
+> **Reading note.** This table records the v2 revision **as it was made**, and its phase labels are
+> v2 labels. Two of them are superseded by v3: the wait families are now **P10a/b/c/d** (closure D
+> inserted `BlockedOnSignal` as P10c), so "P10c deletes the arm / #491 completes at P10c" reads
+> **P10d** today; and the honest PR count is **17**, not 16 (closure D / OQ-8). The cond-7 row below
+> is the one v2 got wrong and v3 corrects (closure G).
 
 | Cond | Condition (verbatim intent) | v2 closure | Where |
 |---|---|---|---|
@@ -28,7 +141,14 @@ criticise is preserved verbatim. Every change below is traceable to a numbered c
 | **4** | P8 must state explicitly how normal exit exercises the return-boundary hook in its own PR (no dormant hook) | §2.5 (new) gives the control flow: `sys_exit` publishes a self-request and returns; the **hook is the only entry to `do_exit_current`**, so every normal exit exercises it in the introducing PR. Also fills Codex's named P8 gaps: tombstone control flow and one-at-a-time FD acquisition | **§2.5** (new); PLAN P8 |
 | **5** | The fatal-signal convergence phase makes the delivery result **intent-only** and deletes the legacy Terminated-channel parent-notification action in the **same** PR | `DeliverResult::Terminated` (and its documented "caller MUST call notify") is **deleted**, replaced by `DeliverResult::FatalIntent{pid,tid,sig,code}` which is documented as performing no notification, no status write and no wake; notification is discharged solely by the P6b ledger | §2.1, §2.6 (new), §3 AC-12; PLAN P11 |
 | **6** | P0's counters wire into **named** existing teardown write-sites with at least one causally-paired nonzero defer/reclaim test; state the honest PR count; delete the false P2/P3/P4/P5 file-disjointness claim | PLAN P0 now names every write site with file:line and marks which counters are legitimately zero until a later phase; adds `fork_exit_defer_reclaim_pairing_test` (nonzero, per-pid paired). Honest count: **13 numbered phases / 16 PRs**. The parallel-merge claim is deleted; all phases merge sequentially | §7 OQ-8; PLAN P0, §0 graph, §0 PR ledger |
-| **7** | OQ-1 decided (coordinator-adopted): protected-init goes **Linux-faithful** — user-originated signals to designated init with no handler are **silently dropped, send returns success**, NOT `EPERM`; only init's own exit/exit_group or an unhandleable fatal fault is kernel-fatal | §2.2 death policy rewritten; §1.3 init row rewritten; §7 OQ-1 marked **DECIDED**; the `EPERM` claim (and its false "Linux-fidelity" label) is removed everywhere | §1.3, §2.2, §3 AC-2, §7 OQ-1; PLAN P12 |
+| **7** | *(corrected in v3 — closure G)* **Close conditions 1-6 and obtain a NEW ratification pass before implementation begins.** v2 mislabelled this row as the OQ-1 decision | **OPEN by construction.** It cannot be closed by the document that seeks the ratification; it is closed only when a fresh pass returns `ENDORSE: YES`. PLAN §2's ratification gate is the binding statement, and no phase — P0 and P1 included — is cleared for build until then. *(v3 tranche pass: the gate is now **tranche-scoped** — condition 7 is discharged per tranche, not once for the whole document. Tranche 1 (P0+P1+P2) is submitted; P0/P1/P2 are cleared for build when **that tranche's** pass returns `ENDORSE: YES`, and every later phase stays uncleared until its own tranche ratifies, with the DESIGN-DEBT REGISTER's rule gating any tranche that contains a debt owner. The condition itself is not weakened — it is applied more times, not fewer.)* | PLAN §2 (ratification gate), **DESIGN-DEBT REGISTER** |
+
+**Coordinator decision recorded alongside the conditions (NOT a ratification condition — closure G).**
+**OQ-1 is DECIDED:** protected init goes **Linux-faithful** — user-originated signals to the
+designated init with no handler are **silently dropped and the send returns success (0)**, NOT
+`EPERM`; only init's own `exit`/`exit_group` or an unhandleable fatal fault is kernel-fatal. The
+`EPERM` claim and its false "Linux-fidelity" label are removed everywhere. *(§1.3, §2.2, §3 AC-2,
+§7 OQ-1; PLAN P12.)*
 
 **Also folded in (Codex per-phase notes that named gaps, not conditions):** P8's hook-activation /
 tombstone / FD-acquisition control flow (§2.5); P7's statement that it does not supply P6's missing
@@ -37,6 +157,10 @@ prerequisite (that is P6a's job); P2's UAF reduction restated with the receipt d
 **Explicitly unchanged from v1** (not criticised, preserved verbatim): §0 adjudication in full, §1.1,
 §1.2, §1.5's rejection of `ExitPending`, §2.3 (#471 detach + seal), §2.4 (fault-victim attribution),
 §5 (scope cuts), §8 (lessons register) except for two added rows, and every residual not listed above.
+
+**Explicitly unchanged from v2** (the re-ratification closed conditions 4, 5 and 6 and criticised
+nothing in these areas): §2.3, §2.4, §2.5's activation argument, §2.6 in full, §4.2, §5, and AC-1,
+AC-3, AC-4, AC-5, AC-6, AC-7, AC-8, AC-9 in §3.
 
 ---
 
@@ -118,10 +242,81 @@ performs the unconditional aarch64 grace-stamped defer. `Process::take_fd_entrie
 **returns an allocating `alloc::vec::Vec`** — confirming Judge 2's warning that it cannot be reused
 unchanged under PM. `init_shell.rs:1028` reads `getpid().map(|p| p.raw()).unwrap_or(0) != 1`.
 
-**v2 additions to the anchor set** (verified during the revision, needed by conditions 3 and 6):
+**v3 corrections to the v2 anchor set** (five v2 citations had drifted; each was re-read at
+`985881a6`, and every other v2 anchor was re-confirmed unchanged):
+
+| v2 said | Actually at `985881a6` |
+|---|---|
+| `waitpid`'s reap at `syscall/wait.rs:385` | **`:386`** (`manager.remove_process(child_pid)`; `complete_wait` begins at `:335`) |
+| `ProcessManager::remove_process` at `manager.rs:1101-1104` | **`:1102-1104`** |
+| the drain spans `task/process_task.rs:375-392` | **`:375-391`** |
+| the reclaim call at `task/process_task.rs:388` | **`:387`** (`Some(reclaim) => reclaim.reclaim()`; `:388` is `None => break`) |
+| `take_fd_entries` called at `task/process_task.rs:236` | **`:233`** (`:236` is a comment line) |
+
+None of these changes an argument — they are cited-line hygiene, corrected because a design document
+whose anchors do not resolve cannot be checked.
+
+**v3 additions to the anchor set** (read at `985881a6`; each is load-bearing for a lettered closure):
+
+- **Closure A — `exit_process` has SEVEN live callers today, and v2 named none of them.**
+  `ProcessManager::exit_process` is declared at `process/manager.rs:1120`. Its callers are: the four
+  aarch64 EL0 fault sites `arch_impl/aarch64/exception.rs:778`, `:1146`, `:1233`, `:1336`; the two
+  x86_64 fault sites `interrupts.rs:1429` and `:1735`; and `process::exit_current` at
+  `process/mod.rs:264` (function at `:258`, which holds `*manager()` live across the call).
+  **Every one of the seven calls `exit_process` inside a live PM guard or `with_process_manager`
+  closure**, so all seven must be restructured, not merely annotated. Two further sites must be
+  adapted in the same PR because they participate in the same receipt hand-off: `handle_thread_exit`'s
+  PM-nested enqueue at `task/process_task.rs:244` (the only one v2 named) and the SIGKILL arm P2
+  itself introduces at `syscall/signal.rs:162`. **Nine ADAPTED sites in total** — which is a different
+  count from the seven `exit_process` callers and is never used as a substitute for it — plus the
+  internal enqueue at `manager.rs:1152` which is deleted rather than adapted. *(v3 tranche pass: the
+  three classes, and the three exact sets P2 must leave behind — 8 wrapper calls, 1
+  `exit_process_locked` caller, 3 PM-free enqueues — are stated once in §1.7 and are the only
+  formulation any gate in these documents may cite. `handle_thread_exit` does **not** call the
+  wrapper: it routes its receipt out through `phase1_result`, which is why "all nine call the
+  wrapper" was never assertable.)*
+- **Closure B — `btrt::on_process_exit` cannot commit under PM, verified.** `test_framework/btrt.rs:393`
+  clears its registry slot and then calls `pass`/`fail` and, on the last completion, `finalize()`,
+  which calls `ktap::emit_summary` and `serial_println!` — **SERIAL under a DAIF-masked PM guard**.
+  That is why `Report` is a class-B obligation with an effect marker instead of a fused PM commit,
+  and why the slot-clear-then-record order inside `on_process_exit` is itself restructured in P6b.
+- **Closure C — the drain's selection rule is `position()` + `swap_remove` under the queue lock**
+  (`task/process_task.rs:379-383`), i.e. it always re-scans from index 0. A re-inserted candidate is
+  therefore *guaranteed* to be re-selected, which is exactly the livelock the re-ratification named.
+- **Closure D — the blocking-primitive inventory as v3 counted it: nine entry points, all in two
+  files.** *(⚠ **DEBT-3**: this count is **not final**. `syscall/futex.rs:115` and
+  `task/scheduler.rs:2175-2194` publish blocking outside this set; P9 owns the corrected inventory.
+  Everything below is the v3 enumeration, retained because it is what the interlock is written
+  against, not because it is complete.)* The nine, as enumerated:
+  `Scheduler::block_current` (`task/scheduler.rs:1726`), `block_current_for_signal` (`:1897`),
+  `block_current_for_signal_with_context` (`:1916`), `block_current_for_child_exit` (`:2065`),
+  `block_current_for_timer` (`:2153`), `block_current_for_io` (`:2218`),
+  `block_current_for_io_with_timeout` (`:2227`), `block_current_for_compositor` (`:2386`), and
+  `WaitQueueHead::prepare_to_wait` (`task/waitqueue.rs:52`, with `finish_wait` at `:87`).
+  The **`BlockedOnSignal` family v2 omitted** is live in four functions:
+  `syscall/signal.rs:819` (`sys_pause_with_frame`, x86), `:1314` (`sys_sigsuspend_with_frame`, x86),
+  `:1815` (`sys_pause_with_frame_aarch64`), `:2097` (`sys_sigsuspend_with_frame_aarch64`), plus the
+  legacy `sys_pause` at `:769`; the scheduler's wake side is `unblock_for_signal`
+  (`task/scheduler.rs:1970`), and `tty/driver.rs:602-603` documents that the TTY unblock path already
+  spans both `Blocked` (stdin read) and `BlockedOnSignal`.
+- **Closure E — there is exactly ONE production write of a non-`None` `thread_group_id`:**
+  `syscall/clone.rs:210` (`child_process.thread_group_id = Some(parent_tg_id)`), where
+  `parent_tg_id` is derived at `:84` (`process.thread_group_id.unwrap_or(pid.as_u64())`) **inside the
+  live PM guard taken at `:60`**. That single write site is what makes the clone-admission half of
+  closure E a two-line structural refusal rather than a policy sprinkled across the tree. The
+  designated-init accessor it consults replaces `syscall/signal.rs:26`'s `const INIT_PID: u64 = 1`
+  (read at `:124` and `:397`).
+- **Closure F — the two SGI send sites are generic by construction.** `send_resched_ipi`
+  (`task/scheduler.rs:1843`, send at `:1857`) wakes *idle* CPUs and `send_resched_ipi_to_cpu`
+  (`:1868`, send at `:1886`) targets the CPU that received a newly runnable task; neither knows a
+  victim. Wiring `EXIT_SGI_SENT` there counts every ordinary wakeup, which is why v3 introduces a
+  teardown-only send helper and declares the counter zero until P2.
+
+**v2 additions to the anchor set** (verified during the v2 revision, needed by conditions 3 and 6;
+re-verified at `985881a6` with the four corrections noted above):
 
 - `PENDING_PROCESS_RECLAIMS` is a `spin::Mutex<Vec<PendingProcessReclaim>>` at `process_task.rs:97`.
-  Its drain, `reclaim_deferred_process_resources` (`process_task.rs:375-392`), evaluates
+  Its drain, `reclaim_deferred_process_resources` (`process_task.rs:375-391`), evaluates
   `retirement_grace_elapsed(&reclaim.after_epoch) && !reclaim.root_is_live()` **while holding the
   queue lock**. Both predicates are lock-free atomic reads today; P1's richer `RootProof` would add
   scheduler-cached-root and live-row blockers, which take SCHEDULER and PM — that is the interim
@@ -136,12 +331,13 @@ unchanged under PM. `init_shell.rs:1028` reads `getpid().map(|p| p.raw()).unwrap
   (`arch_impl/aarch64/constants.rs:85`); the handler dispatches at `exception.rs:1761`.
 - The `#492` overflow is `DeferredFaultExitBuffer::push` returning `false` at `process_task.rs:43`
   (caller `defer_fault_sigsegv_exit`, `process_task.rs:352-360`) — dropped silently today.
-- `waitpid`'s reap physically removes the row: `syscall/wait.rs:385` calls
-  `manager.remove_process(child_pid)` → `manager.rs:1101-1104`. This is the row-lifetime seam
+- `waitpid`'s reap physically removes the row: `syscall/wait.rs:386` calls
+  `manager.remove_process(child_pid)` → `manager.rs:1102-1104`. This is the row-lifetime seam
   condition 2 closes with the tombstone gate.
 - `Process::terminate` (`process.rs:284`) calls `close_all_fds()` (`process.rs:294`, impl at `:347`);
   `terminate_minimal` (`process.rs:320`) early-returns on a repeat pass;
-  `take_fd_entries` (`process.rs:335`) is the allocating extractor used at `process_task.rs:236`.
+  `take_fd_entries` (`process.rs:335`) is the allocating extractor used at `process_task.rs:233`
+  *(v3: corrected from `:236`, which is a comment line; this is the fifth v2 anchor drift)*.
 - `retirement_grace_target`/`retirement_grace_elapsed` are `scheduler.rs:550`/`:563`;
   `is_kernel_stack_slot_live` is `memory/kernel_stack.rs:283`.
 
@@ -235,10 +431,27 @@ enum ObligationState {
     Completed,                                // discharged; terminal
 }
 ExitLedger { state: [ObligationState; 6],     // fixed-size array; never allocates
-             first_status: Option<i32>, batch: GroupBatchId }
+             first_status: Option<i32>, batch: GroupBatchId,
+             // v3 (closure B): class-B effect evidence, written by the effect itself.
+             report_marker: ReportEffectMarker,   // two lock-free bits, see §1.6
+             fd_in_flight: Option<InFlightFd>,             // single-slot custody, not a flag
+             reparent_cursor: Option<ProcessId> }          // resumable, idempotent batches
+
+// v3 (closure B): the effect marker for the ONE obligation whose effect cannot commit under PM.
+ReportEffectMarker { started: AtomicBool, finished: AtomicBool, token: Option<u16> /*btrt test id*/ }
+
+// v3 REPAIR (closure B): the row slot is the SOLE OWNER of a descriptor in flight. The unlocked
+// step is handed a non-owning CloseTicket, never the descriptor itself — a slot cannot both retain
+// ownership and hand the same value out, and a clone would be the second copy the no-double-close
+// argument depends on not existing. See §1.6 and §2.5.
+InFlightFd  { fd: u32, desc: FileDescriptor, hangup_done: bool /* diagnostic only */ }
+CloseTicket { fd: u32, endpoint: EndpointRef }   // endpoint-handle clone; has NO close operation
 
 // v2 (condition 2): row lifetime must outlive every obligation.
-RowState { Live, Zombie, Tombstone { reaped_by: ProcessId, status: i32 }, /* then removed */ }
+// v3 (closure B): removal is a TWO-EVENT JOIN, so the row carries both events, not one state.
+RowState { Live, Zombie, Tombstone }          // derived; see the join rule in §1.6
+reaped:  Option<(ProcessId /*reaped_by*/, i32 /*status*/)>,   // written by the parent's reap
+retired: bool,                                                // written by the retire gate
 teardown_next: Option<ProcessId>              // intrusive link; no collection grows
 
 // Scheduler/boundary mirrors. Release/acquire. Carry NO ownership, authorize NO free.
@@ -249,6 +462,24 @@ ThreadExitRequest { generation, reason, state }
 RetirementFence { epochs: [u64; MAX_CPUS], online_mask }
 RetirementSnapshot                       // proves Acquire loads + fence ran before liveness reads
 RootProof { blocked_epoch, blocked_hw, blocked_shadow, blocked_cached, blocked_live_row }
+
+// v3 (closure A): custody, not advice. No public constructor; crate-private type.
+pub(crate) struct RetirementReceipt { /* fixed size; see §1.7 for the Drop contract */ }
+
+// v3 (closure C): drain progress state. Fixed-size fields on the existing queue entry.
+PendingProcessReclaim { .., last_pass: u32, proof_failures: u8, parked: Option<ParkRecord> }
+
+// v3 REPAIR (closure C) + v3 TRANCHE PASS: a park record captures a FRESH `RetirementSnapshot`
+// TAKEN AT PARK TIME — never the receipt's own `after_epoch` retirement fence (which the drain has
+// already proven elapsed before it could select the entry at all), and never a re-use of the
+// snapshot step 2 of the same cycle already took. The age key is a SCHEDULING-EPOCH COUNT, not a
+// wall-clock or tick duration. See 1.8.
+ParkRecord { fence_at_park: RetirementFence,  // derived from a RetirementSnapshot taken AT PARK TIME;
+                                              // NOT reclaim.after_epoch, NOT step 2's snapshot
+             row_epoch_at_park: u64,          // snapshot of the global ROW_REMOVAL_EPOCH
+             age_epoch_sum_at_park: u64 }     // sum of fence_at_park.epochs over its online_mask —
+                                              // the age-backstop key, denominated in SCHEDULING
+                                              // EPOCHS (backstop: PARK_AGE_BACKSTOP_EPOCHS = 64)
 ```
 
 `ExitLedger`'s `Resources` obligation subsumes design A's proposed `ResourceState{Held,HandedOff}` —
@@ -281,7 +512,7 @@ A wait primitive whose victim-owned cancellation path has not been audited and t
 > **v2 (condition 1) — what "uninterruptible" actually does, and why the sequence works.**
 > v1 said an uninterruptible victim "stays latched and dies at its next natural safe boundary". Under
 > the corrected phase order the request/wake mechanism (P9) ships *before* any wait family is
-> migrated (P10a/b/c), so at P9 **every** family is unmigrated — and "latch and hope" would be a kill-latency
+> migrated (P10a/b/c/d), so at P9 **every** family is unmigrated — and "latch and hope" would be a kill-latency
 > regression against the P2 behaviour already merged. It is therefore replaced by an explicit,
 > named, two-armed predicate that ships with both arms live:
 >
@@ -289,7 +520,7 @@ A wait primitive whose victim-owned cancellation path has not been audited and t
 > /// True iff this victim will demonstrably reach the return-boundary hook (§2.5)
 > /// without external help: it is runnable/running (EL0 or a preemptible kernel path),
 > /// or it is blocked in a wait family whose victim-owned cancellation has been
-> /// audited and tested (P10a/b/c).
+> /// audited and tested (P10a/b/c/d).
 > fn exit_request_is_boundary_reachable(t: &SchedThread) -> bool
 > ```
 >
@@ -299,13 +530,76 @@ A wait primitive whose victim-owned cancellation path has not been audited and t
 >   which is exactly the already-merged, already-gated P2 behaviour — no new mechanism, no new
 >   hazard, no latency regression. Counted per family as `EXIT_LEGACY_REMOTE_MARK{family}`.
 >
-> Each of P10a/b/c moves one family from the false set to the true set; the false set is a ratcheted
-> allowlist that **P10c drives to empty and then deletes along with the fallback arm**. This is the
+> Each of P10a/b/c/d moves one family from the false set to the true set; the false set is a ratcheted
+> allowlist that **P10d drives to empty and then deletes along with the fallback arm**. This is the
 > same shrink-to-empty discipline the `\.terminate\(` allowlist already uses, and it is what makes
 > every wait-family PR a *consumer of a producer that already exists* rather than the reverse.
 > Residual R-2 is restated accordingly, and the new interim is disclosed as R-16.
 
-### 1.6 The exactly-once ledger — claim protocol and row retention *(v2, condition 2)*
+> **v3 (closure D) — the predicate is made STABLE by an admission interlock, and the inventory is
+> made COMPLETE.** The re-ratification's fourth FATAL was that `exit_request_is_boundary_reachable()`
+> is a *classification at an instant*: a victim classified `true` because it is running can, one
+> instruction later, enter an unmigrated wait and become unreachable — the request is published, the
+> remote mark was suppressed, and nothing ever forces the victim to a boundary. Two structural fixes,
+> both landing with the predicate itself in P9:
+>
+> 1. **No-new-block admission interlock.** Every blocking primitive gains a pre-block acquire-load of
+>    the calling thread's own exit-request word and **refuses to block when it is latched**, returning
+>    a refusal the caller maps to `EINTR` (or its family's existing cancel path). The nine entry
+>    points are named and complete at `985881a6`: `Scheduler::block_current` (`scheduler.rs:1726`),
+>    `block_current_for_signal` (`:1897`), `block_current_for_signal_with_context` (`:1916`),
+>    `block_current_for_child_exit` (`:2065`), `block_current_for_timer` (`:2153`),
+>    `block_current_for_io` (`:2218`), `block_current_for_io_with_timeout` (`:2227`),
+>    `block_current_for_compositor` (`:2386`), and `WaitQueueHead::prepare_to_wait`
+>    (`waitqueue.rs:52`). The check lives **inside the primitives**, not at their callers, so no wait
+>    site can forget it and no future wait site can be added without it (a P0 ratchet rule asserts the
+>    primitive set is exactly these nine). Counted `EXIT_BLOCK_REFUSED{family}`, which P9's own test
+>    drives nonzero — and which **no gate may ever assert at zero** (**DEBT-5**: the interlock is
+>    permanent; migration changes the fate of an already-blocked victim, not the refusal owed to an
+>    already-latched one entering a migrated family).
+>
+>    ⚠ **DEBT-3 — this inventory is NOT closed at nine, and P9 owns the closure.** The pre-check found
+>    two live paths outside the set: `syscall/futex.rs:115` publishes `ThreadState::Blocked`
+>    **directly**, bypassing every `block_current*` entry point, and `task/scheduler.rs:2175-2194`
+>    publishes I/O blocking through an unlisted primitive. Until those are brought under the interlock
+>    or proven unreachable after a latch, the one-way-door claim below is an argument P9 still owes.
+>    See the DESIGN-DEBT REGISTER.
+>
+>    *Consequence — the classification becomes a one-way door.* `true` means "running or in a migrated
+>    family"; from the moment the request is latched, entering an unmigrated family is impossible.
+>    A victim can only move from the false set to the true set (by waking), never back. This is what
+>    makes the predicate sound rather than merely plausible, and it is why the interlock ships in P9
+>    rather than being spread across P10.
+>
+>    *It is permanent, and it does NOT fall to zero after migration.* **(v3 repair.)** v3 as first
+>    written said the interlock is "subsumed by the family's own cancellation, so
+>    `EXIT_BLOCK_REFUSED{family}` falls to zero as each family lands". That sentence contradicts
+>    itself — a guard cannot be simultaneously non-redundant and never fire — and it misstates what
+>    migration changes. Migration changes the fate of a victim **already blocked** when the request
+>    lands: remote mark becomes victim-owned cancellation. It changes **nothing** about a victim whose
+>    request is already latched and which then *tries to enter* the wait; that thread must still be
+>    refused admission in a migrated family exactly as in an unmigrated one, because letting it block
+>    would manufacture the very cancellation work the interlock exists to avoid and would reopen a
+>    lost-wakeup window between the block and the cancel. The refusal is therefore permanent, and
+>    `EXIT_BLOCK_REFUSED{family}` is asserted **nonzero for every family both before and after its
+>    migration** — P9's per-family admission-race test is re-run unchanged inside each P10x PR and
+>    must still pass. What falls to zero at migration is `EXIT_LEGACY_REMOTE_MARK{family}`; what
+>    rises from zero is the new `EXIT_WAIT_CANCELLED{family}` (a victim found already blocked in this
+>    family and cancelled by its own continuation). Those two are the migration evidence;
+>    `EXIT_BLOCK_REFUSED` is the standing-guard evidence and is never asserted at zero.
+>
+> 2. **The inventory is completed with `BlockedOnSignal`.** v2's inventory listed futex,
+>    `WaitQueueHead`/stdin/TTY, child-wait, timer/nanosleep and completion/I-O, and omitted the live
+>    `pause`/`sigsuspend` family — while simultaneously claiming the allowlist reaches empty. It is
+>    live in four functions (`syscall/signal.rs:819`, `:1314`, `:1815`, `:2097`, plus the legacy
+>    `sys_pause` at `:769`) with its own scheduler wake path (`unblock_for_signal`,
+>    `scheduler.rs:1970`). It becomes **its own subphase, P10c**, and the subphase that empties the
+>    allowlist and deletes the legacy arm is relabelled **P10d**. The wait inventory is now closed and
+>    stated as such: *futex; `WaitQueueHead` + stdin/TTY readers; `BlockedOnSignal` (pause/sigsuspend);
+>    child-wait + timer/nanosleep + completion/I-O.* Any family discovered later is a new subphase
+>    before P10d, not a silent allowlist entry.
+
+### 1.6 The exactly-once ledger — claim protocol and row retention *(v2, condition 2; class split, effect markers and the two-event join added in v3, closure B)*
 
 Design C discharged exactly-once notification with a **single-worker serialization**: one kthread was
 the only redeemer, so two producers could not both redeem. The synthesis dropped the worker (OQ-6,
@@ -323,9 +617,10 @@ makes the claim atomic; no CAS is required because PM already excludes.
 | # | Transition | Who may perform it | Rule |
 |---|---|---|---|
 | T1 | `Absent → Pending` | S1's request transaction only | Only on the **first** request for that row. A repeat request observes non-`Absent`, creates nothing, writes no second status, and returns the stored batch/status |
-| T2 | `Pending → Claimed{me, fence}` | any control path that will discharge it **immediately** | Claim and the start of work are in the same control path; `fence` is the retirement fence captured at claim time (used only by T4) |
-| T3 | `Claimed{me} → Completed` | **only** the claimer | Performed under a *fresh* PM acquisition after the work completed outside PM. `claimer == current_tid` is asserted; a mismatch bumps `LEDGER_CLAIM_MISMATCH`, which CI asserts is 0 |
-| T4 | `Claimed{dead} → Pending` | **only** the S4 retire/reap gate | Permitted only when the claimer is proven not live by P1's machinery (scheduler thread absent or `Terminated`) **and** the claim-time fence has elapsed. Bumps `LEDGER_CLAIM_ORPHANED` |
+| T2 | `Pending → Claimed{me, fence}` | any control path that will discharge it **immediately** | **Class B only** (§ below). Claim and the start of work are in the same control path; `fence` is the retirement fence captured at claim time (used only by T4) |
+| T3 | `Claimed{me} → Completed` | **only** the claimer | **Class B only.** Performed under a *fresh* PM acquisition after the work completed outside PM. `claimer == current_tid` is asserted; a mismatch bumps `LEDGER_CLAIM_MISMATCH`, which CI asserts is 0 |
+| **T2·3** | `Pending → Completed` **with the effect** | **Class A only** *(v3)* | The effect and the state write happen in **one PM acquisition**, so `Claimed` is never observable and no orphan window exists |
+| T4 | `Claimed{dead} → Pending` **or** `→ Completed` | **only** the S4 retire/reap gate | **Class B only.** Permitted when the claimer is proven not live by P1's machinery (scheduler thread absent or `Terminated`) **and** the claim-time fence has elapsed. *(v3)* The destination is chosen by the obligation's **effect marker**, not by the ledger — see the ruling table. Bumps `LEDGER_CLAIM_ORPHANED` |
 
 **Sole-redeemer invariant (this is what replaces C's single worker):** *at most one control path is
 ever in `Claimed` for a given obligation, because every entry into `Claimed` reads the current state
@@ -343,9 +638,98 @@ between claim and discharge loses the notification **permanently and silently**.
 `Absent`) costs one extra bit per obligation and makes both properties checkable. T4 is the recovery
 path; without it, exactly-once would be purchased with at-most-once.
 
+#### Exactly-once, really — the class split and the effect markers *(v3, closure B)*
+
+The re-ratification's second FATAL is correct against v2 as written: T4 moved `Claimed{dead}` back to
+`Pending` **without any way to know whether the effect had already fired between T2 and T3**, so
+reopening could duplicate and not reopening could lose. A recovery rule that cannot observe the
+effect is a coin flip. v3 removes the guesswork in two steps.
+
+**Step 1 — most obligations never enter `Claimed` at all.** An obligation is **class A** when its
+effect is a write to PM-owned state; for those, the effect and `→ Completed` are performed **in the
+same PM acquisition** (transition T2·3). There is then no interval in which the effect has fired and
+the ledger does not say so, so T4 is *structurally unreachable* for them:
+
+| Obligation | Class | Effect, and where it commits |
+|---|---|---|
+| `Sigchld` | **A** | Set the parent row's pending-SIGCHLD bit — PM-owned memory. Written in the same acquisition that marks `Completed` |
+| `ParentWake` | **A** | Publish the child's status as *collectable* in the parent's wait state — PM-owned. Same acquisition. **The scheduler kick is NOT part of this obligation**: `unblock_for_child_exit` is idempotent (waking a runnable thread is a no-op), so it is declared a *repeatable* side effect, issued unconditionally after PM drops and counted separately as `PARENT_WAKE_KICKS` (which may exceed the exactly-once count, by design and by declaration). AC-12's `PARENT_WAKE_COMPLETED` counts the PM transition, which is the thing that must be exactly-once |
+| `Reparent` | **A** | Re-parent one fixed-size batch of children — PM-owned. Each batch is one acquisition, and the obligation carries a **cursor** (`reparent_cursor`) advanced in that same acquisition, so a claimer that stops mid-way leaves a resumable, idempotent position: re-running a batch skips children already re-parented. `→ Completed` is written in the acquisition that observes the cursor exhausted |
+| `Resources` (take half) | **A** | `page_table.take()` into a `RetirementReceipt` — PM-owned. The take and the state write are one acquisition. The *enqueue* half is not an obligation at all: closure A (§1.7) makes take-and-enqueue a single indivisible public operation, so a receipt is never a thing a control path can be holding when it dies |
+| `Fds` | **B** | Endpoint close — pipe/PTY/TCP locks, which must not be held under PM |
+| `Report` | **B** | `btrt::on_process_exit` — reaches `finalize()` → `ktap::emit_summary` → `serial_println!`, i.e. **SERIAL**, which is forbidden under a DAIF-masked PM guard (`test_framework/btrt.rs:393`). This is verified, not assumed, and it is the whole reason class B exists |
+
+**Step 2 — the two class-B obligations carry an effect marker written by the effect itself, and the
+marker outranks the ledger.**
+
+- **`Fds` — custody, and the descriptor never leaves the row.** **(v3 repair — the custody rule as
+  first written names a state that cannot exist.)** v3 said `take_next_for_exit` "moves one
+  `(fd, FileDescriptor)` out of the table into the row's single-slot `fd_in_flight` **under PM**; the
+  close consumes it". The slot cannot simultaneously **retain** the descriptor — which is the entire
+  content of the custody marker, and the only thing that lets a dead claimer be recovered — and
+  **hand that same value out** to an unlocked close. Cloning it to satisfy both is precisely the
+  second copy the "a double close is not representable" claim depends on not existing, and it
+  reopens double-close / endpoint-refcount corruption. The contradiction is removed by separating
+  *ownership* from *the one step that genuinely cannot run under PM*:
+
+  ```rust
+  // row-resident, PM-owned; the SOLE owner of a descriptor between take and close
+  InFlightFd  { fd: u32, desc: FileDescriptor, hangup_done: bool /* diagnostic */ }
+  // handed to the unlocked step: a cheap clone of the ENDPOINT handle, not the descriptor.
+  // There is no close-with-effect operation on this type, so it cannot close anything.
+  CloseTicket { fd: u32, endpoint: EndpointRef }
+  ```
+
+  - **`begin_fd_close(pid)` [PM]** — if the slot is empty, move one `(fd, desc)` out of the table
+    into it; then mint a `CloseTicket` *from* the slot and return it. If the slot is already
+    occupied (a claimer died mid-close), it returns a ticket for **that** descriptor and takes
+    nothing new. Returns `None` only when the table is empty **and** the slot is empty.
+  - **`endpoint_hangup(&ticket)` [no lock]** — the only step that needs the pipe/PTY/TCP lock. It is
+    defined as an idempotent state transition guarded by a CAS on the endpoint, so a replay is a
+    no-op. That idempotence is a **requirement P7 implements and gates**, not an assumption.
+  - **`finish_fd_close(pid)` [PM]** — set `hangup_done`, then drop the owning `desc` out of the slot
+    and clear it. This is the single destructive step; it happens under PM, and its refcount
+    decrement takes no endpoint lock because the hangup already ran.
+
+  **A double close is not representable** because the owning descriptor is in exactly one place at
+  every instant — table, or slot — and is destroyed exactly once, by `finish_fd_close`, in the same
+  PM acquisition that clears the slot. The only replayable step is the idempotent hangup, so there
+  is no ambiguous window to rule on: `Fds` still needs no started/finished bits and no "which side
+  wins" statement. `hangup_done` is diagnostic only (`FD_HANGUP_REPLAYED`) and is never load-bearing
+  for correctness.
+- **`Report` — two lock-free bits plus a token, and the marker wins.** `on_process_exit` is split so
+  the ledger can see inside it:
+  - `btrt::claim_exit_slot(pid) -> Option<u16>` — a `compare_exchange` on the registry slot
+    (pure atomics, no SERIAL) that yields the test id. Called **inside the T2 acquisition**, and the
+    result is stored in the row as `report_marker.token`, so the slot can never be consumed without
+    the row recording it.
+  - `btrt::record_exit(test_id, code)` — `pass`/`fail`, the completed-count increment, and the
+    possible `finalize()`. Called with **no lock held**. It sets `report_marker.started` (CAS 0→1;
+    a loser returns without recording) *before* the recording and `report_marker.finished` (release
+    store) *after* it.
+
+  **T4's ruling for `Report`, stated so it is not a judgement call at implementation time:**
+
+  | Marker observed | Meaning | T4 destination | Rationale |
+  |---|---|---|---|
+  | `finished == 1` | The effect completed; only the ledger write was lost | **`Completed`** | Re-running would double-count `tests_completed` and could double-`finalize()` |
+  | `started == 0` | The effect never began | **`Pending`**, token preserved | Safe to redo; the token means the next claimer needs no new btrt slot |
+  | `started == 1, finished == 0` | **Ambiguous** — the claimer died *inside* `record_exit` | **`Completed`**, and bump `LEDGER_EFFECT_AMBIGUOUS{report}` | **The marker wins over the ledger.** For `Report` a duplicate corrupts the test ledger and can double-finalize the boot, while a missing report is *caught* by the AC-12 equality (`BTRT_EXIT_REPORTED != parented_first_commits` fails the gate). We take the failure mode that is loud over the one that is silently wrong |
+
+  `LEDGER_EFFECT_AMBIGUOUS` is asserted **0** on every healthy boot: reaching it requires a kernel
+  control path to die inside a short, non-blocking, lock-free atomic sequence, which is itself a fault
+  that fails the run. The orphan-injection test drives it to a known value deliberately so the branch
+  is exercised rather than assumed. The residual is R-19.
+
+**The general rule this yields**, and the one a reviewer should check any future obligation against:
+*an obligation may only be class B if its effect cannot commit under PM; every class-B obligation must
+name a marker that the effect itself writes, and must state which side wins when the marker and the
+ledger disagree.* An obligation with neither a PM-committable effect nor a marker does not belong in
+the ledger.
+
 **Row retention — the reap/tombstone gate.** Obligations are row-resident, so the row must outlive
-every obligation. Today `waitpid` physically removes the row (`syscall/wait.rs:385` →
-`manager.rs:1101-1104 remove_process`), and the `Resources` obligation **by construction outlives
+every obligation. Today `waitpid` physically removes the row (`syscall/wait.rs:386` →
+`manager.rs:1102-1104 remove_process`), and the `Resources` obligation **by construction outlives
 reap** — grace and RootProof are not complete when the parent collects the status (that is R-13, and
 it is a property of the design, not an accident). Shipping row-resident resource bits before fixing
 row lifetime is the P6-before-P7 seam the ratification flagged. Therefore:
@@ -353,10 +737,50 @@ row lifetime is the P6-before-P7 seam the ratification flagged. Therefore:
 > **Retention rule.** A row is removed from the process table only when (a) every obligation in its
 > ledger is `Completed` or `Absent`, **and** (b) its retirement receipt has been retired (grace
 > elapsed + RootProof passed) or was never created. `waitpid` no longer removes the row: it records
-> the reap and transitions `Zombie → Tombstone{reaped_by, status}`. A `Tombstone` row is invisible to
+> the reap and transitions `Zombie → Tombstone`. A `Tombstone` row is invisible to
 > every lookup that means "a live process" — `find_process_by_pid/thread/cr3`, signal delivery, wait
 > scanning, procfs enumeration, and PID-reuse allocation — and visible only to the ledger and the
 > retire gate. The gate that finally removes it is the same S4 drain that retires resources.
+
+**The two-event join — who actually performs the removal** *(v3, closure B; the MAJOR the
+re-ratification raised).* v2 stated the *condition* for removal but named no *trigger*, and
+`RowState` carried only the reap. If retirement completed first, nothing revisited the row when the
+reap arrived; if the reap completed first, nothing revisited it when retirement landed. Either order
+could leave a permanent tombstone, and an implementer patching around it would reach for premature
+removal. v3 makes removal a symmetric join over two independently-written flags:
+
+```
+row.reaped : Option<(reaped_by, status)>     // written by the parent's reap  (P6a)
+row.retired: bool                            // written by the S4 retire gate (P1/P6a)
+
+reap(pid)      [PM]:  row.reaped = Some(..);  if row.retired  { remove_row(pid) }   // reap  is 2nd
+retire(pid)    [PM]:  row.retired = true;     if row.reaped.is_some() { remove_row(pid) } // retire is 2nd
+```
+
+- **Both writes happen under PM**, so the read-of-the-other-flag and the removal are in the same
+  acquisition as the write. PM serializes the two writers, so exactly one of them observes the other
+  flag already set, and **removal happens exactly once regardless of order**.
+- **Removal also requires the ledger term** (every obligation `Completed`/`Absent`); the ledger is
+  PM-owned, so it is read in that same acquisition. If the ledger is not yet satisfied, neither
+  writer removes and the row is revisited by the S4 drain — which re-evaluates the join for every
+  tombstone it passes, so the join is not a one-shot edge trigger.
+- **Rows with no receipt** (`Resources == Absent`, e.g. an x86_64 exit that released synchronously)
+  have `retired = true` written at the same moment the ledger determines `Resources` is `Absent`, so
+  the ordinary reap removes them immediately — the join degenerates correctly rather than stalling.
+- **Rows that will never be reaped** (no parent, or the parent exits first) are covered by the
+  reparent cursor handing them to the designated init before the parent's own row tombstones; a build
+  with no designated init sets `reaped` at commit via an explicit `auto_reap`, which is a named
+  branch, not an implicit fallthrough.
+- **Both orders are gated, not just described — and the two workloads map the way the pseudocode
+  says, not the way v3 first wrote them. (v3 repair.)** The counter incremented inside `reap()` is
+  `{reap_second}`: *the reap was the second event, retirement had already landed.* The one
+  incremented inside `retire()` is `{retire_second}`. v3 attached each to the opposite workload.
+  Correctly: the **prompt-reap** fork/exit/reap workload — the parent collects the status long before
+  grace elapses — makes the **retire gate** the second writer and drives `{retire_second}`; a
+  **delayed-reap** injection — the child exits, the test sleeps past two grace epochs so retirement
+  completes first, and only then does the parent `waitpid` — makes the **reap** the second writer and
+  drives `{reap_second}`. P6b's gate asserts **both are nonzero in one run**. A join arm that no test
+  can reach is dormant code wearing a different hat (phasing rule 2).
 
 Two consequences, stated so they are not discovered later: PID reuse is delayed until the tombstone
 is removed (strictly safer than today, and bounded by the same grace the resources already wait on),
@@ -369,6 +793,209 @@ seed obligations (`Report`, `Sigchld`) are exempt and may ship first, because bo
 later than the zombie transition and a parent cannot reap a process that has not reached zombie —
 so they cannot outlive the row even under today's removal semantics. `Resources` is not exempt, and
 is the reason P6a exists.
+
+> **v3 repair — what P2's `Report` seed does and does not ship.** v3 as first written said the seed
+> ships "with its effect marker and the split `claim_exit_slot`/`record_exit` API from day one",
+> while the PLAN keeps `btrt::on_process_exit` intact (and ratcheted to its single call site) until
+> P6b performs the split. Both cannot be true, and P2 would otherwise be shipping a class-B
+> obligation with no recovery marker while claiming to have one. **The PLAN's sequencing is the one
+> that holds**, and the reason is stated here rather than papered over:
+>
+> - **P2 ships the seed's *shape*, not its marker.** The obligation uses the four-state machine and
+>   transitions T1/T2/T3 from day one — it is never a bool that a later phase upgrades. It does not
+>   carry `report_marker`, and `on_process_exit` is called unchanged.
+> - **At P2 there is nothing to recover with, and nothing that recovers.** T4 is performed *only* by
+>   the S4 retire/reap gate, which does not exist until P6b (P6a's removal join runs with a
+>   vacuously-true ledger term and performs no recovery). An obligation that is never recovered needs
+>   no marker: the marker exists solely to tell T4 which destination to choose.
+> - **Exactly-once still holds at P2**, by the sole-redeemer invariant alone — the commit path and
+>   `handle_thread_exit` race under PM and exactly one of them claims.
+> - **The cost is stated, not hidden.** Between P2 and P6b, a claimer that dies between T2 and T3
+>   loses that one `btrt` report. That is **precisely what `main` does today** for a remotely-marked
+>   victim (the sole `on_process_exit` call site is inside `handle_thread_exit`, which such a victim
+>   never runs), so it is not a regression and rule 1 holds at every commit.
+> - **P6b introduces T4 and the `claim_exit_slot`/`record_exit` split in the SAME PR.** A recovery
+>   rule and the marker it reads must never be separated by a merge boundary; that pairing is what
+>   closure B is actually about. P2's gate asserts `LEDGER_CLAIM_ORPHANED == 0` for exactly this
+>   reason — no recovery path exists yet, so any nonzero value means one was added unnoticed.
+
+---
+
+### 1.7 Receipt custody — a receipt is never in a caller's hands *(v3, closure A)*
+
+v2 changed `exit_process` to return a `#[must_use] Option<RetirementReceipt>` and adapted the two
+PM-nested `enqueue_process_reclaim` sites. The re-ratification's first FATAL is that this **creates**
+a loss channel rather than closing one: `#[must_use]` is satisfied by `let _ = …`, and the **seven
+live `exit_process` callers** (enumerated in §0.3, all verified at `985881a6` — neither of the two
+sites v2 adapted is one of them) would now be handed a receipt they were never written to carry. A dropped receipt destructs a root **with no grace and no RootProof** — strictly worse than
+`main`. `#[must_use]` is a lint. This design does not accept a lint as a safety mechanism.
+
+**The API is restructured so no caller can hold a raw receipt.**
+
+```rust
+// crate-private. No public constructor anywhere; the type is not nameable outside the crate.
+pub(crate) struct RetirementReceipt { /* fixed size, preallocated fields */ }
+
+// crate-private, PM-guard-taking. Exactly ONE caller is permitted (ratcheted).
+pub(crate) fn exit_process_locked(pm: &mut ProcessManager, pid: ProcessId, code: i32)
+    -> Option<RetirementReceipt>;
+
+// The ONLY public entry point. Takes PM, drops the guard, then enqueues.
+pub fn exit_process_and_retire(pid: ProcessId, exit_code: i32) -> ExitOutcome {
+    let receipt = with_process_manager(|pm| exit_process_locked(pm, pid, exit_code));
+    // PM guard is provably dropped here: with_process_manager owns the guard's scope.
+    if let Some(r) = receipt { enqueue_process_reclaim(r); }        // leaf queue lock only
+    ...
+}
+```
+
+Four properties, each structural rather than conventional:
+
+1. **No caller ever sees a receipt.** `RetirementReceipt` is `pub(crate)` with no public constructor,
+   `exit_process_locked` is `pub(crate)`, and the P0 ratchet asserts `exit_process_locked` has
+   **exactly one** call site — the wrapper. There is no signature in the public surface that can hand
+   a receipt to code that might drop it.
+
+   > **The adapted-site set, in three disjoint classes — one live-verified statement the whole round
+   > uses** *(v3 tranche pass; this replaces every earlier "all nine call sites call the wrapper"
+   > phrasing, which could not be true of class 3 and therefore could not be gated as an exact set).*
+   > Verified by `git grep` at `main` @ `985881a6`. **"Nine" is the count of sites P2 ADAPTS. It has
+   > never been the count of `exit_process` callers, which is SEVEN.** The two counts describe
+   > different things and are never interchangeable in these documents:
+   >
+   > | Class | Count | Sites (live at `985881a6`) | What P2 does to it |
+   > |---|---|---|---|
+   > | **1 — `exit_process` callers** | **7** | `arch_impl/aarch64/exception.rs:778`, `:1146`, `:1233`, `:1336`; `interrupts.rs:1429`, `:1735`; `process/mod.rs:264` | each is restructured to call `exit_process_and_retire(pid, code)` **with no PM guard live** — the call is lifted out of the closure/binding, not renamed |
+   > | **2 — the new SIGKILL arm** | **1** | `syscall/signal.rs:162` (today `process.terminate(-9)` under PM) | becomes a call to the **same** wrapper after `drop(guard)` |
+   > | **3 — the PM-nested enqueue** | **1** | `task/process_task.rs:244` (`handle_thread_exit` phase 1) | **does NOT call the wrapper.** `handle_thread_exit` already owns its PM guard and its two-phase shape; the receipt rides out of phase 1 through the existing `phase1_result` value and is enqueued in phase 2, where PM is already dropped |
+   >
+   > **Deleted, not adapted:** `process/manager.rs:1152`, the enqueue inside `exit_process`'s own
+   > body — it moves into the receipt returned by `exit_process_locked`. It is not a tenth adapted
+   > site and is never counted as one.
+   >
+   > **The exact sets P2 must leave behind** (this is what the gate asserts, and it is stated as
+   > three separate exact sets because one set cannot express three different shapes):
+   >
+   > - `exit_process_and_retire` — **exactly 8** call sites: classes 1 and 2. Class 3 is *not* among
+   >   them, and a gate that expected nine could not pass.
+   > - `exit_process_locked` — **exactly 1** caller: the wrapper.
+   > - `enqueue_process_reclaim` — **exactly 3** call sites, all provably PM-free: the wrapper's
+   >   post-guard enqueue, `handle_thread_exit`'s phase-2 enqueue, and `RetirementReceipt::drop`'s
+   >   re-enqueue. `manager.rs:1152` is gone. *(P0's baseline pins the pre-P2 set at **2**; this is
+   >   the post-P2 set, and the transition is part of P2's diff.)*
+   > - `ProcessManager::exit_process` — **0** call sites in the public surface; the name survives only
+   >   as the crate-private `exit_process_locked`.
+
+2. **Dropping a receipt cannot free anything.** `impl Drop for RetirementReceipt` does **not** run
+   destructors: it moves its contents into the reclaim queue and bumps `RECEIPT_DROPPED_UNRETIRED`
+   (CI-asserted 0). So even an unreachable path that somehow drops one degrades to "retired late",
+   never to "freed early". This is the belt to the private-constructor braces, and it is the reason
+   the mechanism does not depend on nobody ever making a mistake.
+3. **The Drop path cannot nest the queue lock under PM.** A receipt exists in exactly two places: the
+   window inside `exit_process_and_retire` between the guard dropping and the enqueue, and P1's local
+   detach slot (§1.8). Both are provably PM-free, and `RECLAIM_ENQUEUE_UNDER_PM` catches a violation
+   at runtime if a future edit creates a third place.
+4. **The take-and-enqueue pair is indivisible from the outside.** Because there is no public API that
+   performs only the take, "the root left the row but never entered the pipeline" is not a state a
+   caller can construct. That is what lets §1.6 treat the take-half of `Resources` as class A.
+
+**All nine adapted sites move in P2**, in the PR that introduces the wrapper — they are enumerated
+per class, with their required restructuring, in PLAN P2's call-site table. The seven class-1 sites
+(the four aarch64 fault sites, the two x86_64 fault sites, and `process::exit_current`) currently call
+`exit_process` **inside a live PM guard or `with_process_manager` closure**, so each needs the call
+lifted out of the closure, not merely renamed. That is the honest size of this closure, and it is why
+P2 declares its split seam.
+
+### 1.8 Drain progress — the refusal path cannot livelock *(v3, closure C)*
+
+v2's P1 cycle detaches a candidate under the queue lock, proves it with the lock dropped, and on
+refusal "re-inserts and rotates". The re-ratification correctly observed that **there is no rotation**:
+the live drain selects with `position()` from index 0 and `swap_remove`s
+(`task/process_task.rs:379-383`), and it loops until no candidate is found. A receipt whose cheap
+(epoch + shadow) predicate passes but whose live-row or cached-root blocker persists is therefore
+re-selected immediately, forever — a single-entry livelock in the *first* behaviour-preserving phase.
+
+Two rules fix it, and neither is a cap on work.
+
+**Rule 1 — a bounded pass: no candidate may be selected twice in one pass.** The drain takes a pass
+id (a monotonic `u32` bumped once per `reclaim_deferred_process_resources` invocation). Each queue
+entry carries `last_pass`. The under-lock scan skips entries whose `last_pass == current_pass`, and
+stamps the entry it selects. A pass therefore examines each live entry at most once and terminates in
+at most *queue length* iterations, whatever the proofs say.
+
+**Rule 2 — bounded retry, then park with a FRESH fence and a three-armed unpark.** Each entry
+carries `proof_failures`. On the `K`-th consecutive refusal (`K = 3`) attributable to a **liveness**
+blocker (`blocked_cached` or `blocked_live_row` — the two whose answer can change without time
+passing), the entry is moved to a side list `PARKED_PROCESS_RECLAIMS` and is **not scanned at all**
+until unparked. Refusals attributable to grace/hardware/shadow blockers do **not** count toward `K`,
+because those clear with time alone and re-checking them is the whole point of the drain.
+
+**(v3 repair — two defects in the park rule as first written.)**
+
+1. **`parked_at` is a FRESHLY CAPTURED fence, never the receipt's retirement fence.** v3 said the
+   entry is parked "with `parked_at` = the fence captured at parking", and PLAN P1's cycle said "park
+   with `parked_at` = the captured fence" — both readable as reusing `reclaim.after_epoch`. That
+   would be inert by construction: step 1 only selects an entry **whose fence has already elapsed**,
+   so an unpark predicate keyed on it is *already true at the instant of parking*, the entry unparks
+   on the very next sweep, and the livelock returns with two extra counter bumps per cycle. The park
+   therefore takes a **FRESH `RetirementSnapshot` at the parking instant** and stores the fence
+   derived from it (`ParkRecord.fence_at_park`, §1.4) — new acquire-fenced read of every online CPU's
+   scheduling epoch, new online mask. *(v3 tranche pass — stated as a snapshot, not merely a "fresh
+   fence", because the two obvious wrong implementations are both "a fence": reusing
+   `reclaim.after_epoch`, and reusing the `RetirementSnapshot` step 2 of this same cycle already took
+   before the proof ran. Step 2's snapshot predates the three refusals that led to the park; a fence
+   built from it is stale by exactly the interval that matters. The park takes its own.)* A parked
+   entry that unparks in the same drain invocation that parked it is a bug, counted
+   `RECLAIM_PARK_IMMEDIATE_UNPARK` and asserted **0**.
+2. **The epoch is NOT "the only event that can change a liveness blocker's answer" — that claim is
+   false for `blocked_live_row`, and a park keyed on it alone can strand.** A live row is PM-owned:
+   it disappears when the reap/retire join removes it (§1.6), which can happen on another CPU with
+   **no scheduling-epoch advance anywhere** — e.g. a parent calls `waitpid` while every CPU in the
+   captured mask sits in WFI. The unpark predicate is therefore a **disjunction of three arms**, any
+   one of which returns the entry to the live queue for a full re-proof:
+
+   | Arm | Fires when | Clears which blocker |
+   |---|---|---|
+   | **epoch** | a `RetirementSnapshot` shows every CPU in `fence_at_park`'s captured online mask has advanced its scheduling epoch | `blocked_cached` (a stale cached root can only be dropped by that CPU rescheduling) |
+   | **row** | the global `ROW_REMOVAL_EPOCH` differs from `row_epoch_at_park` | `blocked_live_row` — bumped by one relaxed increment inside `remove_row(pid)` and the creating-row completion path, under the PM acquisition that already holds them. The bump takes no lock, walks no list and knows nothing about the parked list, so no ordering is inverted; the sweep reads it outside PM |
+   | **age** | the epochs of the CPUs in `fence_at_park.online_mask`, **summed**, have advanced by at least `PARK_AGE_BACKSTOP_EPOCHS = 64` since `age_epoch_sum_at_park` | *nothing specific* — a pure safety net so that even if both keyed arms are somehow missed, the entry re-enters the live queue and is re-proved |
+
+   **The age backstop is denominated in SCHEDULING EPOCHS, not wall time** *(v3 tranche pass — the
+   pre-check's residual MINOR was that the arm's own gate required completion "within the stated
+   backstop" while no unit was ever stated)*. The unit is deliberate: this design has no wall clock
+   it is willing to depend on inside the drain, the epoch words are already captured in
+   `fence_at_park`, and an epoch count is exactly the quantity the other two arms are expressed in.
+   Concretely, the sweep re-reads the same epoch words the park captured, sums them over the *same*
+   captured mask, and fires when `sum_now - age_epoch_sum_at_park >= 64`. Three properties follow and
+   each matters: **(i) it needs no extra state** — the key is derived from `fence_at_park`, so the
+   park record does not grow a timestamp; **(ii) it is strictly weaker than the `epoch` arm** — that
+   arm needs *every* captured CPU to advance, this one accepts 64 advances anywhere in the mask, so a
+   single scheduling CPU is enough and a mostly-idle machine cannot starve it; **(iii) it cannot be
+   starved at all on this kernel**, because the 1 kHz tick drives a scheduler pass on every online
+   CPU including the idle loop, so the sum is monotone and unbounded above. *(Informative only, and
+   deliberately not the definition: at 4 online CPUs that is on the order of a few tens of
+   milliseconds. No gate is written against the millisecond figure.)*
+
+   The unpark sweep runs at the **head of every drain invocation**, fork's pre-allocation drain
+   included, so a row removal is followed by a sweep at the next drain rather than needing one of its
+   own. The age arm is explicitly **not a cap**: it only ever *adds* work — it makes a parked entry
+   eligible again and never stops examining, skips or drops anything — which is what makes the stall
+   in R-20 provably bounded rather than merely visible.
+
+**Why this is not a drain cap** (the r23 round reverted three bounded drains, and phasing rule 1
+forbids reintroducing that class): a cap stops examining entries that are *ready*; this stops
+**re-examining entries already examined in this pass** and defers entries whose blocker provably
+cannot have changed. Fork's pre-allocation drain keeps its full semantics — one full pass over every
+live entry plus an unpark sweep first — and no cap parameter is introduced anywhere. The v2 statement
+"no cap is added, no drain is moved, no drain is shared" is unchanged and remains true.
+
+**Observability.** `RECLAIM_PASS_SKIPPED`, `RECLAIM_PARKED`, `RECLAIM_UNPARKED{epoch|row|age}`
+*(v3 repair: split per unpark arm, so an arm that never fires is visible rather than hidden inside a
+total)*, `RECLAIM_PARK_IMMEDIATE_UNPARK` (asserted **0** — the fresh-fence proof), and the gauge
+`RECLAIM_PARK_RESIDENT` (with a reader, asserted to return to 0 at quiesce). A parked receipt is a
+*visible, bounded, counted* stall rather than a spin that starves the drain — residual R-20. P1's
+gate drives every one of these nonzero by forcing refusals at each blocker class **and by exercising
+each unpark arm separately**, so no park/unpark arm lands dormant in the PR that introduces them.
 
 ---
 
@@ -401,18 +1028,32 @@ Plus the durable `report`/`sigchld` obligation seed (below).
 > still a violation. Phase 2 therefore changes the signature:
 >
 > ```rust
-> #[must_use]
-> pub fn exit_process(&mut self, pid: ProcessId, exit_code: i32) -> Option<RetirementReceipt>;
+> pub(crate) fn exit_process_locked(pm: &mut ProcessManager, pid: ProcessId, exit_code: i32)
+>     -> Option<RetirementReceipt>;                       // crate-private; ONE permitted caller
+> pub fn exit_process_and_retire(pid: ProcessId, exit_code: i32) -> ExitOutcome;  // the only public API
 > ```
 >
-> `exit_process` *stamps and takes* the root into the receipt under PM (as today) but **returns** it;
-> `with_process_manager(...)` yields the receipt to the caller, the PM guard drops, and only then does
-> the caller `enqueue_process_reclaim(receipt)` with no other lock live. The move is allocation-free:
+> The locked half *stamps and takes* the root into the receipt under PM (as today) but **returns** it;
+> the wrapper's `with_process_manager(...)` yields the receipt, the PM guard drops, and only then does
+> the wrapper `enqueue_process_reclaim(receipt)` with no other lock live. The move is allocation-free:
 > `PendingProcessReclaim` is a fixed-size value and `core::mem::take(&mut process.pending_old_page_tables)`
 > leaves an empty `Vec` behind without allocating. The **other** PM-nested enqueue,
 > `handle_thread_exit` phase 1 at `process_task.rs:244`, is converted in the same PR by riding the
 > receipt out through the existing `phase1_result` value and enqueuing it in phase 2, where PM is
 > already dropped. After Phase 2, `RECLAIM_ENQUEUE_UNDER_PM == 0` is assertable and ratcheted.
+>
+> **v3 (closure A) — and no caller is handed the receipt at all.** v2 stopped at "return it and trust
+> `#[must_use]`", which the re-ratification correctly called a receipt-loss channel: seven further
+> live call sites would have been handed a value they were never written to carry. The public surface
+> is therefore the wrapper alone, the receipt type is crate-private with no public constructor, its
+> `Drop` re-enqueues instead of freeing, and **all nine sites P2 must adapt are enumerated and
+> adapted in that PR** — in three classes: the **seven** live `exit_process` callers and the new
+> SIGKILL arm (**eight** wrapper calls), plus `handle_thread_exit`'s PM-nested enqueue, which keeps
+> its own two-phase shape and routes the receipt out through `phase1_result` instead of calling the
+> wrapper. *(v3 repair: nine is the adapted-site count, not the `exit_process` caller count, which is
+> seven at `985881a6`. v3 tranche pass: the three classes and the three exact post-P2 sets are stated
+> once, in §1.7; no gate in these documents asserts "all nine call the wrapper", because class 3 does
+> not and cannot.)* See §1.7 and PLAN P2's call-site table.
 
 What Increment 1 does and does not buy, stated exactly:
 - **Removes** the eager CoW walk while the victim may be remote — the confirmed UAF class. *Strict
@@ -447,9 +1088,12 @@ here is the corrected one — the request/wake producer at P9 precedes every wai
    victim** (§1.5). SIGKILL becomes a group-scoped `ExitIntent` and the group seal ships. Victims
    blocked in a not-yet-migrated wait family take the counted legacy arm — the merged P2 behaviour,
    unchanged.
-3. **P10a/b/c** migrate the wait families one per PR, each consuming the request/wake mechanism P9
-   already publishes and each proving deregistration-before-commit for its family. **P10c** empties
-   the legacy allowlist and deletes the remote-marking body; only then is #491 complete.
+3. **P10a/b/c/d** migrate the wait families one per PR, each consuming the request/wake mechanism P9
+   already publishes and each proving deregistration-before-commit for its family: 10a futex,
+   10b `WaitQueueHead` + stdin/TTY readers, **10c `BlockedOnSignal` (`pause`/`sigsuspend`) — the
+   family v2 omitted (v3, closure D)**, and 10d child-wait + timer/nanosleep + completion/I-O.
+   **P10d** empties the legacy allowlist and deletes the remote-marking body; only then is #491
+   complete.
 4. **P11** deletes the last direct `Process::terminate` callers (§2.6), at which point
    `Process::terminate` itself is deleted.
 
@@ -509,6 +1153,62 @@ so no ABI divergence has to be documented and no test may assert `EPERM`; the dr
 drop happens at send time, init's group is never sealed and `INIT_DEATH_LATCH` is never set by an
 external kill — the latch's only producers are init's own exit commit and the unhandleable-fault
 path, which is a strictly smaller and more auditable set than v1's.
+
+> **v3 (closure E) — the group-sibling bypass is closed at BOTH ends.** The re-ratification found a
+> FATAL hole in exactly the seam between P9 and P12: P9 makes fatal signals **thread-group scoped**,
+> while v2's P12 dropped only a signal aimed at the designated-init **row**. A user who obtains a
+> `CLONE_VM` sibling sharing init's effective TGID could target the sibling; S1 would seal and kill
+> the whole group — init included — without the drop check ever being consulted. The hole is a
+> composition defect, so it is closed compositionally, at both ends, and neither end is load-bearing
+> alone:
+>
+> **End 1 — admission (ships in P5, with the designation authority).** `sys_clone` **refuses to
+> publish into the designated init's thread group**: after deriving the parent's effective TGID at
+> `syscall/clone.rs:84` — already inside the live PM guard taken at `:60` — it compares that TGID
+> against the designated init's effective TGID and returns **`EINVAL`** if they match. **The
+> designated init cannot acquire `CLONE_VM` siblings, deliberately and by documented design.** This
+> is a real, stated ABI restriction, not an accident: Breenix's init is a single-threaded supervisor,
+> nothing in-tree clones from it, and a multi-threaded init would need a separate, explicit design
+> pass for group-scoped death anyway. There is exactly **one** production write of a non-`None`
+> `thread_group_id` (`syscall/clone.rs:210`), so this refusal is the complete admission surface, and
+> a P0 ratchet rule pins that write site by name so a second one cannot appear unnoticed.
+>
+> **End 2 — the seal itself (ships in P12, defence in depth).** S1's group-seal check does not test
+> "is the target row the designated init"; it tests **"is the designated init a member of the target
+> effective thread group"**. If it is, the entire request is dropped silently, nothing is sealed,
+> nothing is marked, and the send returns 0, counted `INIT_FATAL_SIGNAL_DROPPED{group}`. The check is
+> a membership test over the group the transaction is about to seal, evaluated in the **same PM
+> acquisition** as the seal, so it cannot be raced by a clone (a clone either published before the
+> transaction and is a member the check sees, or acquires PM afterwards and hits a sealed group).
+>
+> **v3 repair — the drop is scoped by REQUEST ORIGIN, or it would swallow init's own `exit_group`.**
+> As first written, end 2 dropped *any* request whose target group contains the designated init.
+> That contradicts the policy's own third rule ("kernel-fatal, and only these: init's **own**
+> `exit`/`exit_group`, or an unhandleable fatal fault"): init's `exit_group` **is** a group-scoped
+> request naming a group that contains init, so the unscoped check would silently discard it and the
+> required panic path would become unreachable. Every `ExitIntent` therefore carries an explicit
+> origin, and the drop applies to exactly one of them:
+>
+> | `ExitIntent.origin` | Produced by | Init-group drop applies? |
+> |---|---|---|
+> | `Signal` | a default-fatal signal reaching disposition with no handler installed — `sys_kill`, `sys_tgkill`, `sys_killpg`, **including a self-directed `kill(getpid(), …)`/`raise`** | **YES** — dropped, nothing sealed, send returns 0, `INIT_FATAL_SIGNAL_DROPPED{group}`++ |
+> | `ExitSyscall` | `sys_exit_group`, or `sys_exit` of the group's last member | **NO** — the seal proceeds, the request commits, `INIT_DEATH_LATCH` is set, S5 panics |
+> | `FatalFault` | an unhandleable synchronous fatal fault taken by a member (P11's converged path) | **NO** — same; this is the second kernel-fatal producer |
+>
+> The `Signal` drop is deliberately **sender-agnostic**, which is both Linux-faithful and stricter
+> than "externally-originated": Linux's `sig_task_ignore` consults `SIGNAL_UNKILLABLE` and the
+> disposition, never the sender, so `kill(1, SIGKILL)` issued *by init itself* is also dropped — only
+> `force`d kernel-only signals bypass, which is exactly the `FatalFault` row. `ExitSyscall` and
+> `FatalFault` bypass the membership test entirely, so the kernel-fatal path is preserved by
+> construction rather than by the check happening not to fire. Note also that P5's clone-admission
+> refusal makes init's group a singleton, so an `ExitSyscall`-origin request in init's group can only
+> have come from init — there is no sibling that could issue `exit_group` on init's behalf.
+>
+> Why both: end 1 makes the dangerous state unconstructible; end 2 makes the policy correct **even
+> if** the state is somehow constructed — by a future kernel-side init helper thread, a test harness,
+> or a `thread_group_id` write added later. Belt-and-braces is recorded honestly as R-18, including
+> the maintenance obligation that if init ever legitimately gains siblings, end 1 is what must be
+> revisited and end 2 is what keeps the system safe meanwhile.
 
 The fatal action never happens under a guard. S1 sets `INIT_DEATH_LATCH` (one relaxed store) **only
 for a committed, certainly-attributed victim** — an attribution miss or a TID/CR3 divergence can
@@ -638,23 +1338,54 @@ S4 retire/reap gate once the ledger is fully `Completed` and the receipt has ret
 to the designated init before the parent's own row tombstones — the victim never short-circuits the
 gate.
 
-**FD acquisition control flow (P7's API, used here).** Exactly one descriptor crosses each PM
-acquisition, and the obligation states bracket the loop:
+**FD acquisition control flow (P7's API, used here).** **(v3 repair — restated so the descriptor is
+never in two places.)** Exactly one descriptor is in flight at a time, the owning value never leaves
+the row, and the obligation states bracket the loop:
 
 ```
 T2: Fds -> Claimed{me}                            [inside PM #1]
 loop {
-    let entry = with_process_manager(|pm| pm.take_next_for_exit(pid));   // PM held: move ONE
-    match entry { None => break, Some(e) => { /* PM dropped */ close(e); } }
-}                                                  // endpoint locks only, never with PM live
-T3: Fds -> Completed                              [fresh PM acquisition; table proven empty]
+    // PM: if the slot is empty, move ONE (fd, desc) from the table into the ROW's slot;
+    //     then mint a NON-OWNING CloseTicket from the slot and return it.
+    //     If the slot is already occupied (a dead claimer), re-ticket THAT descriptor.
+    //     None <=> table empty AND slot empty.
+    let Some(ticket) = with_process_manager(|pm| pm.begin_fd_close(pid)) else { break };
+
+    endpoint_hangup(&ticket);            // NO LOCK HELD: pipe/PTY/TCP lock taken here only.
+                                         // Idempotent by CAS on the endpoint -> replay-safe.
+
+    // PM: mark hangup_done, DROP the owning desc out of the slot, clear the slot.
+    //     This is the one destructive step and it is PM-atomic with the custody release.
+    with_process_manager(|pm| pm.finish_fd_close(pid));
+}
+T3: Fds -> Completed                              [fresh PM acquisition; table AND slot proven empty]
 ```
 
-`take_next_for_exit` moves one `(fd, FileDescriptor)` out of the table into a fixed-size single-slot
-receipt; it never builds a `Vec`, which is why the allocating `Process::take_fd_entries()`
-(`process.rs:335`) is retired rather than reused. If the victim is preempted mid-loop the ledger
-still reads `Claimed{me}`, and T4 (orphan recovery) can only fire if `me` is proven dead — which
-cannot happen while `me` is the running victim.
+The owning `FileDescriptor` is moved out of the table into the row's slot and is destroyed there —
+it is **never returned to the caller**, so no `Vec` is built and the allocating
+`Process::take_fd_entries()` (`process.rs:335`) is retired rather than reused. If the victim is
+preempted mid-loop the ledger still reads `Claimed{me}`, and T4 (orphan recovery) can only fire if
+`me` is proven dead — which cannot happen while `me` is the running victim.
+
+**v3 repair (closure B) — the slot is the SOLE OWNER, and the unlocked step gets a ticket, not the
+descriptor.** v3 as first written had `take_next_for_exit` return the `(fd, FileDescriptor)` to the
+caller for an unlocked `close(e)` *and* leave it visible in `fd_in_flight` for recovery. Those are
+mutually exclusive: retaining the value and returning the same value cannot both happen, and cloning
+it to make them both happen is exactly the second copy that "a double close is not representable"
+depends on not existing — reopening double-close and endpoint-refcount corruption, which is the
+failure class this whole obligation exists to prevent. The repaired shape splits the operation in
+three (§1.6): `begin_fd_close` **[PM]** takes/retains and mints a `CloseTicket` — a clone of the
+*endpoint handle* with **no close operation on it**, so it is structurally incapable of closing
+anything; `endpoint_hangup(&ticket)` **[no lock]** performs the only step that needs an endpoint
+lock and is idempotent by construction (a CAS-guarded state transition — a **requirement P7
+implements and gates**, not an assumption); `finish_fd_close` **[PM]** performs the single
+destructive step, dropping the owning descriptor and clearing the slot in one acquisition. A claimer
+that dies anywhere leaves the descriptor in the slot with `hangup_done == false`; the next claimer
+re-tickets it and replays only the idempotent half. **A double close is not representable**, because
+the owning descriptor exists in exactly one place at every instant — table, or slot — and is
+destroyed exactly once. This is why `Fds` needs no started/finished bits and no "which side wins"
+ruling: there is no ambiguous window to rule on. `hangup_done` is diagnostic
+(`FD_HANGUP_REPLAYED`), never load-bearing.
 
 ### 2.6 Fatal-signal delivery is intent-only *(v2, condition 5)*
 
@@ -680,28 +1411,110 @@ loss that design A's `terminate_minimal` hand-off would have caused, the SCHEDUL
 inversion at `scheduler.rs:3101-3109`, and a `log::info!` under mask all disappear with the two
 mutating blocks at `signal/delivery.rs:224-239` and `:258-269`.
 
+### 2.7 Expedite evidence is teardown-attributed *(v3, closure F)*
+
+AC-11's central claim is that a victim's time-to-death is bounded by an **SGI round trip** rather than
+by its next natural tick. v2 tried to evidence that with `EXIT_SGI_SENT` wired to the scheduler's two
+existing `SGI_RESCHEDULE` send sites. Read live at `985881a6`, those sites are
+`Scheduler::send_resched_ipi` (`scheduler.rs:1843`, send at `:1857`), which wakes **idle** CPUs, and
+`send_resched_ipi_to_cpu` (`:1868`, send at `:1886`), which targets the CPU that received a **newly
+runnable task**. Neither knows anything about a victim, so on a busy boot the counter is nonzero
+before any kill happens and a "> 0" gate is satisfied by ordinary scheduling. That is not evidence;
+it is a coincidence with a counter attached. The MAJOR is sustained and the wiring is replaced.
+
+- **A teardown-only send helper.** P2 introduces
+  `Scheduler::send_exit_expedite_sgi(victim_pid: u64, batch: GroupBatchId)`, which broadcasts
+  `SGI_RESCHEDULE` to every other online CPU and is the **only** site that records `EXIT_SGI_SENT`.
+  The two generic helpers are explicitly **not** wired, and a P0 ratchet rule asserts that
+  `EXIT_SGI_SENT` appears at exactly one source location. Because the helper does not exist before
+  P2, **P0 declares `EXIT_SGI_SENT` legitimately zero until P2** — the same honesty the v2 P0 table
+  already applies to `TEARDOWN_ENTRY{group}`.
+- **Per-PID pairing, mirroring the defer/reclaim gate.** Each send emits a `trace_event!` carrying the
+  victim pid; the victim's own CPU emits an observation event carrying the same pid the first time it
+  observes that this victim can no longer be dispatched. The gate asserts, **for the specific pid the
+  test created**, that a `SENT{pid}` event exists, that an `OBSERVED{pid}` event exists, and that the
+  observation timestamp follows the send. Two unrelated streams with equal totals cannot satisfy a
+  per-pid pairing, which is exactly the property the P0 defer/reclaim test was given.
+- **The latency claim is measured, not asserted.** The interval `SENT{pid} → OBSERVED{pid}` is
+  compared against the victim's tick period; the gate requires it to be strictly shorter. A gate that
+  merely counts SGIs would pass even if the victim died at its next tick, which is the thing AC-11
+  exists to rule out.
+
+#### The P2-era observation side is a specified mechanism, not a placeholder *(v3 tranche pass)*
+
+The pre-check sustained a further gap that v3 left as the words "the P2-era proxy": **`EXIT_REQUEST_OBSERVED{pid}`
+is written by the return-boundary hook, which does not exist until P8**, and the live SGI receiver at
+`arch_impl/aarch64/exception.rs:1761-1768` does exactly two things — record
+`SCHED_RESCHED_IPI_RECV` with the **interrupt id** as its payload, and `set_need_resched(true)`. It
+carries no pid and no batch. A P2 gate keyed on `EXIT_REQUEST_OBSERVED` would be keyed on a counter
+that structurally cannot move, which is a vacuous gate wearing a pairing's clothes. **P2 therefore
+ships its own attributed observation mechanism, and it is specified here rather than deferred.**
+
+**`EXIT_KICK` buckets — a fixed table, three atomics wide, no lock and no allocation.** A
+`[KickSlot; 64]` array lives in the P0 teardown provider alongside the counters;
+`KickSlot { pid: AtomicU64, at: AtomicU64, seq: AtomicU64 }`.
+
+- **Publish (sender side, in the teardown-only helper).** Inside
+  `send_exit_expedite_sgi(victim_pid, batch)`, **before** the broadcast and with no lock held:
+  `bucket = victim_pid % 64`; store `pid` (Relaxed) and `at` (Relaxed — the same monotonic read the
+  tracing framework already uses for event timestamps); then `seq.fetch_add(2, Release)`, which both
+  publishes the two preceding stores and leaves **bit 0 free as the observed flag**.
+  `EXIT_KICK_PUBLISHED{bucket}` increments. This is the only site that touches the table's publish
+  side, ratcheted the same way `EXIT_SGI_SENT` is.
+- **Observe (victim side, at the victim's next scheduler pass).** The event AC-11 actually needs at
+  P2 is *"the victim can no longer be dispatched to EL0"* — and that decision is already made, on the
+  peer, at the scheduler pass where `terminate_process_threads`' quarantine makes the scheduler
+  **decline to dispatch** that thread. At exactly that point, on a path that already holds the
+  scheduler's own state and takes no additional lock: acquire-load `seq` for
+  `bucket = thread_pid % 64`, check `pid` equals the thread being declined, and if bit 0 is clear
+  `compare_exchange(seq, seq | 1)`. The single winner records `EXIT_KICK_OBSERVED{pid}` with the
+  interval `now - at`. One CAS, no lock, no allocation, no serial, and **no new per-thread field** —
+  the victim's identity is the pid the scheduler already has in hand.
+- **Bucket collisions are counted, not assumed away.** Two victims congruent mod 64 in flight
+  simultaneously make the later publish overwrite the earlier, and the earlier kick then goes
+  unobserved; the publisher detects that case (an unobserved slot holding a *different* pid) and
+  bumps `EXIT_KICK_BUCKET_COLLISION`. P2's gate runs a **single named victim**, so a collision cannot
+  occur in the gated workload; the counter exists so that a collision during a soak is *visible*
+  rather than silently weakening a later run's evidence.
+- **What the proxy proves, stated exactly, and what it does not.** It proves that **this** send was
+  followed by **this** victim's quarantine being observed on a peer CPU, within a **measured**
+  interval shorter than a tick. It does **not** prove the victim observed a *latched exit request* —
+  that word does not exist until P8. P2's AC-11 claim is therefore precisely *"the expedite reached
+  the peer and the peer stopped dispatching this victim, faster than a tick"*, and it is written that
+  way in P2's gate. The stronger request-observation claim arrives with the boundary hook in **P8**,
+  where `EXIT_REQUEST_OBSERVED{pid}` replaces the proxy and **the bucket table is deleted in the same
+  PR** — the proxy is scaffolding with a demolition date, not a permanent second mechanism.
+  Residual **R-21**.
+
+The same helper and the same pairing are reused by P9's group cutover, where the payload additionally
+carries the batch id so a group kill's expedites are attributable to one batch rather than summed;
+between P2 and P8 the observation half of that pairing is the kick bucket, and from P8 it is
+`EXIT_REQUEST_OBSERVED{pid}`.
+
 ---
 
 ## 3. Numbered traceability — all 13 acceptance criteria
 
-*(Rows whose mechanism changed in v2 are marked; unmarked rows are v1 verbatim. Phase numbers reflect
-the corrected order: old P10 → **P9**, old P9a/b/c → **P10a/b/c**, old P6 → **P6a + P6b**.)*
+*(Rows whose mechanism changed in v2 or v3 are marked; unmarked rows are v1 verbatim. Phase numbers
+reflect the corrected order: old P10 → **P9**, old P9a/b/c → **P10a/b/c**, old P6 → **P6a + P6b**, and
+in v3 the wait families become **P10a/b/c/d** with `BlockedOnSignal` inserted as P10c and the
+legacy-arm deletion moving to **P10d** — closure D.)*
 
 | # | Criterion | Mechanism | Phase | Evidence that must be produced |
 |---|---|---|---|---|
 | **1** | Init designation only after creation fully succeeds; no phantom PIDs | Held-publication ticket: row inserted **and** non-runnable scheduler thread created before `designated_init` is committed under PM; PID 1 reserved off-table so a failed attempt leaves no row, no designation, and PID 1 retryable. Nothing in `create_*` touches designation. | 5 | Failure injection after PID selection at each fallible stage (page table, ELF, stack, publication): `designated_init() == None`, no row; retry succeeds as PID 1 |
-| **2** *(v2 — cond. 7)* | No panic/fatal action while PM held with DAIF masked | S1 does **one relaxed store** to `INIT_DEATH_LATCH`. All fatal escalation is a receipt redeemed at S5 with PM and scheduler guards out of scope and DAIF restored; a pre-panic lock/IRQ snapshot is recorded first. No `#[cfg]`, so no build carries a differently-scoped variant. **The latch's producer set shrinks under the adopted Linux-faithful policy: external fatal signals to init are dropped at send and can never latch, so only init's own exit commit and an unhandleable fault remain.** | 12 | `INIT_PANIC_WITH_LOCK == 0`; injected init death records PM owner `None`, scheduler owner `None`, IRQ state normal immediately before panic; the panic's serial output is **complete** (proving no lock was held). **`kill(1, SIGKILL)` from userspace returns 0, `INIT_FATAL_SIGNAL_DROPPED` increments, init survives, `INIT_DEATH_LATCH == 0`; no test asserts `EPERM`** |
+| **2** *(v2 — cond. 7; v3 — closure E)* | No panic/fatal action while PM held with DAIF masked; **and the protection cannot be bypassed through a group sibling** | S1 does **one relaxed store** to `INIT_DEATH_LATCH`. All fatal escalation is a receipt redeemed at S5 with PM and scheduler guards out of scope and DAIF restored; a pre-panic lock/IRQ snapshot is recorded first. No `#[cfg]`, so no build carries a differently-scoped variant. **The latch's producer set shrinks under the adopted Linux-faithful policy: external fatal signals to init are dropped at send and can never latch, so only init's own exit commit and an unhandleable fault remain.** **v3: the drop check is a *group-membership* test evaluated in the seal's own PM acquisition, and `sys_clone` refuses to publish into init's thread group at all (§2.2) — so a `CLONE_VM` sibling cannot be used to seal and kill init's group.** | 5 (clone admission), 12 (drop + latch) | `INIT_PANIC_WITH_LOCK == 0`; injected init death records PM owner `None`, scheduler owner `None`, IRQ state normal immediately before panic; the panic's serial output is **complete** (proving no lock was held). **`kill(1, SIGKILL)` from userspace returns 0, `INIT_FATAL_SIGNAL_DROPPED` increments, init survives, `INIT_DEATH_LATCH == 0`; no test asserts `EPERM`.** **v3: `clone()` from init returns `EINVAL` and no row with init's TGID is ever created (asserted over the whole boot); a group-scoped fatal request naming a group containing the designated init is dropped with `INIT_FATAL_SIGNAL_DROPPED{group}` incremented, nothing sealed, send returns 0; the ratchet asserts `thread_group_id = Some(…)` has exactly one production write site** |
 | **3** | Victim attribution certain before fatal escalation; a heuristic CR3 miss must not panic | §2.4: TID-first, stack-slot cross-check, CR3 as root-consistency only, divergence counted and never fatal, `AttributionUncertain` → safe redirect + deferred intent. The latch keys on a **committed** victim, never on a resolution attempt. | 11 (attribution), 12 (escalation) | `clonevm_fault_test`: a CLONE_VM child faults → the **child** row dies, the parent survives, no refault loop. *This test fails on `main` today* — it is a live bug fixed, not a tautology. TID/CR3 mismatch injection bumps `EXIT_ATTRIBUTION_UNCERTAIN`, latches nothing, kills nobody |
 | **4** | One source of truth for init identity; no hardcoded PID 1 beside runtime designation | `ProcessManager::designated_init` is the sole authority; the three production literals (`manager.rs:1178`, `process_task.rs:226`, `:285`) and `signal.rs`'s `INIT_PID` become the accessor. `ProcessId::INIT` survives only as the ABI *validation* constant, never a lookup. | 5 | P0 ratchet fails on any new `ProcessId::new(1)` in production teardown/wait/signal/reparent code; the three `test_userspace.rs` sites are allowlisted **by name** |
 | **5** | Kernel and userspace init guards must agree (`init_shell` keys on `getpid()==1`) | Structural, not conventional: PID 1 is **reserved** for the explicit init constructor and production designation is **validated == PID 1 and refuses otherwise**. `init_shell.rs:1028` is not changed, so no second contract exists to drift. A non-PID-1 init would require an explicit userspace ABI change and is not silently supported. | 5 | Cross-tree source assertion + boot test: designated pid == 1 == the pid `init_shell` observes; a build with no real init leaves designation unset and does **not** treat whichever process got the low PID as init |
 | **6** | exec detaches `thread_group_id` **and** `inherited_cr3` | Both assignments at every exec commit point, after all fallible work, before PM release; both preserved on every failure; existing live-sibling guard retained. Both arches in one commit. **(v2: also a hard prerequisite of P8's last-reference decision — §2.3.)** | 3 | `clonevm_exec_test` extended: successful exec → both `None`, fresh root, effective TGID == pid, and a kill aimed at the **old** group cannot reach it; failed exec → both preserved byte-identical |
 | **7** | Group membership examined atomically; no snapshot stale across a PM drop | **No snapshot exists.** The group-exit PM transaction *is* the seal: mark every live effective-TGID member with one batch id inside one guard; `sys_clone` publication validates group lifecycle under the same lock; scheduler threads carry group id + generation and re-check before first dispatch; threads publish non-runnable until the row is published. | 3 (admission), **9** (cutover) | Deterministic clone-vs-seal barrier test: the child is either included in the batch or `sys_clone` returns `EAGAIN` — never a runnable unrequested member. Ratchet rejects any group PID `Vec` snapshot in teardown code |
 | **8** | Sibling kernel stacks freed ONLY behind two-epoch grace via scheduler ownership | All three creation paths — fork, CLONE_VM clone, **and spawn/direct-init/test-disk** — transfer `kernel_stack_allocation` to the scheduler-owned copy before the thread can run; a `Process` row can no longer synchronously drop a published stack. **(v2: the ungated free this closes was via `remove_process` at `waitpid` reap — that call site is itself replaced by the tombstone gate in P6a, so the two fixes meet rather than overlap.)** | 4 | Ownership assertion after every creation path (exactly one owner, and it is the scheduler copy); 1000-iteration fork/clone/spawn exit stress with stack-pool accounting (allocated == freed) and an allocator assertion that never selects a live slot |
-| **9** | No N-member FD/resource teardown loop in one PM-locked, IRQ-masked section | Each victim takes and closes **only its own** descriptors, **one at a time**: `take_next_for_exit()` under PM → drop PM → close (explicit control flow: §2.5). The existing allocating `take_fd_entries() -> Vec` (`process.rs:335`) is retired, not reused. Group work under PM is bitmap/flag stores only. No sweep loops over members' FD tables. | 7 | `FD_CLOSES_UNDER_PM == 0`; 256-FD × large-group test measures bounded PM hold; ratchet forbids close/reclaim calls inside any request/commit transaction body |
-| **10** *(v2 — cond. 1, 3)* | No eager `cleanup_cow_frames` while the victim may run elsewhere; all kill paths grace-defer | Phase 2 routes SIGKILL through `exit_process`, whose aarch64 defer takes the page table into a grace-stamped **receipt returned to the caller and enqueued only after PM drops** (§2.1), so the CoW walk becomes a `None`-walk and no queue lock nests under PM. Phases 9–11 remove every direct `terminate` caller; resources stay in the row until the victim's own commit, and release requires grace + RootProof. `Process::terminate` is deleted with its last caller. | 2, 7, **9**, 11 | Ratchet allowlist of `\.terminate\(` shrinks phase-by-phase to **empty**, asserted as an exact set; **`RECLAIM_ENQUEUE_UNDER_PM == 0` from P2 onward**; peer-CPU SIGKILL stress asserts zero reclaim before the fence elapses and a complete RootProof; `TEARDOWN_MASKED_FRAMES_WALKED == 0` for kill paths |
-| **11** *(v2 — cond. 1)* | Killed threads quiesced in the scheduler AND expedited with the existing `SGI_RESCHEDULE` | Phase 2: quarantine via the proven `terminate_process_threads` + **broadcast** `SGI_RESCHEDULE` to other online CPUs (no residency predicate to go stale). **Phase 9 (was 10): the scheduler *requests* instead of remote-marking for every boundary-reachable victim, returns `ExitKickPlan`, and takes the counted legacy arm only for not-yet-migrated wait families. Phases 10a/b/c migrate the families; P10c empties the legacy allowlist and deletes the remote-marking body — that is where AC-11 is fully discharged.** The SGI handler keeps doing only `need_resched`; the victim can never be re-dispatched to EL0 once the generation is observed. **No `ExitPending`.** | 2, **9, 10a/b/c** | Victim spinning at EL0 pinned to a peer: `EXIT_SGI_SENT > 0`, target observes it, time-to-`Terminated` bounded by an SGI round trip rather than the victim's next natural tick; per-wait-family blocked-victim kill tests; **`EXIT_LEGACY_REMOTE_MARK{family}` reported per family and asserted to reach 0 with the allowlist empty at P10c**; unmigrated families explicitly reported, never silently advertised as killable |
-| **12** *(v2 — cond. 2, 5)* | Exactly-once SIGCHLD/wake/report with **first-recorded** status, idempotent under repeat passes | **Four-state obligations (`Absent/Pending/Claimed{claimer}/Completed`, §1.6), all transitions under the PM lock, which is the sole serializer — this restores what design C's single-worker serialization discharged after the worker was dropped.** Created at the **first** request; a repeat request returns the stored batch/status and creates no second obligation and no second status. At most one control path is ever `Claimed`, so the commit path and `handle_thread_exit` cannot both redeem; an abandoned claim is recoverable (T4) rather than a silent permanent loss. **Row lifetime is extended by the tombstone gate (P6a) so no obligation can outlive its row.** **The legacy `DeliverResult::Terminated` notification action is deleted in P11, so no second notifier exists.** Still not suppression: the obligation is shared, so a later pass redeems it rather than skipping it. | 2 (seed), **6a (retention), 6b (ledger)**, 11 (legacy notifier deleted) | Matrix — exit→fault, SIGKILL→fault, fault→SIGKILL, repeat request/wait: exactly one SIGCHLD, one parent wake, one `btrt` report, and `waitpid` returns the **first** status; equalities `SIGCHLD_FIRST_SET == PARENT_WAKE_COMPLETED == BTRT_EXIT_REPORTED == parented_first_commits`; **`LEDGER_CLAIM_MISMATCH == 0`, `LEDGER_CLAIM_ORPHANED == 0` on a healthy boot, `TOMBSTONE_RESIDENT == 0` at quiesce**; forced-orphan injection proves T4 recovers the notification instead of losing it |
-| **13** *(v2 — cond. 3)* | New reclaim/drain respects lock ordering and is bounded on idle paths without throttling fork's drain | **No cap is added, no drain is moved, no drain is shared.** Fork's pre-allocation drain stays full/unbounded. The only addition to a return tail is an acquire-load + branch, placed **after** the `PREEMPT_ACTIVE`/nested-return gate. Every scheduler critical section is entered with **no PM guard live**, structurally: request/commit APIs take `pid`/`tid`, never `&mut Process`. **v2 adds two absolute rules: (i) P1's proof reads never hold `PENDING_PROCESS_RECLAIMS` while acquiring SCHEDULER or PM — the drain detaches a candidate under the queue lock, drops it, proves, then frees or re-inserts (§4.3); (ii) every retirement receipt is enqueued only after the PM guard drops, including in P2's interim shape.** No `FRAME_METADATA` and no `log::*` is added under any mask. Full analysis: §4. | all | Lock-depth/owner counters (with `try_manager()` instrumented — the r20 blind spot is not repeated); `RECLAIM_CONTEXT_VIOLATIONS == 0`; **`RECLAIM_ENQUEUE_UNDER_PM == 0` and `PROOF_UNDER_QUEUE_LOCK == 0`**; ratchet rejects scheduler-under-PM, queue-lock-then-PM/SCHEDULER, and any reclaim/close/walk in idle or exception tails; fork-pressure test proves a *full* eligible drain, not a capped one. **Declared partial:** this design does not fix #448's or #492's pre-existing boundedness; it must not make them worse, and §5 states the argument |
+| **9** | No N-member FD/resource teardown loop in one PM-locked, IRQ-masked section | Each victim closes **only its own** descriptors, **one at a time**, and the owning descriptor never leaves the row: `begin_fd_close()` under PM takes one into the row's slot and returns a **non-owning `CloseTicket`** → drop PM → `endpoint_hangup(&ticket)` (the only step needing an endpoint lock; idempotent by CAS) → `finish_fd_close()` under PM drops the owning descriptor and clears the slot (explicit control flow: §2.5). **(v3 repair: the earlier `take_next_for_exit() -> (fd, FileDescriptor)` shape could not both retain custody and hand the value out.)** The existing allocating `take_fd_entries() -> Vec` (`process.rs:335`) is retired, not reused. Group work under PM is bitmap/flag stores only. No sweep loops over members' FD tables. | 7 | `FD_CLOSES_UNDER_PM == 0`; 256-FD × large-group test measures bounded PM hold; ratchet forbids close/reclaim calls inside any request/commit transaction body; **`fd_in_flight` holds at most one descriptor at any sampled instant and is `None` at quiesce for every row; a unit test proves `CloseTicket` exposes no close operation and that a replayed `endpoint_hangup` leaves endpoint refcounts unchanged (`FD_HANGUP_REPLAYED` nonzero, close count unchanged)** |
+| **10** *(v2 — cond. 1, 3; v3 — closure A)* | No eager `cleanup_cow_frames` while the victim may run elsewhere; all kill paths grace-defer; **and no path can drop a receipt instead of retiring it** | Phase 2 routes SIGKILL through the single public `exit_process_and_retire` wrapper, whose aarch64 defer takes the page table into a grace-stamped receipt **inside a crate-private locked half and enqueues it after the PM guard drops** (§1.7, §2.1), so the CoW walk becomes a `None`-walk and no queue lock nests under PM. **v3: `RetirementReceipt` is crate-private with no public constructor, `exit_process_locked` has exactly one permitted caller, and the receipt's `Drop` re-enqueues rather than freeing — so a lost receipt cannot destruct a root even on an unreachable path. All nine adapted sites — the seven live `exit_process` callers plus `handle_thread_exit`'s enqueue and the new SIGKILL arm — are converted in P2 (v3 repair: seven callers, not nine; v3 tranche pass: the post-P2 exact sets are **8** `exit_process_and_retire` call sites, **1** `exit_process_locked` caller and **3** PM-free `enqueue_process_reclaim` sites — `handle_thread_exit` is an adapted site that does NOT call the wrapper, §1.7).** Phases 9–11 remove every direct `terminate` caller; resources stay in the row until the victim's own commit, and release requires grace + RootProof. `Process::terminate` is deleted with its last caller. | 2, 7, **9**, 11 | Ratchet allowlist of `\.terminate\(` shrinks phase-by-phase to **empty**, asserted as an exact set; **`RECLAIM_ENQUEUE_UNDER_PM == 0` from P2 onward**; peer-CPU SIGKILL stress asserts zero reclaim before the fence elapses and a complete RootProof; `TEARDOWN_MASKED_FRAMES_WALKED == 0` for kill paths. **v3: ratchet asserts one call site for `exit_process_locked` and zero public constructors for `RetirementReceipt`; `RECEIPT_DROPPED_UNRETIRED == 0`; a fault injected at each of the nine adapted sites still shows the pid's root entering the reclaim queue exactly once** |
+| **11** *(v2 — cond. 1; v3 — closures D, F)* | Killed threads quiesced in the scheduler AND expedited with the existing `SGI_RESCHEDULE` | Phase 2: quarantine via the proven `terminate_process_threads` + **broadcast** `SGI_RESCHEDULE` to other online CPUs through the **teardown-only `send_exit_expedite_sgi` helper** (§2.7; no residency predicate to go stale, and no generic send site wired). **Phase 9 (was 10): the scheduler *requests* instead of remote-marking for every boundary-reachable victim, returns `ExitKickPlan`, and takes the counted legacy arm only for not-yet-migrated wait families. v3: P9 also ships the no-new-block admission interlock in all nine blocking primitives, which makes the reachability classification a one-way door. Phases 10a/b/c/d migrate the four families (10c is the `BlockedOnSignal` family v2 omitted); P10d empties the legacy allowlist and deletes the remote-marking body — that is where AC-11 is fully discharged.** The SGI handler keeps doing only `need_resched`; the victim can never be re-dispatched to EL0 once the generation is observed. **No `ExitPending`.** | 2, **9, 10a/b/c/d** | Victim spinning at EL0 pinned to a peer: **per-pid paired `EXIT_SGI_SENT{pid}` and an observation event for the test's own victim, with the send→observe interval measured strictly shorter than the victim's tick period — the observation half is `EXIT_KICK_OBSERVED{pid}` (the specified P2-era kick-bucket proxy, §2.7) from P2, and `EXIT_REQUEST_OBSERVED{pid}` from P8, when the boundary hook exists and the bucket table is deleted** (a bare "SGI count > 0" gate is explicitly rejected — the generic send sites are not wired and the counter is declared zero until P2); per-wait-family blocked-victim kill tests; **`EXIT_LEGACY_REMOTE_MARK{family}` reported per family and asserted to reach 0 with the allowlist empty at P10d**; **`EXIT_BLOCK_REFUSED{family}` nonzero in P9's own test and re-asserted nonzero in each P10x — the admission interlock is permanent and is never asserted at zero (v3 repair); what falls to 0 per family is `EXIT_LEGACY_REMOTE_MARK{family}`, and what rises from 0 is `EXIT_WAIT_CANCELLED{family}`**; unmigrated families explicitly reported, never silently advertised as killable |
+| **12** *(v2 — cond. 2, 5; v3 — closure B)* | Exactly-once SIGCHLD/wake/report with **first-recorded** status, idempotent under repeat passes | **Four-state obligations (`Absent/Pending/Claimed{claimer}/Completed`, §1.6), all transitions under the PM lock, which is the sole serializer — this restores what design C's single-worker serialization discharged after the worker was dropped.** Created at the **first** request; a repeat request returns the stored batch/status and creates no second obligation and no second status. **v3 makes the exactly-once claim real rather than asserted: class-A obligations (`Sigchld`, `ParentWake`, `Reparent`, the take-half of `Resources`) commit their effect in the SAME PM acquisition as `→ Completed`, so `Claimed` is never observable and T4 is unreachable for them; the two class-B obligations carry markers written by the effect itself: `Fds` by single-slot row-resident custody (*v3 repair* — the row's slot is the **sole owner** and the unlocked step receives a non-owning `CloseTicket`, so a double close is unrepresentable), and `Report` by started/finished bits plus the btrt token, with T4's destination chosen by the marker and the marker outranking the ledger. The scheduler kick is declared an idempotent repeatable side effect, not an obligation.** **Row lifetime is extended by the tombstone gate (P6a), and removal is an explicit two-event join over `reaped`/`retired` — whichever writer observes the other flag already set removes the row in that same acquisition, both orders specified and gated.** **The legacy `DeliverResult::Terminated` notification action is deleted in P11, so no second notifier exists.** Still not suppression: the obligation is shared, so a later pass redeems it rather than skipping it. | 2 (seed), **6a (retention + join), 6b (ledger)**, 11 (legacy notifier deleted) | Matrix — exit→fault, SIGKILL→fault, fault→SIGKILL, repeat request/wait: exactly one SIGCHLD, one parent wake, one `btrt` report, and `waitpid` returns the **first** status; equalities `SIGCHLD_FIRST_SET == PARENT_WAKE_COMPLETED == BTRT_EXIT_REPORTED == parented_first_commits` at the nonzero value the 64-child workload produces; **`LEDGER_CLAIM_MISMATCH == 0`, `LEDGER_CLAIM_ORPHANED == 0` on a healthy boot, `LEDGER_EFFECT_AMBIGUOUS == 0` on a healthy boot, `TOMBSTONE_RESIDENT == 0` at quiesce**; **`TOMBSTONE_JOIN{reap_second}` and `TOMBSTONE_JOIN{retire_second}` both nonzero in one run**; forced-orphan injection at each of the three marker states (`finished`, `not-started`, `ambiguous`) proves T4 takes the ruled destination — the notification is delivered exactly once, never twice |
+| **13** *(v2 — cond. 3)* | New reclaim/drain respects lock ordering and is bounded on idle paths without throttling fork's drain | **No cap is added, no drain is moved, no drain is shared.** Fork's pre-allocation drain stays full/unbounded. The only addition to a return tail is an acquire-load + branch, placed **after** the `PREEMPT_ACTIVE`/nested-return gate. Every scheduler critical section is entered with **no PM guard live**, structurally: request/commit APIs take `pid`/`tid`, never `&mut Process`. **v2 adds two absolute rules: (i) P1's proof reads never hold `PENDING_PROCESS_RECLAIMS` while acquiring SCHEDULER or PM — the drain detaches a candidate under the queue lock, drops it, proves, then frees or re-inserts (§4.3); (ii) every retirement receipt is enqueued only after the PM guard drops, including in P2's interim shape.** **v3 adds the progress rule the refusal path was missing (§1.8): a bounded pass (`last_pass` stamping — no candidate selected twice in one pass) plus bounded retry (`K = 3` liveness-blocker refusals park the entry on a side list under a fence built from a **`RetirementSnapshot` taken at park time** — never the receipt's already-elapsed retirement fence and never the cycle's earlier snapshot — with a three-armed unpark: all-CPU scheduling-epoch advance, a `ROW_REMOVAL_EPOCH` bump, or an age backstop of **64 scheduling epochs summed over the captured online mask** (no wall clock); v3 repair + v3 tranche pass, §1.8). This is an exclusion rule, NOT a drain cap: fork's pre-allocation drain keeps full semantics and no cap parameter exists.** No `FRAME_METADATA` and no `log::*` is added under any mask. Full analysis: §4. | all | Lock-depth/owner counters (with `try_manager()` instrumented — the r20 blind spot is not repeated); `RECLAIM_CONTEXT_VIOLATIONS == 0`; **`RECLAIM_ENQUEUE_UNDER_PM == 0` and `PROOF_UNDER_QUEUE_LOCK == 0`**; **`RECLAIM_PASS_SKIPPED`/`RECLAIM_PARKED` driven nonzero by forced refusals at each blocker class; `RECLAIM_UNPARKED{epoch}`, `{row}` and `{age}` each driven nonzero by their own injection (the `{row}` arm proved with every other CPU held off the scheduler, which an epoch-only rule cannot pass); `RECLAIM_PARK_IMMEDIATE_UNPARK == 0` (the fresh-fence proof); `RECLAIM_PARK_RESIDENT == 0` at quiesce having been observably nonzero mid-run; and a bounded-iteration assertion that one drain pass performs at most *queue length* selections**; ratchet rejects scheduler-under-PM, queue-lock-then-PM/SCHEDULER, and any reclaim/close/walk in idle or exception tails; fork-pressure test proves a *full* eligible drain, not a capped one. **Declared partial:** this design does not fix #448's or #492's pre-existing boundedness; it must not make them worse, and §5 states the argument |
 
 ---
 
@@ -722,16 +1535,28 @@ enqueue nests a queue op under PM at both `manager.rs:1152` and `process_task.rs
 **v2 (condition 3): the rule binds interim shapes too.** A phase may not adopt an overlapping-lock
 shape "temporarily" on the way to the end state. Two v1 shapes violated it and are corrected:
 
-1. **P1's proof under the queue lock.** `reclaim_deferred_process_resources` (`process_task.rs:375-392`)
+1. **P1's proof under the queue lock.** `reclaim_deferred_process_resources` (`process_task.rs:375-391`)
    evaluates its readiness predicate while holding `PENDING_PROCESS_RECLAIMS`. Today both terms are
    lock-free atomic reads, so `main` is legal; P1's `RootProof` adds scheduler-cached-root and
    live-row blockers, which would take SCHEDULER and PM **under the queue lock**. P1 restructures the
    drain instead (§4.3, "P1 retire cycle"): the under-queue-lock predicate stays **epoch + shadow
    only** (lock-free), the candidate is detached, the queue lock is dropped, and only then is the full
    proof run.
-2. **P2's enqueue under PM.** `exit_process` returns a `#[must_use] RetirementReceipt` and the caller
+2. **P2's enqueue under PM.** The locked half returns a `RetirementReceipt` and the **wrapper**
    enqueues it after the PM guard drops; the `handle_thread_exit` enqueue is moved into phase 2 of
    that function, where PM is already released. Both conversions are in P2's PR.
+
+**v3 (closure A): the rule is enforced by custody, not by discipline.** "The caller enqueues after
+the guard drops" is only a rule if callers exist that could do otherwise. §1.7 removes them: there is
+one public wrapper, the receipt type is crate-private with no public constructor, and the receipt's
+`Drop` re-enqueues rather than freeing. The two places a receipt can exist — inside the wrapper
+between guard-drop and enqueue, and P1's local detach slot — are both provably PM-free, so the `Drop`
+path can never nest the queue lock under PM either.
+
+**v3 (closure C): the no-overlap rule must also not cost progress.** §1.8's pass cursor and parked
+side list exist because detach-prove-reinsert is only safe if it terminates. The parked list is a
+second leaf structure taken **only** under the same discipline as the live queue (never with PM or
+SCHEDULER live), and the unpark check reads a `RetirementSnapshot`, which takes no lock at all.
 
 This makes both nesting directions impossible for teardown, so no ordering *cycle* can exist —
 rather than relying on everyone remembering which order is legal. It is enforced structurally
@@ -759,7 +1584,7 @@ consumed in place), by the P0 ratchet, and observed by counters — in that orde
 | S2 scheduler request/quarantine + `ExitKickPlan` | **SCHEDULER only** | entered with **no PM guard live** — structural: API takes `pid`/`tid`, never `&mut Process` | none | none | O(threads) mark + O(queues×threads) retain — identical to the merged fault path's existing cost |
 | SGI kick | **no lock** | after both guards drop | none | none | ≤ MAX_CPUS MMIO writes; handler does only `need_resched` |
 | S3 commit transaction | **PM only** | short; single hold; no drop mid-transaction | none (fixed receipts preallocated) | none | O(1) per victim; one victim per transaction, always |
-| S3 FD close | PM only to `take_next_for_exit`; **then endpoint lock with PM dropped** | strict edge: PM released before any endpoint lock | none | none | one descriptor per PM acquisition |
+| S3 FD close *(v3 repair)* | PM only for `begin_fd_close`; **endpoint lock with PM dropped**; PM only for `finish_fd_close` | strict edge: PM released before any endpoint lock, and re-acquired only after it is released | none | none | one descriptor per take/close pair; the owning descriptor never leaves the row |
 | S3 reparent cursor | **PM only**, fixed-size batch | PM dropped and DAIF restored between batches | none (`children` mirror not extended) | none | fixed batch (Residual R-4) |
 | **S3 ledger claim (T2)** *(v2)* | **PM only** | inside the commit transaction; read-then-write in one acquisition; no second lock | none | none | O(1) per obligation |
 | **S3 ledger completion (T3)** *(v2)* | **PM only**, fresh acquisition after the work | never overlaps the work it completes; no second lock | none | none | O(1) per obligation |
@@ -770,7 +1595,13 @@ consumed in place), by the P0 ratchet, and observed by counters — in that orde
 | **P1 retire cycle — free or re-insert** *(v2)* | free: **no lock**; re-insert: **reclaim queue only** | refusal bumps its blocker counter and rotates | frees only | none | per-victim |
 | S4 resource claim + physical free | PM only to `take` → **drop** → TLBI/CoW walk/frame free with no PM or scheduler held; preemption pinned across `FRAME_METADATA` | no heavy destructor under PM; no broadcast TLBI under PM/scheduler/IRQ-off | frees only | none | per-victim |
 | S4 stack release | SCHEDULER only to prove/detach → drop → stack-pool bitmap | allocator never acquired under scheduler | none | none | one thread per pass |
-| **S4 tombstone removal** *(v2 — cond. 2)* | **PM only**, after the ledger is proven `Completed` and the receipt retired | entered with no queue lock and no scheduler lock live | frees the row only | none | one row per pass |
+| **S4 tombstone removal — two-event join** *(v2 cond. 2; v3 closure B)* | **PM only**, in the SAME acquisition that writes `reaped` or `retired` and reads the other | entered with no queue lock and no scheduler lock live; the ledger term is read in that same acquisition | frees the row only | none | one row per pass; both join orders exercised |
+| **Class-A obligation commit (T2·3)** *(v3 — closure B)* | **PM only** | the effect and `→ Completed` are one acquisition; takes no second lock | none | none | O(1); `Reparent` is one fixed batch per acquisition with a cursor |
+| **Class-B effect marker writes** *(v3 — closure B)* | **no lock** (lock-free atomics in the row) | `started`/`finished` are plain atomics written outside PM; `fd_in_flight` is written under PM by `begin_fd_close` and both **cleared and destroyed** under PM by `finish_fd_close` in one acquisition — the unlocked step holds only a non-owning `CloseTicket` (v3 repair) | none | none | O(1) per descriptor / per report |
+| **`btrt::claim_exit_slot`** *(v3 — closure B)* | **PM only** (inside T2) | pure `compare_exchange` on the btrt registry; **no SERIAL** — the SERIAL-reaching `record_exit` half runs with no lock held | none | none | O(registry) scalar scan |
+| **P1 park / unpark** *(v3 — closure C; repaired)* | **parked-list lock only** | leaf; never entered with PM, SCHEDULER or the live queue lock held. All three unpark arms are lock-free reads: a `RetirementSnapshot` (epoch), a relaxed load of the global `ROW_REMOVAL_EPOCH` (row), and a second read of the same epoch words the park captured (age — a scheduling-epoch count, no clock). The `ROW_REMOVAL_EPOCH` **bump** is one relaxed increment inside the PM acquisition that already performs `remove_row`, taking no additional lock and touching no list | none | none | O(parked length) scalar scan |
+| **Teardown expedite SGI** *(v3 — closure F)* | **no lock** | `send_exit_expedite_sgi` is called after every guard drops, exactly like the v2 broadcast it replaces | none | none | ≤ MAX_CPUS MMIO writes + one trace event each |
+| **No-new-block admission check** *(v3 — closure D)* | **whatever the primitive already holds** | one acquire-load of the caller's own per-thread request word, evaluated **before** the primitive takes any wait-queue state; takes no new lock and cannot deadlock because it reads a per-thread atomic | none | none | O(1) |
 | S5 init escalation | **none** | all guards out of scope, DAIF restored | panic path may allocate — legal here | panic only | one atomic load |
 | Boundary hook (Tier-2) | **none** | acquire-load + branch, placed **after** the `PREEMPT_ACTIVE`/nested-return gate | none | none | O(1); no drain, no walk, no lock |
 
@@ -787,7 +1618,15 @@ receipts are fixed-size and preallocated; the allocating `take_fd_entries()` is 
 **`log::*` under mask** — none added anywhere; all new diagnostics are `trace_count!`/`trace_event!`
 from the lock-free framework, with `raw_serial_char()` remaining the last resort at fault sites that
 already use it. **Heavy work before a safety gate** — the boundary hook goes after the
-`PREEMPT_ACTIVE` gate, and no drain is added to any tail.
+`PREEMPT_ACTIVE` gate, and no drain is added to any tail. *(v3)* **A receipt reaching a destructor** —
+`RetirementReceipt`'s `Drop` re-enqueues instead of freeing, and both of the two contexts a receipt can
+exist in are PM-free (§1.7). *(v3, repaired)* **A drain that cannot make progress** — the pass cursor bounds one
+pass; the park rule bounds retries under a *freshly captured* fence, so a park is never instantly
+undone; and the unpark disjunction covers the PM-side event that clears a live-row blocker with no
+scheduling anywhere, with an age backstop behind both arms. Detach-prove-reinsert therefore
+terminates and a parked entry cannot be stranded (§1.8). *(v3)* **A victim
+entering an unmigrated wait after being classified reachable** — every blocking primitive refuses to
+block a latched thread (§1.5), so the classification is a one-way door.
 
 **Honest limit.** The runtime lock-order detector compares against `PROCESS_MANAGER_OWNER_TID`, and
 that bookkeeping was *not* updated by `try_manager()` — blocking finding #8 in the parked branch's
@@ -812,7 +1651,11 @@ release-stripped assertion, and no correctness argument rests on a counter.
    Design A's proposal to insert quarantine work into the pre-gate deferred-fault drain is rejected
    precisely because it would worsen #448. **Honest cost:** routing more paths through unconditional
    grace deferral raises the peak deferred-entry count and peak retained frames under burst
-   (Residual R-6); the phase gates include an explicit retention measurement.
+   (Residual R-6); the phase gates include an explicit retention measurement. *(v3, closure C: the
+   pass cursor and parked side list added in §1.8 are an **exclusion** rule, not a cap — they stop the
+   drain re-examining an entry it already examined this pass and defer entries whose blocker provably
+   cannot have changed. No cap parameter is introduced, no drain is moved, and fork's pre-allocation
+   drain keeps full semantics. The three reverted bounded-drain attempts are not reopened.)*
 3. **#493 — `check_signals_for_eintr` disposition.** Untouched. `has_deliverable_signals()` is not
    modified. Group exit is set only *after* the existing disposition code determines the effective
    action is terminate; the request API takes an already-resolved fatal intent, so a later
@@ -859,7 +1702,11 @@ victim in a wait family whose victim-owned cancellation path has not yet been au
 simply latch: from P9 it takes the explicit legacy remote-mark arm (§1.5), i.e. exactly the merged P2
 behaviour, so kill latency for those victims is unchanged from what has already shipped. What remains
 residual is that such a victim is torn down **remotely** rather than by itself until its family lands
-in P10a/b/c, and that a family with a genuinely stuck wait still blocks *prompt* victim-owned death.
+in P10a/b/c/d, and that a family with a genuinely stuck wait still blocks *prompt* victim-owned death.
+*(v3, closure D: the inventory is now closed at four families — futex; `WaitQueueHead` + stdin/TTY;
+`BlockedOnSignal` (`pause`/`sigsuspend`); child-wait + timer/nanosleep + completion/I-O — and the
+no-new-block interlock means an unmigrated family can only be **entered before** the request is
+latched, never after.)*
 The group stays sealed and its resources pinned rather than freed underneath it — a *safe* failure
 (leak/stall, never early free) — and it is counted per family. Breenix has no killable-wait taxonomy
 today; building one is P10's whole job and it is honestly incomplete until every family lands.
@@ -930,13 +1777,16 @@ programs comparing thread IDs across exec. Transplant would require a registry-w
 **R-15. This is a design-only artifact.** No build, QEMU, or Parallels evidence exists yet. Every
 gate below is a requirement on the implementation, not a result.
 
-**R-16. The legacy remote-mark arm is live from P9 until P10c.** *(new, condition 1.)* Between the
+**R-16. The legacy remote-mark arm is live from P9 until P10d.** *(condition 1; renumbered in v3 by
+closure D's added family.)* Between the
 request/wake cutover and the last wait-family migration, two teardown shapes coexist for SIGKILL:
 victim-owned for boundary-reachable victims, and the merged P2 remote-mark for the rest. This is a
 deliberate, counted, ratcheted interim — both arms are exercised in every PR that ships them, the
-false set is an explicit allowlist that only shrinks, and P10c deletes the arm — but during that
+false set is an explicit allowlist that only shrinks, and P10d deletes the arm — but during that
 window two paths must both be correct, and a review of any P10x PR must check both. The alternative
-(migrate every family in one PR) is the 15-phase big bang Judge 1 found fatal.
+(migrate every family in one PR) is the 15-phase big bang Judge 1 found fatal. *(v3: the window is one
+subphase longer than v2 stated, because the `BlockedOnSignal` family was missing from the inventory.
+That is a real cost of the correction and it is recorded rather than absorbed.)*
 
 **R-17. Orphaned-claim recovery depends on the same liveness machinery it protects.** *(new,
 condition 2.)* T4 (`Claimed{dead} → Pending`) uses P1's proof (`scheduler thread absent or
@@ -945,13 +1795,65 @@ the *unsafe* direction — declaring a live claimer dead — two paths could red
 mitigation is that T4 is gated on the *same* two-epoch fence that gates physical free, so a claimer
 that could still run cannot be declared dead without also making a use-after-free reachable, which the
 existing gates already test for. It is a shared dependency, not an independent proof, and is recorded
-as such.
+as such. *(v3, closure B: the blast radius of a wrong T4 is now much smaller — T4 is unreachable for
+the four class-A obligations, `Fds` cannot double-close because custody is single-slot, and only
+`Report` has a ruling that could in principle drop a report. So a T4 misfire degrades to "one btrt
+report possibly missing, and the AC-12 equality fails loudly", not "an obligation performed twice".)*
+
+**R-18. Init's group protection is belt-and-braces, and the belt is an ABI restriction.** *(new, v3,
+closure E.)* End 1 (clone admission refusing to publish into the designated init's thread group,
+`EINVAL`) is a **deliberate and documented ABI restriction**: Breenix's designated init cannot have
+`CLONE_VM` siblings. Nothing in-tree clones from init and a multi-threaded init would need its own
+design pass, so the cost today is zero — but it *is* a restriction, and if init ever legitimately
+needs siblings, end 1 is what must be revisited. End 2 (the group-membership drop in S1's seal) is
+what keeps the system safe in the meantime, and it is the guard that must never be removed as
+"redundant". Both ends are separately tested so neither can silently rot into the other's shadow.
+
+**R-19. `Report` has one irreducible ambiguity window, and we rule against re-running.** *(⚠ Tracked
+as **DEBT-1**, owner **P6b** — this residual is the reason `Report` is at-most-once rather than
+exactly-once, and P6b's tranche cannot ratify until the window is either closed or explicitly
+accepted by the operator as the round's single at-most-once obligation. It is listed here as an
+accepted risk **only** in the sense that v3 named it; the register is where it is owed.)* *(new, v3,
+closure B.)* If a claimer dies *inside* `btrt::record_exit` — between the `started` CAS and the
+`finished` store — T4 cannot tell whether the recording landed. The ruling is **treat it as done**
+(`→ Completed`, bump `LEDGER_EFFECT_AMBIGUOUS{report}`), because a duplicate corrupts the test ledger
+and can double-`finalize()` the boot, whereas a missing report is caught by the AC-12 equality. The
+window requires a kernel control path to fault inside a short lock-free atomic sequence, which is
+itself a run-failing bug; the counter is asserted 0 on every healthy boot and driven to a known value
+only by deliberate injection. This is the one place in the design where exactly-once degrades to
+at-most-once, it is named, and it is the *only* one.
+
+**R-20. Parked receipts are a bounded, visible stall.** *(new, v3, closure C; scope corrected by the
+v3 repair.)* An entry whose liveness blocker never clears sits on the parked side list and is retried
+on any of the three unpark arms (all-CPU scheduling-epoch advance, a `ROW_REMOVAL_EPOCH` bump, or the
+age backstop of 64 scheduling epochs summed over the captured online mask). Because the age arm
+cannot be starved while any captured CPU still schedules — and the 1 kHz tick guarantees one does — a parked entry is **always** eventually
+re-proved, so the residual is narrower than v3 first stated: what remains is not "an entry that is
+never revisited" but "an entry whose blocker is genuinely permanent (a leaked scheduler-cached root,
+say), which is re-proved forever and never retired" — a leak, not a use-after-free, and one that
+consumes at most one proof per drain. `RECLAIM_PARK_RESIDENT` is a gauge with a reader asserted to
+return to 0 at quiesce in every boot gate, so the leak is loud. The alternative — retrying the same
+entry inside a single pass — is the livelock this closure removes.
+
+**R-21. The P2-era expedite observation is a proxy with a demolition date.** *(new, v3 tranche
+pass; closure F.)* Between P2 and P8, the observation half of AC-11's send→observe pairing is the
+`EXIT_KICK` bucket table (§2.7), not `EXIT_REQUEST_OBSERVED{pid}` — which cannot exist before the
+return-boundary hook does. Two limits are accepted and both are counted rather than argued away.
+**(i) It observes a weaker event.** "The peer's scheduler declined to dispatch this victim" is not
+"the victim observed a latched exit request"; the latter is not expressible before P8, and P2's gate
+is worded to the former rather than overclaiming. **(ii) 64 buckets alias.** Two victims congruent
+mod 64 in flight at once cost the earlier one its observation, counted `EXIT_KICK_BUCKET_COLLISION`
+and impossible in P2's single-victim gate. The residual is bounded by construction: the table and
+both counters are **deleted in P8**, in the same PR that introduces the hook, so the round never
+carries two observation mechanisms past the phase that unifies them. A P8 that keeps the bucket table
+alive is the failure mode this residual exists to make visible.
 
 ---
 
 ## 7. Open questions — operator decisions only
 
-**OQ-1. Init death policy — DECIDED (coordinator-adopted at v2, condition 7).** **Linux-faithful
+**OQ-1. Init death policy — DECIDED (coordinator-adopted at v2; recorded here as a coordinator
+decision, NOT as ratification condition 7 — see closure G).** **Linux-faithful
 protected init:** a user-originated signal to the designated init whose effective disposition is the
 default fatal action and for which init has no handler is **silently dropped and the send returns
 success (0)** — not `EPERM`. Handled signals are delivered normally. Only init's own `exit`/`exit_group`
@@ -984,7 +1886,10 @@ Increment-1 strength (still a real UAF fix, but the remote-mark model survives).
 v1's blast radius: refusal parks P8 *through P12*, not just P8.** Under the corrected order the group
 seal lives in P9 (which needs P8's hook) and the init-death latch's only producers are P8's own-exit
 commit and P11's unhandleable-fault path, so a refusal leaves #464 identity-complete but death-policy
-parked and #471 with exec detach (P3) but no seal. v1's claim that "#464 and #471 ship complete"
+parked and #471 with exec detach (P3) but no seal. *(v3 note: closure E's **end 1** — the clone
+admission refusal — ships in **P5** and therefore survives an OQ-5 refusal. End 2 rides with P12 and
+would be parked; that is acceptable precisely because end 1 makes the state end 2 guards against
+unconstructible, which is the whole reason the closure is at both ends.)* v1's claim that "#464 and #471 ship complete"
 without OQ-5 was wrong and is withdrawn. *(Ratification:
 AGREE, strictly under the stated constraints: post-gate, acquire-load + branch only, preemptible-context
 work, no logging. §2.5 now states the activation control flow those constraints apply to.)*
@@ -998,14 +1903,19 @@ worker used to provide.)*
 selection, and nonleader PID transplant are all **out** of this round. Recommended **yes** — each is a
 separate blast radius, and #471 as filed is satisfied by detach + seal. *(Ratification: AGREE.)*
 
-**OQ-8. Phase count — CORRECTED (condition 6).** v1 claimed "13 phases / 13 PRs", which the
-ratification correctly called a contradiction with the split phases. The honest figure is
-**13 numbered phases / 16 PRs**: P6 splits into P6a + P6b (condition 2) and P10 into P10a + P10b + P10c
-(the wait families), while every other phase is one PR. Each PR targets ≤ ~230 changed non-generated
-lines across ≤ 5 production files (PR #418's 236-line, 5-file diff is the ceiling). The full PR ledger
-is enumerated in PLAN §0. That is a lot of review cycles, and it is the deliberate price of Judge 1's
-fatal finding against a 15-phase big bang. **Open decision: accept 16 PRs, or batch adjacent phases and
-accept larger review surface per PR?**
+**OQ-8. Phase count — CORRECTED AGAIN (condition 6; updated by v3 closure D).** v1 claimed
+"13 phases / 13 PRs", which the first ratification correctly called a contradiction with the split
+phases; v2 said 16 PRs. Adding the omitted `BlockedOnSignal` wait family as its own subphase makes the
+honest figure **13 numbered phases / 17 PRs**: P6 splits into P6a + P6b (condition 2) and P10 into
+P10a + P10b + P10c + P10d (four wait families, the last of which also deletes the legacy arm), while
+every other phase is one PR. Each PR targets ≤ ~230 changed non-generated lines across ≤ 5 production
+files (PR #418's 236-line, 5-file diff is the ceiling). The full PR ledger is enumerated in PLAN §0.
+That is a lot of review cycles, and it is the deliberate price of Judge 1's fatal finding against a
+15-phase big bang. **Open decision: accept 17 PRs, or batch adjacent phases and accept larger review
+surface per PR?** *(The coordinator's recommendation is unchanged: accept the count. The one batching
+candidate a reviewer might reasonably propose is P10c into P10b, since `tty/driver.rs:602-603` shows
+the TTY unblock path already spans `Blocked` and `BlockedOnSignal` — but the signal family has four
+separate syscall entry points across both architectures and would put P10b over the line ceiling.)*
 
 **OQ-9. x86_64 rollout.** Land shared semantics now with no SMP proof (recommended), or gate the
 victim-owned path to aarch64 and keep an explicitly audited synchronous x86 hook? *(Ratification:
@@ -1031,3 +1941,9 @@ approval if one is found to bypass it — that proof is a named P8 gate item.)*
 | **Interim shapes that violate the end-state lock rule "temporarily"** *(new, v2 — condition 3)* | **No** | v1 let P1 prove under the reclaim-queue lock and P2 enqueue under PM. Both are corrected at the phase that introduces them: the drain detaches before proving, and receipts are returned and enqueued after PM drops. `PROOF_UNDER_QUEUE_LOCK` and `RECLAIM_ENQUEUE_UNDER_PM` are asserted 0 from the phase that creates them onward |
 | **A wait-family contract shipping before its producer exists** *(new, v2 — condition 1)* | **No** | The request/wake publication and victim-owned commit suppression now land in P9, before every P10x consumer; each family PR is a consumer of an already-merged producer, and the interim legacy arm is explicit, counted and ratcheted rather than implied |
 | **A second notification path surviving alongside the ledger** *(new, v2 — condition 5)* | **No** | `DeliverResult::Terminated` and its caller-side notify action are deleted in the same PR that introduces the intent-only `FatalIntent`; the ratchet asserts the variant's absence by name |
+| **A lint standing in for a safety mechanism** *(new, v3 — closure A)* | **No** | v2 relied on `#[must_use]` to stop a returned receipt being dropped, which `let _ =` defeats and which seven unadapted call sites would have met head-on. Custody replaces advice: crate-private type, no public constructor, one permitted caller of the locked half, a `Drop` that re-enqueues instead of freeing, and all nine adapted sites moved in the introducing PR |
+| **A recovery rule that cannot observe the thing it recovers** *(new, v3 — closure B)* | **No** | v2's T4 reopened an orphaned claim without knowing whether the effect had fired. v3 removes the question for four obligations (effect and completion in one PM acquisition), removes it by ownership for `Fds`, and answers it with an effect-written marker for `Report` — with the winning side stated in a table rather than left to the implementer |
+| **A refusal path with no progress argument** *(new, v3 — closure C)* | **No** | v2's "re-insert and rotate" had no rotation: the live drain re-scans from index 0. v3 stamps a pass id (no candidate selected twice per pass) and parks entries after `K` liveness refusals until a scheduling-epoch advance. Stated explicitly as an exclusion rule, not a cap, so the three reverted bounded-drain attempts are not reopened |
+| **A classification treated as stable without an interlock** *(new, v3 — closure D)* | **No** | "Boundary-reachable" is now a one-way door: every blocking primitive refuses to block a thread whose exit request is latched, so a victim classified reachable cannot later become unreachable. The wait inventory is closed at four families with `BlockedOnSignal` added, and the missing graph edges are present |
+| **A protection checked at one end of a two-end mechanism** *(new, v3 — closure E)* | **No** | Group-scoped kill plus row-scoped protection left a sibling bypass. v3 refuses the sibling at clone admission **and** tests designated-init membership of the whole target group at the seal, with each end separately tested so neither rots in the other's shadow |
+| **Evidence attached to a counter that unrelated work increments** *(new, v3 — closure F)* | **No** | `EXIT_SGI_SENT` moves off the two generic scheduler send helpers onto a teardown-only helper that does not exist until P2 (declared zero until then), and the gate is per-victim-PID paired with the observation event plus a measured send→observe interval — the defer/reclaim pairing pattern, applied to expedite |

--- a/docs/planning/teardown-unification/PLAN.md
+++ b/docs/planning/teardown-unification/PLAN.md
@@ -1,17 +1,122 @@
-# Teardown Unification — PHASED IMPLEMENTATION PLAN v2 (revised against ratification)
+# Teardown Unification — PHASED IMPLEMENTATION PLAN v3 (revised against two ratification passes)
 
-Companion to `teardown-unification-DESIGN-v2.md`. Design-only: nothing below has been implemented and
+Companion to `teardown-unification-DESIGN-v3.md`. Design-only: nothing below has been implemented and
 no gate result is claimed.
 
-**Base:** `main` @ `eebc8868` (docs re-verified at `main` @ `c9efdcc7`). **Issues:** #491 (spine), #464, #471.
+**Status:** **Tranche-ratified document. Tranche 1 (P0+P1+P2): submitted for ratification. Later phases: design-debt register applies; sections may change before their tranche ratifies.**
+
+**Base:** `main` @ `eebc8868` (docs re-verified at `main` @ `c9efdcc7`; **re-verified again for v3 at
+`main` @ `985881a6`** — v2 of these documents merged, no kernel change. Every file:line below was read
+out of the tree at `985881a6`; five v2 citations that had drifted are corrected — see DESIGN §0.3
+for the table).
+**Issues:** #491 (spine), #464, #471.
 
 ---
 
-## CHANGELOG — v2 deltas against the ratification conditions
+## DESIGN-DEBT REGISTER
 
-The Codex Sol ratification refused endorsement (`ENDORSE: NO`) with 2 FATAL seams, 7 MAJOR, 1 MINOR and
-7 conditions. This is a **targeted** revision: phases and text the ratification did not criticise are
-preserved verbatim.
+*(New in the v3 tranche pass. This section is normative: it is the complete list of open items that
+these documents do **not** close, each bound to the phase that owns its closure.)*
+
+**Why this exists.** Two full ratification passes and two pre-checks refused this design as a whole
+document. The whole-document bar is replaced by **tranche ratification**: a tranche of phases is
+submitted, pre-checked and ratified on its own, and the items a later phase owns are recorded here as
+numbered debts instead of blocking the tranche in front of them. Nothing is being waved through — a
+debt is an obligation with a named owner and a written acceptance condition, and the rule below makes
+it un-skippable.
+
+> **RULE (binding).** **A tranche containing a debt's owner phase CANNOT be ratified until that
+> debt's closure is written into these documents and has passed a pre-check.** Writing the closure is
+> not enough; it must survive the same adversarial pre-check that produced the debt. A tranche may be
+> submitted while debts owned by *later* phases remain open, and only while that is true.
+>
+> **Tranche 1 = P0 + P1 + P2. It owns none of the six debts below** (their owners are P6a, P6b, P7,
+> P9, P10 and P12), which is precisely why it is submitted for ratification now.
+
+| Debt | Owner phase | What must be true before that phase's tranche can ratify | Source finding |
+|---|---|---|---|
+| **DEBT-1 — `Report` exactly-once is not achieved; it degrades to at-most-once in one window** | **P6b** | Two things, together. **(a) The R-19 window.** When an effect marker reads `started == 1 && finished == 0`, T4 cannot tell whether `record_exit` landed; the current ruling is `→ Completed` + `LEDGER_EFFECT_AMBIGUOUS{report}`, i.e. a *possibly missing* report. P6b must either close the window with a mechanism that makes the record step itself recoverable, **or** carry an explicit operator acceptance that this is the round's single at-most-once obligation, with the counter asserted `0` on every healthy boot and moved only by deliberate injection. A silent third option — restating exactly-once while shipping at-most-once — is what the pre-check rejected twice and is not available. **(b) `on_process_exit` split phasing.** The split into `claim_exit_slot` (pure atomics, PM-callable) + `record_exit` (reaches SERIAL via `finalize()` → `ktap::emit_summary`) must be shown not to reorder the registry-slot clear relative to the serial emission, and must land in the **same PR** as T4 — a recovery rule and the marker it reads must never be separated by a merge boundary | v3 pre-check and re-check, item **B NOT-CLOSED** (both passes, verbatim unchanged): *"R-19 permits missing report when `started==1 && finished==0`"*. DESIGN §1.6 (class-B `Report`), §6 R-19; PLAN P6b |
+| **DEBT-2 — `Fds` close replay safety needs a PER-DESCRIPTOR token; the endpoint-CAS `CloseTicket` design is REJECTED** | **P7** | The v3 repair made `endpoint_hangup` idempotent by a **CAS on the shared endpoint**. The re-check's new FATAL is that live close accounting in the pipe/PTY/TCP endpoints is **per-descriptor**: a `dup`'d descriptor is a second, legitimate decrement on the *same* endpoint, and an endpoint-level CAS would suppress it — trading a double-close for a leaked endpoint that never hangs up. **P7 must not implement the CAS as specified.** It must carry a replay token that is unique to the `(row, fd)` pair being closed and that survives the unlocked window, so that a *replayed exit-close of the same descriptor* is suppressed while a *legitimate close of a different descriptor on the same endpoint* still decrements. DESIGN §1.4/§1.6/§2.5 and PLAN P6b/P7 must be rewritten to that mechanism before P7's tranche is submitted, and P7's gate must include a `dup`-then-close-both workload that fails by construction under an endpoint CAS | v3 re-check, **NEW FATAL**: *"the CloseTicket repair assumes endpoint-level CAS idempotence despite current close accounting being per-descriptor; duplicated descriptors make the CAS unsafe and would suppress legitimate closes"*; re-check item **1 NOT-CLOSED**. Also flagged by the repair pass itself as unreviewed (*"nobody has checked the current endpoints can satisfy it"*) |
+| **DEBT-3 — the blocking-primitive inventory is NOT closed at nine** | **P9** | The no-new-block admission interlock is what makes the boundary-reachability classification a one-way door, and it is specified as living inside "the exact nine" primitives. Two live paths are outside that set: **`kernel/src/syscall/futex.rs:115`**, which publishes `ThreadState::Blocked` **directly**, bypassing every `Scheduler::block_current*` entry point, and **`kernel/src/task/scheduler.rs:2175-2194`**, which publishes I/O blocking through a primitive the inventory does not list. Either is enough for a victim to block *after* its exit request is published, which is exactly the hole the interlock exists to close. Before P9's tranche: each path is brought under the interlock **or** proven unreachable once a request is latched; P0's ratchet rule 2 (*"the blocking-primitive set is exactly the nine above"*) is restated to the corrected inventory; and DESIGN §1.5's one-way-door claim and §0.3's "inventory is declared CLOSED at four families" are restated to match | v3 pre-check and re-check, item **D NOT-CLOSED** (both passes, verbatim unchanged). DESIGN §0.3 (closure D), §1.5; PLAN P0 rule 2, P9 |
+| **DEBT-4 — the x86 reap path bypasses the tombstone gate** | **P6a** | P6a's whole claim is that a row is removed only by the **two-event join** (`reaped` ∧ `retired`, whichever writer sees the other flag set performs the removal). **`kernel/src/syscall/handlers.rs:3101` removes the row directly on the live x86 reap path**, so the join is not the only remover and the retention gate can pass on aarch64 while x86 still frees a row out from under an un-retired receipt. Before P6a's tranche: that site routes through the join, **or** P6a's retention gate is honestly re-scoped to aarch64 with the x86 divergence named in AC-12's evidence column, a ratchet pinning `handlers.rs:3101` by name, and a stated phase that closes it. Scoping the gate narrowly to avoid tripping on it, without naming it, is not available | v3 pre-check and re-check, item **B NOT-CLOSED** (second half, both passes): *"P6a omits the live x86 reap at `kernel/src/syscall/handlers.rs:3101`, which still removes the row directly"*. PLAN P6a |
+| **DEBT-5 — `EXIT_BLOCK_REFUSED` post-migration semantics: it is NEVER asserted to zero** | **P10** *(a/b/c/d)* | The admission interlock is **permanent**, not scaffolding. Migration changes only the fate of a victim *already* blocked; it does not change the refusal owed to an already-latched victim trying to **enter** a migrated wait — which must stay refused, or migration manufactures cancellation work and reopens a lost-wakeup window between block and cancel. Therefore: **no gate anywhere may assert `EXIT_BLOCK_REFUSED{family} == 0`**, before or after migration. `EXIT_BLOCK_REFUSED{family}` is asserted **nonzero** in P9's own admission-race test and **re-asserted nonzero** in each of P10a-d; the migration evidence is the *pair* `EXIT_LEGACY_REMOTE_MARK{family} → 0` and `EXIT_WAIT_CANCELLED{family} → nonzero`. This debt is **repaired in the v3 text**; it is registered because it is a standing guard that a later phase can silently break, and because the failure mode (a "tidy-up" that asserts the counter to zero once migration is done) reads like cleanup | v3 pre-check, MAJOR item 5: *"P10's requirement that `EXIT_BLOCK_REFUSED{family}` hits zero post-migration contradicts the permanent admission interlock"*. DESIGN §1.5, §3 AC-11; PLAN P0 counter table, P9, P10a-d |
+| **DEBT-6 — P12's group-membership drop is scoped to EXTERNALLY-ORIGINATED signals only** | **P12** | The S1 group-seal check drops a fatal request when the designated init is a member of the **target group**. That drop applies to **`ExitIntent.origin == Signal` only** — sender-agnostic (a self-directed `kill(getpid())`/`raise` is still a signal and is still dropped, matching Linux's `sig_task_ignore`, which consults `SIGNAL_UNKILLABLE` and disposition and never the sender). **`ExitSyscall`** (init's own `exit_group`, or the exit of its last member) **and `FatalFault` BYPASS the membership test entirely**, so init's own exit still seals, latches and reaches the kernel-fatal panic. An unscoped check makes that panic path unreachable and the system hangs with init alive — a silent inversion of the policy. P12's gate must include the negative (a deliberate init `exit_group` still panics; a `FatalFault` injection still panics; an ordinary group kill still works) and record the unscoped-check pre-image. This debt is **repaired in the v3 text** and is registered because the failure is silent | v3 pre-check, MAJOR item 6: *"P12's group-membership signal drop isn't scoped to externally-originated signals; as written it would also suppress init's own `exit_group`, contradicting the required panic path"*. DESIGN §2.2 (End 2); PLAN P12 |
+
+**Not in this register, and why.** Items the pre-checks raised that are *closed in the v3 text* and
+carry no further obligation are recorded in the changelogs, not here: the seven-vs-nine caller count
+(closed by the three-class taxonomy — DESIGN §1.7), the reversed P6a join gates, the Report-marker
+phasing contradiction, and `parked_at` freshness. The design's *accepted* risks live in DESIGN §6 as
+residuals R-1…R-21; a residual is a risk taken with eyes open, a **debt is an unfinished argument**,
+and the two are deliberately kept in separate lists.
+
+---
+
+## CHANGELOG
+
+### v3 tranche pass — acceptance model changed, three tranche-1 items closed, six debts registered *(current revision)*
+
+**The acceptance model changed, and that is the headline.** The whole-document ratification bar is
+**replaced by TRANCHE ratification**. A tranche of phases is submitted, pre-checked and ratified on
+its own; items owned by later phases are recorded as numbered debts in the **DESIGN-DEBT REGISTER**
+above rather than blocking the tranche in front of them. **Tranche 1 = P0 + P1 + P2**, and it is
+submitted for ratification now. The register's binding rule: *a tranche containing a debt's owner
+phase cannot be ratified until that debt's closure is written and pre-checked.* Tranche 1 owns none
+of the six registered debts (owners: P6a, P6b, P7, P9, P10, P12).
+
+This pass is **surgical**. It fixes exactly the three tranche-1-relevant items the v3 pre-check and
+re-check left open, adds the register and the status header, and changes nothing else.
+
+| # | Tranche-1 item | What was wrong | What this pass wrote |
+|---|---|---|---|
+| **i** | **The seven-vs-nine caller count contradicted itself across the two documents** | The v3 repair correctly pinned P0's baseline at **seven** `exit_process` callers, but did not propagate: DESIGN §1.7 and PLAN P2's gate still demanded that "all NINE adapted sites call `exit_process_and_retire`", asserted as an exact set. `handle_thread_exit` (`task/process_task.rs:244`) routes its receipt through `phase1_result` and never calls the wrapper, so that gate was **unsatisfiable by construction** — the docs were half-updated | One live-verified taxonomy, stated once in **DESIGN §1.7** and mirrored verbatim in **PLAN P0 rule 1** and **P2's call-site table** (which gains a `Class` column). **Three disjoint classes: 7 `exit_process` callers + 1 new SIGKILL arm + 1 PM-nested enqueue = 9 ADAPTED SITES.** Callers and enqueue sites are never conflated again. The post-P2 gate becomes **three exact sets — 8 / 1 / 3** (`exit_process_and_retire` call sites / `exit_process_locked` callers / PM-free `enqueue_process_reclaim` sites), because one set cannot express three shapes. Verified by `git grep` at `main` @ `985881a6` |
+| **ii** | **P2's victim-attributed observation was a placeholder** | Closure F gated AC-11 on per-victim-PID pairing, but `EXIT_REQUEST_OBSERVED{pid}` is written by the return-boundary hook, which does not exist until **P8**, and the live SGI receiver (`arch_impl/aarch64/exception.rs:1761-1768`) carries only an interrupt id — no pid, no batch. The docs said "the P2-era proxy described in their own gates"; the gates pointed back at the counter table. Nothing specified the mechanism, so P2's pairing gate was vacuous | **The mechanism is chosen and written** (option: specify, not downgrade). **DESIGN §2.7** gains the `EXIT_KICK` bucket table: a fixed `[KickSlot; 64]` of three atomics, **published** by `send_exit_expedite_sgi(victim_pid, batch)` before the broadcast (`pid`/`at` Relaxed, `seq.fetch_add(2, Release)`), **consumed** by one `compare_exchange` at the peer scheduler pass that declines to dispatch the quarantined victim — lock-free, no allocation, no new per-thread field. Counters `EXIT_KICK_PUBLISHED{bucket}` / `EXIT_KICK_OBSERVED{pid}` / `EXIT_KICK_BUCKET_COLLISION` added to P0's table, declared zero until P2 and **deleted in P8**. The proxy's weaker claim is written into the gate rather than overclaimed, and its two limits are **residual R-21** |
+| **iii** | **Parked receipts: "fresh" was under-specified and the age backstop had no unit** | The repair said `ParkRecord` captures a "freshly captured fence", which still permits reusing the `RetirementSnapshot` the same drain cycle took at step 2 — stale by exactly the interval that caused the park. And the age arm was `now - parked_at_tick` "exceeds the park backstop", with the backstop never defined, while gate 3(c) required completion "within the stated backstop" | **`parked_at` captures a FRESH `RetirementSnapshot` taken AT PARK TIME** — never `reclaim.after_epoch`, never the cycle's earlier snapshot — with a **second negative gate** (P1 gate 5(b)) that an earlier-snapshot implementation fails while passing the first. **The age backstop gets a concrete unit: `PARK_AGE_BACKSTOP_EPOCHS = 64` SCHEDULING EPOCHS, summed over `fence_at_park.online_mask` — not wall time.** `parked_at_tick` is deleted; the key is derived from the captured fence, so `ParkRecord` carries no timestamp. P1 gate 3(c) becomes checkable (fires at a sum advance of 64, still parked at 63) |
+
+**Everything else is byte-stable.** No phase was added, split, reordered or renumbered; the ledger is
+still **13 phases / 17 PRs**; no dependency edge changed; no acceptance criterion changed except the
+evidence columns of AC-10, AC-11 and AC-13, which were made consistent with the three fixes above.
+
+### v3 — the seven required closures from the re-ratification refusal
+
+The re-ratification of v2 refused endorsement again (`ENDORSE: NO`): conditions **1, 2, 3 and 7
+NOT-CLOSED**, plus 5 new FATAL, 3 MAJOR and 1 MINOR. This revision is **targeted**: phases and text
+neither pass criticised are preserved verbatim.
+
+| Closure | What changed in this PLAN | Where |
+|---|---|---|
+| **A** — receipts cannot be dropped | **P2** no longer just "returns a `#[must_use]` receipt". `RetirementReceipt` becomes crate-private with no public constructor; `exit_process_locked` is `pub(crate)` with exactly **one** permitted caller; the single public `exit_process_and_retire(pid, code)` takes PM, drops the guard, then enqueues; the receipt's `Drop` re-enqueues instead of freeing. **All nine sites P2 must adapt are enumerated with their required restructuring, in three disjoint classes** *(v3 repair: nine is the count of ADAPTED sites — seven of them are `exit_process` callers; `985881a6` has seven, not nine. v3 tranche pass: class 1 = the seven callers, class 2 = the new SIGKILL arm — these eight call the wrapper — and class 3 = `handle_thread_exit`'s PM-nested enqueue, which routes its receipt through `phase1_result` and does **not** call the wrapper. The post-P2 exact sets are 8 / 1 / 3, not one set of nine)* — the four aarch64 fault sites, the two x86_64 fault sites, `process::exit_current`, `handle_thread_exit`, and the new SIGKILL arm | P2 (call-site table), P0 (ratchet + `RECEIPT_DROPPED_UNRETIRED`) |
+| **B** — exactly-once, really | **P6b** splits obligations into class A (effect commits in the SAME PM acquisition as `→ Completed`; `Claimed` never observable; T4 unreachable) and class B (`Fds` by single-slot row custody — *v3 repair:* the row's slot is the **sole owner** and the unlocked step gets a non-owning `CloseTicket`; `Report` by an effect-written marker with a stated winning side). **P6a** gains the **two-event join**: the row carries `reaped` and `retired`, whichever writer sees the other flag set removes the row in that same acquisition, **both orders gated nonzero** | P6a, P6b, P2 (seed) |
+| **C** — drain progress | **P1** adds a pass cursor (`last_pass` stamping — no candidate selected twice in one pass) and bounded retry (`K = 3` liveness-blocker refusals park the entry on a side list under a fence built from a **`RetirementSnapshot` taken at park time**, unparked by a three-armed disjunction — epoch / `ROW_REMOVAL_EPOCH` bump / age backstop of **64 scheduling epochs** summed over the captured mask; *v3 repair + v3 tranche pass*). Stated as an exclusion rule, **not** a cap | P1, P0 (park counters) |
+| **D** — wait-migration soundness | **P9** ships the **no-new-block admission interlock** inside all nine blocking primitives (latched request ⇒ refuse to block ⇒ `EINTR`), making the reachability classification a one-way door. **`BlockedOnSignal` (`pause`/`sigsuspend`) becomes its own subphase P10c**; the legacy-arm deletion moves to **P10d**. The missing hard edges are added to the graph | P9, P10a-d, §0 graph |
+| **E** — init group-kill hole | **P5** refuses `sys_clone` publication into the designated init's thread group (`EINVAL`, deliberate); **P12**'s drop check tests **designated-init membership of the whole target group**, not just the target row | P5, P12, P0 (ratchet on the single `thread_group_id` write site) |
+| **F** — SGI evidence attribution | `EXIT_SGI_SENT` moves off the two generic scheduler send sites onto a teardown-only `send_exit_expedite_sgi(victim_pid, batch)` introduced in P2, is **declared zero until P2** in P0, and is gated by **per-victim-PID pairing** with `EXIT_REQUEST_OBSERVED{pid}` plus a measured send→observe interval | P0 table, P2, P9 |
+| **G** — changelog honesty | Condition 7 is restated as its real content — *close 1-6 and obtain a NEW ratification pass before implementation* — and tracked as an open gate; the OQ-1 adoption is recorded separately as a coordinator decision | this changelog's cond-7 row, §2 |
+
+**Honest count change:** adding the omitted wait family makes the ledger **13 numbered phases /
+17 PRs** (was 16). The dependency graph, PR ledger, stop-point table and OQ-8 are updated together.
+
+### v3 repair — seven gaps closed against the v3 pre-check *(this revision; nothing else changed)*
+
+A pre-implementation check of v3 found two FATAL and five MAJOR defects **inside the v3 closures
+themselves**. Each is repaired in place and marked "v3 repair" at the point of change; no phase, gate
+or edge the check did not name has been touched, and **the ledger is still 13 phases / 17 PRs** — no
+repair adds or splits a PR.
+
+| # | Sev | Defect in v3 as written | Repair in this PLAN | Phases touched |
+|---|---|---|---|---|
+| 1 | **FATAL** | **`Fds` custody is impossible as specified.** `take_next_for_exit` had to *retain* the descriptor in the row's `fd_in_flight` slot (the recovery marker) **and** return that same value for an unlocked close. A slot cannot do both; cloning to satisfy both is exactly the second copy the "double close is unrepresentable" argument rests on not existing, and reopens double-close / endpoint-refcount corruption | The exit-close API becomes three calls: `begin_fd_close` **[PM]** takes into the row's slot (sole owner) and mints a **non-owning `CloseTicket`** (endpoint-handle clone, no close operation on the type); `endpoint_hangup` **[no lock]** does the only lock-needing step and is idempotent by CAS (a P7 obligation, gated); `finish_fd_close` **[PM]** drops the owning descriptor and clears the slot in one acquisition. The descriptor never leaves the row | **P7** (API), **P6b** (class-B bullet + gate 3) |
+| 2 | **FATAL** | **Report-marker phasing self-contradicts.** DESIGN §1.6 said P2 ships `claim_exit_slot`/`record_exit` "from day one"; P0 rule 5 and P6b keep `on_process_exit` intact until P6b. P2 would ship a class-B obligation *claiming* a recovery marker it does not have | This PLAN's sequencing holds and the design was corrected to it. **P2 ships the seed's shape (T1/T2/T3, never a bool) and no marker**, because **T4 does not exist until P6b** — P6a's join runs a vacuously-true ledger term and performs no recovery. Exactly-once at P2 rests on the sole-redeemer invariant; the single lost-report window equals `main`'s behaviour today and is declared. **P6b introduces T4 and the btrt split in the same PR** | **P2** (scope + new gate 4: `LEDGER_CLAIM_ORPHANED == 0`), **P6b**, **P0** rule 5 unchanged |
+| 3 | MAJOR | **P0's "exact nine `exit_process` callers" ratchet is false on `985881a6`** — a grep finds **seven**; `manager.rs:1152` and `process_task.rs:244` are `enqueue_process_reclaim` sites (one of them inside `exit_process`'s own body). The baseline ratchet could not pass | P0 rule 1 pins **seven** `exit_process` call sites; the two enqueue sites stay on the existing v2 `enqueue_process_reclaim` ratchet set and `signal.rs:162` on the `\.terminate\(` allowlist. "Nine" is restated as the count of sites **P2 adapts** (7 callers + 1 enqueue + the new SIGKILL arm), which is unchanged. Gate 6's broken variant becomes an **eighth** caller, plus a **third** enqueue site | **P0** (rule 1, gate 6), changelog closure-A row |
+| 4 | MAJOR | **P6a's two join gates are reversed.** The counter incremented in `reap()` is `{reap_second}` (retirement landed first); the one in `retire()` is `{retire_second}`. Prompt-reap-before-grace therefore drives `{retire_second}` and delayed-reap-after-retirement drives `{reap_second}` — the opposite of what the gates asserted, so neither could pass | Gates (f) and (g) swapped onto the counters the pseudocode actually increments, with the "who is second" reasoning written into each. Both still asserted nonzero in one run | **P6a** gates (f)/(g) |
+| 5 | MAJOR | **"`EXIT_BLOCK_REFUSED{family}` reaches zero post-migration" contradicts the permanent admission interlock** (and contradicts the same sentence's "not redundant after migration"): an already-latched victim must still be refused admission to a **migrated** family | The interlock is permanent; its counter is asserted **nonzero before and after** migration, and P9's admission-race test is re-run unchanged in each P10x. The migration evidence becomes the pair `EXIT_LEGACY_REMOTE_MARK{family}` → 0 and the **new** `EXIT_WAIT_CANCELLED{family}` → nonzero | **P0** counter table (+1 counter), **P9**, **P10a-d** |
+| 6 | MAJOR | **P12's group-membership drop is unscoped** — as written it drops *any* request whose target group contains init, including init's **own `exit_group`**, making the kernel-fatal panic path unreachable and inverting the policy | `ExitIntent` carries an explicit `origin`; the drop applies to **`Signal` only** (sender-agnostic — Linux-faithful, so init's self-`kill` is dropped too). `ExitSyscall` and `FatalFault` bypass the membership test entirely. Ratchet pins that `origin` is set at every construction site and tested explicitly | **P12** (scope bullet + new gate 4) |
+| 7 | MAJOR | **`parked_at` freshness unspecified and the unpark trigger incomplete.** Reusing the receipt's retirement fence makes the unpark predicate true at the instant of parking (step 1 only selects entries whose fence has elapsed) ⇒ immediate unpark ⇒ the livelock returns. And `blocked_live_row` can clear under PM with **no** scheduling-epoch advance anywhere, so an epoch-only unpark can strand an entry | `ParkRecord` captures a fence built from a **`RetirementSnapshot` taken AT PARK TIME** (`RECLAIM_PARK_IMMEDIATE_UNPARK` asserted 0, plus two negative gates). Unpark becomes a **three-armed disjunction** — epoch / `ROW_REMOVAL_EPOCH` bump (one relaxed increment inside the PM acquisition that already removes the row) / age backstop — swept at the head of every drain. The age arm only ever adds work, so it is not a cap. *(v3 tranche pass: "fresh" specified as a fresh **snapshot**, ruling out reuse of the cycle's earlier one; and the age backstop given its unit — `PARK_AGE_BACKSTOP_EPOCHS = 64` scheduling epochs summed over the captured mask, never wall time.)* | **P0** counter table, **P1** (cycle, bullet 2, gates 3 & 5, revert) |
+
+### v2 deltas against the first ratification's conditions *(retained)*
+
+The first Codex Sol ratification refused endorsement (`ENDORSE: NO`) with 2 FATAL seams, 7 MAJOR,
+1 MINOR and 7 conditions. Phase labels in this table are **v2 labels**: the wait families are now
+P10a/b/c/d, so "P10c empties the allowlist" reads **P10d** today, and "16 PRs" reads **17**.
 
 | Cond | What changed in this PLAN | Where |
 |---|---|---|
@@ -21,10 +126,20 @@ preserved verbatim.
 | **4** | **P8** now states the hook-activation control flow explicitly (the hook is the *only* entry to `do_exit_current`, so normal exit exercises it in this PR), plus the tombstone and one-at-a-time FD-acquisition control flow Codex's P8 note called for | P8 |
 | **5** | **P11** deletes `DeliverResult::Terminated` **and** its caller-side parent-notification action in the same PR, replacing it with intent-only `DeliverResult::FatalIntent` | P11 |
 | **6** | **P0** names every existing teardown write-site (file:line) each counter attaches to, marks which counters are legitimately zero until a later phase, and adds a **nonzero causally-paired** defer/reclaim test. The **honest PR count is 13 numbered phases / 16 PRs**, enumerated below. The false "P3/P4/P5 are file-disjoint from P2, so they can merge in parallel" claim is **deleted** — the file lists overlap and all phases merge sequentially | P0, §0 PR ledger, §0 graph |
-| **7** | **P12** implements the coordinator-adopted Linux-faithful protected-init policy: user-originated default-fatal signals to designated init with no handler are **silently dropped and the send returns 0**. All `EPERM` language and its test assertion are removed | P12 |
+| **7** | *(corrected in v3 — closure G)* The real condition 7 is **"close conditions 1-6 and obtain a NEW ratification pass before implementation begins"**. v2 mislabelled this row as the OQ-1 decision. It is **OPEN by construction** and is closed only when a fresh pass returns `ENDORSE: YES`. *(v3 tranche pass: the gate is now **tranche-scoped** — condition 7 is discharged per tranche, not once for the whole document. Tranche 1 (P0+P1+P2) is submitted; P0/P1/P2 are cleared for build when **that tranche's** pass returns `ENDORSE: YES`, and every later phase stays uncleared until its own tranche ratifies, with the DESIGN-DEBT REGISTER's rule gating any tranche that contains a debt owner. The condition itself is not weakened — it is applied more times, not fewer.)* | §2 ratification gate, **DESIGN-DEBT REGISTER** |
+
+**Coordinator decision recorded separately (NOT a ratification condition — closure G).** **P12**
+implements the coordinator-adopted Linux-faithful protected-init policy: user-originated default-fatal
+signals to the designated init with no handler are **silently dropped and the send returns 0**. All
+`EPERM` language and its test assertion are removed. *(P12.)*
 
 **Unchanged from v1:** the five phasing rules (with one refinement noted in rule 2), the standard gate,
 P3, P4, P5, P7 (except an honesty note), the merge discipline, and the round-level stop rule.
+
+**Unchanged from v2** (the re-ratification closed conditions 4, 5 and 6 and criticised nothing here):
+the phasing contract and standard gate, P3, P4, P7, P8's hook-activation control flow, P11's
+intent-only delivery, and P0's counter-to-write-site wiring except the one `EXIT_SGI_SENT` row that
+closure F re-wires.
 
 ---
 
@@ -51,30 +166,36 @@ class (r23: fixed 3, introduced 4).
 5. **One revert story per phase**, written in the PR body before merge, and the phase's code must
    actually be revertable alone (verified by `git revert` dry run on the merge commit).
 
-### The honest PR ledger — 13 numbered phases, **16 PRs** *(condition 6)*
+### The honest PR ledger — 13 numbered phases, **17 PRs** *(condition 6; updated by v3 closure D)*
 
-v1 claimed "13 phases / 13 PRs" while splitting P9 into three; the ratification counted 15 and called
-the contradiction a MAJOR. With P6 also split (condition 2) the true figure is **16 PRs**. Every one
-is listed; there are no others.
+v1 claimed "13 phases / 13 PRs" while splitting P9 into three; the first ratification counted 15 and
+called the contradiction a MAJOR. v2 said 16. Adding the wait family v2 omitted (`BlockedOnSignal`)
+as its own subphase makes the true figure **17 PRs**. Every one is listed; there are no others.
 
 | # | PR | Phase | Ceiling estimate |
 |---|---|---|---|
 | 1 | Teardown observability + call-site ratchet | P0 | ~200 lines / 3 files |
-| 2 | Retirement fence + RootProof taxonomy + drain restructure | P1 | ~190 lines / 5 files |
-| 3 | SPINE-1: SIGKILL stops eager-freeing (+ receipt-after-PM-drop) | P2 | ~210 lines / 5 files |
+| 2 | Retirement fence + RootProof taxonomy + drain restructure **+ pass cursor / park list** | P1 | ~210 lines / 5 files |
+| 3 | SPINE-1: SIGKILL stops eager-freeing **+ receipt custody across all 9 adapted sites** *(7 `exit_process` callers + 1 new SIGKILL arm + 1 PM-nested enqueue)* | P2 | ~230 lines / 5 files |
 | 4 | exec detach + clone/exec admission | P3 | ~150 lines / 4 files |
 | 5 | Kernel-stack ownership parity | P4 | ~150 lines / 5 files |
-| 6 | Runtime init designation (identity only) | P5 | ~180 lines / 5 files |
-| 7 | Reap/tombstone retention gate | **P6a** | ~170 lines / 5 files |
-| 8 | Exactly-once ledger (four-state obligations) | **P6b** | ~190 lines / 5 files |
+| 6 | Runtime init designation (identity only) **+ init-group clone refusal** | P5 | ~200 lines / 5 files |
+| 7 | Reap/tombstone retention gate **+ two-event join** | **P6a** | ~190 lines / 5 files |
+| 8 | Exactly-once ledger (class A/B obligations + effect markers) | **P6b** | ~210 lines / 5 files |
 | 9 | FD closure leaves the PM lock | P7 | ~160 lines / 5 files |
 | 10 | Victim-owned `do_exit_current` + boundary hook | P8 | ~220 lines / 5 files |
-| 11 | Request-only scheduler termination + group cutover | **P9** (was P10) | ~220 lines / 5 files |
+| 11 | Request-only scheduler termination + group cutover **+ no-new-block interlock** | **P9** (was P10) | ~230 lines / 5 files |
 | 12 | Killable wait: futex | **P10a** (was P9a) | ~150 lines / 4 files |
 | 13 | Killable wait: `WaitQueueHead` + stdin/TTY readers | **P10b** (was P9b) | ~150 lines / 4 files |
-| 14 | Killable wait: child-wait + timer/nanosleep + completion/I-O; **delete the legacy arm** | **P10c** (was P9c) | ~180 lines / 5 files |
-| 15 | Fatal-signal + fault convergence (intent-only delivery) | P11 | ~220 lines / 5 files |
-| 16 | Init death policy | P12 | ~120 lines / 4 files |
+| 14 | Killable wait: **`BlockedOnSignal` — `pause`/`sigsuspend`** *(NEW in v3 — closure D)* | **P10c** | ~170 lines / 4 files |
+| 15 | Killable wait: child-wait + timer/nanosleep + completion/I-O; **delete the legacy arm** | **P10d** (was P9c/P10c) | ~180 lines / 5 files |
+| 16 | Fatal-signal + fault convergence (intent-only delivery) | P11 | ~220 lines / 5 files |
+| 17 | Init death policy **+ group-membership drop check** | P12 | ~140 lines / 4 files |
+
+> **Ceiling honesty (rule 4).** Five PRs now sit at or within ~10 lines of the ~230-line ceiling
+> (P1, P2, P6a, P6b, P9). Each states its named split seam in its own section; crossing the ceiling
+> means splitting at that seam **before** review, which would make the count 18-22 rather than 17.
+> That is the price of the closures and it is stated up front rather than discovered at review.
 
 ### Standard gate — run on EVERY phase, no exceptions
 
@@ -93,8 +214,10 @@ is listed; there are no others.
    until a named later phase.
 4. **Parallels launcher streak:** 10 consecutive PASS with `inject_retries=0`, ≤15 attempts, fresh
    epoch-named VM via `./run.sh --parallels`, `prlctl stop --kill` after each.
-5. **Soak** on any phase that changes kill timing or retention (2, 6a, 6b, 7, 8, 9, 10c, 11): 30-min
-   minimum, plus the retention measurement where noted.
+5. **Soak** on any phase that changes kill timing or retention (2, 6a, 6b, 7, 8, 9, 10d, 11): 30-min
+   minimum, plus the retention measurement where noted. *(v3: 10c — the `BlockedOnSignal` family — does
+   not change retention, but it does change kill timing for `pause`/`sigsuspend`, so it takes the soak
+   too; the list reads 2, 6a, 6b, 7, 8, 9, 10c, 10d, 11.)*
 6. **Frozen-region hash gate:** all six gold-master regions byte-identical vs `main`; all five Tier-1
    files byte-identical unless OQ-4 has been granted in writing.
 7. **Cleanup:** all Parallels VMs stopped, all stray QEMU killed, before reporting the phase done.
@@ -125,6 +248,16 @@ P4  ──> P8, P9                          (all stacks scheduler-owned before a
                                          request-only termination)
 
 P5  ──> P12                             (identity before policy — never bundled)
+    ──> P9    *** NEW (closure E) ***    (P9 makes fatal signals THREAD-GROUP scoped. Today a kill
+                                         aimed at a CLONE_VM sibling kills only that row; from P9 it
+                                         seals and kills the whole group. If the designated init
+                                         could be in that group, P9 would introduce a way to kill
+                                         init that main does not have — a regression, which rule 1
+                                         forbids. P5's clone-admission refusal makes an init sibling
+                                         unconstructible BEFORE the group scope exists, so P9 is
+                                         strictly better than main at every commit. P12's
+                                         group-membership drop check is the second end, not the
+                                         first)
 
 P6a ──> P6b   *** NEW ***               (row must outlive obligations before Resources becomes
                                          row-resident — DESIGN §1.6)
@@ -137,16 +270,38 @@ P8  ──> P9                              (the hook + do_exit_current are what
                                          resolves to)
     ──> P12                             (init's own exit commit is a latch producer)
 
-P9  ──> P10a, P10b, P10c   *** REORDERED ***
-                                        (every wait-family PR consumes the request/wake mechanism;
-                                         v1 had this edge backwards)
+P9  ──> P10a, P10b, P10c, P10d   *** REORDERED (v2) ***
+                                        (every wait-family PR consumes the request/wake mechanism
+                                         AND the no-new-block interlock P9 ships; v1 had this
+                                         edge backwards)
     ──> P11                             (the terminate() allowlist cannot reach empty until SIGKILL
                                          has left the exit_process/terminate route)
 
-P10c ──> (no successor is blocked; it is the completion point for #491 and AC-11)
+P10a ──> P10d   *** MISSING IN v2 ***   (P10d deletes exit_request_is_boundary_reachable()'s legacy
+P10b ──> P10d   *** MISSING IN v2 ***    arm and asserts the allowlist EMPTY as an exact set; it
+P10c ──> P10d   *** NEW (closure D) ***  cannot do that until futex, WaitQueueHead/stdin/TTY and
+                                         BlockedOnSignal have each left the allowlist. Deleting the
+                                         arm with any family still on it would strand that family
+                                         with a published request and no producer — the exact defect
+                                         condition 1 exists to prevent)
+
+P10d ──> P11    *** MISSING IN v2 ***   (P11 deletes Process::terminate; the legacy arm is one of its
+                                         live callers, so the arm must be gone first. v2's graph let
+                                         P11 precede P10c, which would have deleted a function the
+                                         fallback still calls)
+     ──> (otherwise no successor is blocked; P10d is the completion point for #491 and AC-11)
 
 P11 ──> P12                             (the unhandleable-fault latch producer lives here)
 ```
+
+> **The three edges the re-ratification required are present, under v3's labels.** The refusal named
+> them as `P10a → P10c`, `P10b → P10c`, `P10c → P11`, using v2's labels in which P10c was the
+> *deleting* subphase. Closure D inserts `BlockedOnSignal` as P10c and moves the deletion to **P10d**,
+> so the required edges are written above as `P10a → P10d`, `P10b → P10d`, `P10d → P11` — the same
+> three constraints ("every migration precedes the deletion" and "the deletion precedes
+> `Process::terminate`'s removal") — plus the fourth edge the new family creates, `P10c → P10d`, and
+> a fifth the re-ratification did not name, `P5 → P9` (closure E). No edge was dropped in the
+> relabel: **five arrows are added and none removed.**
 
 **No parallel-merge path is claimed.** *(condition 6 — v1's "P3, P4, P5 can run in parallel with P2
 (disjoint files)" was false and is deleted.)* The production file lists overlap materially:
@@ -176,16 +331,25 @@ the *exact current* bypass surface so any regression fails CI immediately.
 | `TEARDOWN_ENTRY{group}` | *(no group path exists on `main`)* | **declared zero until P9** — not part of any equality gate before then |
 | `EXIT_FIRST_REQUESTS` / `EXIT_REPEAT_REQUESTS` | the `already_terminated` reads at `process/manager.rs:1121` and `task/process_task.rs:222`, plus `Process::terminate_minimal`'s repeat early-return (`process/process.rs:320`) | yes (first); repeat is exercised by the P0 repeat test |
 | `TEARDOWN_QUARANTINE` | `task/scheduler.rs:2599 terminate_process_threads` (five call sites: `exception.rs:768,1135,1230,1333`, and `signal.rs` from P2) | yes under the fault tests |
-| `EXIT_SGI_SENT` | the `SGI_RESCHEDULE` sends at `task/scheduler.rs:1857` and `:1886` | yes |
+| `EXIT_SGI_SENT` *(re-wired in v3 — closure F)* | **NOT** the generic sends. `task/scheduler.rs:1857` is inside `send_resched_ipi` (`:1843`), which wakes **idle** CPUs, and `:1886` is inside `send_resched_ipi_to_cpu` (`:1868`), which targets the CPU that got a **newly runnable task** — neither knows a victim, so wiring them makes every ordinary wakeup satisfy a "> 0" gate. The counter is written **only** by the teardown-specific `Scheduler::send_exit_expedite_sgi(victim_pid, batch)` that P2 introduces, carrying the victim pid in the `trace_event!` payload | **declared zero until P2** — the write site does not exist before then; excluded from every gate until P2 |
+| `EXIT_REQUEST_OBSERVED` *(new, closure F)* | the boundary hook's first observation of a latched request, carrying the observed pid — i.e. the paired consumer side of `EXIT_SGI_SENT{pid}` **from P8 onward** | **declared zero until P8** (the hook does not exist before then). P2 and P9 pair against the **`EXIT_KICK` bucket proxy** specified in DESIGN §2.7 — *not* against this counter, and not against an unnamed "P2-era proxy" *(v3 tranche pass: the proxy is now a specified mechanism; the earlier wording pointed at gates that pointed back at it)* |
+| `EXIT_KICK_PUBLISHED{bucket}`, `EXIT_KICK_OBSERVED{pid}`, `EXIT_KICK_BUCKET_COLLISION` *(new, v3 tranche pass — closure F's P2-era observation half)* | the `[KickSlot; 64]` table in this provider (`KickSlot { pid, at, seq }`, three atomics). **Publish:** the teardown-only `Scheduler::send_exit_expedite_sgi(victim_pid, batch)` — `pid`/`at` Relaxed, then `seq.fetch_add(2, Release)`; the only publish site, ratcheted. **Observe:** the peer scheduler pass that declines to dispatch a quarantined victim — acquire-load `seq`, match `pid`, `compare_exchange(seq, seq\|1)`; the single winner records `EXIT_KICK_OBSERVED{pid}` with the interval `now - at`. No lock, no allocation, no per-thread field | **declared zero until P2** (the table and the helper do not exist before then); **deleted in P8**, in the same PR that introduces the boundary hook and `EXIT_REQUEST_OBSERVED{pid}` — the round never carries two observation mechanisms past the phase that unifies them. Residual R-21 |
 | `TEARDOWN_DEFER` | `task/process_task.rs:129 defer_process_resources` (reached from `:125 defer_live_process_resources` and `process/manager.rs:1151`) | **yes** — every aarch64 exit |
-| `TEARDOWN_RECLAIM` | `task/process_task.rs:388` (`reclaim.reclaim()` inside `reclaim_deferred_process_resources`, `:375`) | **yes** |
+| `TEARDOWN_RECLAIM` | `task/process_task.rs:387` (`reclaim.reclaim()` inside `reclaim_deferred_process_resources`, `:375-391`) *(v3: line corrected from `:388`)* | **yes** |
 | `TEARDOWN_MASKED_FRAMES_WALKED` | `task/process_task.rs:100 release_process_resources` → `cleanup_cow_frames()`, incremented only when the PM-owner instrumentation says a PM guard is live (call sites `manager.rs:1156`, `process_task.rs:247`, `:250`) | yes on `main` (that is the defect P2/P7/P11 drive to 0) |
-| `FD_CLOSES_UNDER_PM` | `process/process.rs:347 close_all_fds` reached under PM via `Process::terminate` (`:284`, `:294`) from `manager.rs:1161`, `signal.rs:162`, `delivery.rs:224`, `:258`, `interrupts/context_switch.rs:1021`; plus `take_fd_entries` (`process.rs:335`) at `process_task.rs:236` | yes on `main` (driven to 0 by P7) |
+| `FD_CLOSES_UNDER_PM` | `process/process.rs:347 close_all_fds` reached under PM via `Process::terminate` (`:284`, `:294`) from `manager.rs:1161`, `signal.rs:162`, `delivery.rs:224`, `:258`, `interrupts/context_switch.rs:1021`; plus `take_fd_entries` (`process.rs:335`) at `process_task.rs:233` *(v3: corrected from `:236`)* | yes on `main` (driven to 0 by P7) |
 | `TEARDOWN_VICTIM_DIVERGENCE` / `TEARDOWN_CR3_MISS` | `process/manager.rs:1313-1335 find_process_by_cr3_mut` vs the TID-derived owner at the four EL0 sites | zero on a clean boot; **driven nonzero by the P11 `clonevm_fault_test`**, declared until then |
 | `EXIT_ATTRIBUTION_UNCERTAIN` | the total-resolution-failure branch at the four EL0 sites | declared zero until injected |
 | `DEFERRED_FAULT_RING_DROPPED` | `task/process_task.rs:43` — `DeferredFaultExitBuffer::push` returning `false` (caller `defer_fault_sigsegv_exit`, `:352`) | zero normally; **P0 ships a 17-deep injection that drives it nonzero**, proving the counter is real (#492's overflow is invisible today) |
 | `RECLAIM_ENQUEUE_UNDER_PM` *(new, cond. 3)* | `task/process_task.rs:140 enqueue_process_reclaim`, incremented when the PM-owner instrumentation says PM is live — true today at **both** call sites (`manager.rs:1152`, `process_task.rs:244`) | **yes on `main`** — this is the pre-existing violation P2 drives to 0 |
-| `PROOF_UNDER_QUEUE_LOCK` *(new, cond. 3)* | `task/process_task.rs:375-392`, incremented if SCHEDULER or PM is acquired while `PENDING_PROCESS_RECLAIMS` is held | zero on `main` (both predicates are lock-free); P1 must keep it zero |
+| `PROOF_UNDER_QUEUE_LOCK` *(new, cond. 3)* | `task/process_task.rs:375-391` *(v3: span corrected)*, incremented if SCHEDULER or PM is acquired while `PENDING_PROCESS_RECLAIMS` is held | zero on `main` (both predicates are lock-free); P1 must keep it zero |
+| `RECEIPT_DROPPED_UNRETIRED` *(new, closure A)* | `RetirementReceipt::drop` — the self-healing destructor that re-enqueues instead of freeing | **declared zero until P2** (the type does not exist before then); asserted 0 from P2 onward |
+| `RECLAIM_PASS_SKIPPED`, `RECLAIM_PARKED`, `RECLAIM_UNPARKED{epoch\|row\|age}`, `RECLAIM_PARK_IMMEDIATE_UNPARK`, `RECLAIM_PARK_RESIDENT` *(new, closure C; split + immediate-unpark counter added by the v3 repair)* | the drain's pass-stamp check and the park/unpark transitions in `task/process_task.rs:375-391`; the `{row}` arm additionally keys on the global `ROW_REMOVAL_EPOCH` bumped by one relaxed increment inside `ProcessManager::remove_process` (`manager.rs:1102-1104`, and P6a's `remove_row`); the `{age}` arm keys on `PARK_AGE_BACKSTOP_EPOCHS = 64` **scheduling epochs** summed over `fence_at_park.online_mask` (no wall clock, no timestamp field) | **declared zero until P1** (the fields do not exist before then); P1 drives `RECLAIM_PASS_SKIPPED`/`RECLAIM_PARKED` and **each of the three `RECLAIM_UNPARKED` arms** nonzero, asserts `RECLAIM_PARK_IMMEDIATE_UNPARK == 0`, and asserts the gauge returns to 0 at quiesce having been observably nonzero mid-run |
+| `LEDGER_EFFECT_AMBIGUOUS{report}` *(new, closure B)* | T4's ruling branch when `report_marker.started == 1 && finished == 0` | **declared zero until P6b**; asserted 0 on every healthy boot, driven to a known value only by deliberate injection |
+| `TOMBSTONE_JOIN{reap_second}`, `TOMBSTONE_JOIN{retire_second}` *(new, closure B)* | the two removal branches of the two-event join in `ProcessManager` | **declared zero until P6a**; P6b asserts **both** nonzero in one run |
+| `EXIT_BLOCK_REFUSED{family}` *(new, closure D)* | the pre-block interlock inside the nine blocking primitives: `task/scheduler.rs:1726`, `:1897`, `:1916`, `:2065`, `:2153`, `:2218`, `:2227`, `:2386`, and `task/waitqueue.rs:52` | **declared zero until P9**; P9 drives it nonzero and **each P10x re-asserts its own family's value is still nonzero** — *v3 repair:* the interlock is permanent, so this counter never reaches 0; what falls to 0 per family is `EXIT_LEGACY_REMOTE_MARK{family}` |
+| `EXIT_WAIT_CANCELLED{family}` *(new, v3 repair)* | the migrated family's own cancellation path — a victim found **already blocked** in this family at request time and cancelled by its own resumed continuation. This is the counter that actually rises at migration, and it is the partner of `EXIT_LEGACY_REMOTE_MARK{family}` falling | **declared zero until P10a**; each P10x drives its own family's value nonzero |
+| `INIT_FATAL_SIGNAL_DROPPED`, `INIT_FATAL_SIGNAL_DROPPED{group}` *(the group variant new, closure E)* | the disposition-time drop in `syscall/signal.rs` and S1's group-membership check | **declared zero until P12** |
 | `RECLAIM_CONTEXT_VIOLATIONS`, `TEARDOWN_LOCK_ORDER_SUSPECT` | the lock-depth/owner instrumentation, **including `try_manager()`** (the r20 detector blind spot) | zero; asserted |
 
 Ratchet (`tests/teardown_structure.rs`) asserts the exact current sets of: `\.terminate\(` /
@@ -194,8 +358,72 @@ Ratchet (`tests/teardown_structure.rs`) asserts the exact current sets of: `\.te
 `kernel_stack_allocation` mutation sites; **`enqueue_process_reclaim` call sites** (v2). It passes on
 `main` unchanged; later phases shrink the allowlists, and any *new* bypass fails on arrival.
 
+**v3 adds five ratchet rules**, each pinning a set that a lettered closure depends on being exactly
+what it is today:
+
+1. *(closure A; **corrected by the v3 repair**)* **`exit_process` call sites — the exact SEVEN.**
+   Pinned by name at `arch_impl/aarch64/exception.rs:778`, `:1146`, `:1233`, `:1336`;
+   `interrupts.rs:1429`, `:1735`; `process/mod.rs:264`.
+   > **Why seven and not nine.** v3 as first written pinned "the exact nine" and listed those seven
+   > plus `process/manager.rs:1152` and `task/process_task.rs:244`. Those two are
+   > **`enqueue_process_reclaim` call sites, not `exit_process` callers** — `manager.rs:1152` is
+   > *inside* `exit_process`'s own body and `process_task.rs:244` is inside `handle_thread_exit`.
+   > A ratchet asserting nine `exit_process` call sites therefore **cannot pass on `985881a6`**,
+   > where a grep finds seven. The two enqueue sites are already pinned by the v2 rule above
+   > (`enqueue_process_reclaim` call sites — exactly two, both PM-nested), which is where they
+   > belong; and `syscall/signal.rs:162` is pinned by the `\.terminate\(` allowlist. **"Nine" is,
+   > and always was, the count of sites P2 *adapts*** — seven `exit_process` callers + one PM-nested
+   > enqueue + the SIGKILL arm P2 itself introduces — and that count is unchanged in P2's table.
+
+   From P2 the rule inverts into **three separate exact sets** *(v3 tranche pass — one set cannot
+   express three different shapes, and the single-set version could not pass)*:
+
+   | Post-P2 exact set | Value | Members |
+   |---|---|---|
+   | `exit_process_and_retire` call sites | **8** | the seven pinned class-1 sites above, each now naming the wrapper, **plus** `syscall/signal.rs`'s new SIGKILL arm |
+   | `exit_process_locked` call sites | **1** | the wrapper, and nothing else |
+   | `enqueue_process_reclaim` call sites | **3** | the wrapper's post-guard enqueue, `handle_thread_exit` phase 2, and `RetirementReceipt::drop`'s re-enqueue — all three provably PM-free; `manager.rs:1152` is deleted. *(The pre-P2 baseline pinned by the v2 rule is **2**; P2's diff is what moves it.)* |
+
+   Plus: `RetirementReceipt` must have **zero** `pub fn new`/`pub` constructors and must not be
+   nameable outside the crate; and `ProcessManager::exit_process` must have **zero** call sites in the
+   public surface.
+
+   > **`handle_thread_exit` is an adapted site that does NOT call the wrapper.** It owns its own PM
+   > guard and its own two-phase shape; its receipt rides out of phase 1 through the existing
+   > `phase1_result` value and is enqueued in phase 2. Any gate phrased as "all nine now call
+   > `exit_process_and_retire`" is therefore unsatisfiable by construction, and no gate in these
+   > documents is phrased that way. DESIGN §1.7 carries the same three-class table; the two documents
+   > state it identically or one of them is wrong.
+
+2. *(closure D)* **The blocking-primitive set — the exact nine** listed in the counter table above.
+   A tenth blocking primitive added without the interlock fails CI on arrival, which is what keeps
+   the reachability predicate total after P9.
+
+   > ⚠ **DEBT-3 — this rule is written against an inventory that is not closed.**
+   > `syscall/futex.rs:115` (direct `ThreadState::Blocked` publish) and
+   > `task/scheduler.rs:2175-2194` (I/O blocking via an unlisted primitive) are outside the nine.
+   > **P9 owns the closure**, and P9's tranche cannot ratify until this rule is restated to the
+   > corrected inventory. P0 may still ship the rule as-is — it is a ratchet on today's set and
+   > shipping it does not make the gap worse — but it must not be read as evidence the set is
+   > complete. See the DESIGN-DEBT REGISTER.
+
+3. *(closure E)* **`thread_group_id = Some(` production write sites — exactly one**
+   (`syscall/clone.rs:210`). A second one would reopen the init-sibling bypass silently.
+4. *(closure F; extended by the v3 tranche pass)* **`EXIT_SGI_SENT` appears at exactly one source
+   location**, and neither `send_resched_ipi` nor `send_resched_ipi_to_cpu` may reference it. **The
+   `EXIT_KICK` table's publish side is pinned the same way**: `EXIT_KICK_PUBLISHED` and the
+   `seq.fetch_add` that publishes a slot appear at **exactly one** source location — inside
+   `send_exit_expedite_sgi` — so the observation gate can never be satisfied by a second publisher
+   wired somewhere convenient. The consume side (`compare_exchange` on `seq`) is likewise pinned to
+   the one scheduler site that declines to dispatch a quarantined victim.
+5. *(closure B)* **`btrt::on_process_exit` has exactly one call site** (`task/process_task.rs:267`),
+   pinned before P6b splits it into `claim_exit_slot` + `record_exit`; after P6b, `record_exit` must
+   have exactly one call site and `claim_exit_slot` must not appear outside a PM-guarded body.
+
 **Files.** `kernel/src/tracing/providers/teardown.rs` (new), tracing registration,
-`tests/teardown_structure.rs` (new). **~200 lines, 2 commits.**
+`tests/teardown_structure.rs` (new). **~200 lines, 2 commits.** *(v3: the added counters are
+declarations in the same new provider file and the added ratchet rules are assertions in the same new
+test file, so the file count does not grow.)*
 
 **Gate extras.** *(v2 — condition 6: no vacuous zero-baseline gate.)*
 1. **`fork_exit_defer_reclaim_pairing_test` (the causally-paired nonzero gate).** Fork and exit **64**
@@ -210,10 +438,23 @@ Ratchet (`tests/teardown_structure.rs`) asserts the exact current sets of: `\.te
    defects later phases drive to zero; recording the baseline is what makes those later gates meaningful.
 4. `TEARDOWN_LOCK_ORDER_SUSPECT == 0`, `PROOF_UNDER_QUEUE_LOCK == 0`, and every counter has a reader
    (no write-only counters).
+5. *(v3 — closure F)* **A negative assertion that `EXIT_SGI_SENT` is zero on a normal boot**, proving
+   it is not wired to the generic send helpers. A boot performs many reschedule IPIs; if the counter
+   moves at P0, the wiring is wrong and the phase fails. This is the inverse of a vacuous-zero gate:
+   the zero is the *evidence*, and it is explained by a named workload (every boot sends reschedule
+   IPIs) rather than by absence of activity.
+6. *(v3 — closures A, D, E)* The five new ratchet rules pass on `main` unchanged, and each is proven
+   to be a real constraint by a deliberately-broken variant in the test: adding a tenth blocking
+   primitive, a second `thread_group_id` write, an **eighth** `exit_process` caller *(v3 repair — the
+   pinned set is seven, not nine)*, a **third** `enqueue_process_reclaim` call site, or an
+   `EXIT_SGI_SENT` reference inside `send_resched_ipi` must each fail the ratchet.
 
 **Strictly better.** Every later phase's evidence becomes a counter equality instead of a log-reading
 exercise, and the bypass surface can only shrink. #492's silent drops become visible, and two
-pre-existing lock violations become measurable before anyone tries to fix them.
+pre-existing lock violations become measurable before anyone tries to fix them. *(v3: the complete
+`exit_process` caller set, the complete blocking-primitive set and the single `thread_group_id` write
+site are pinned **before** any phase depends on them, so the three structural closures A, D and E
+cannot be quietly undermined by an unrelated PR landing between phases.)*
 
 **Revert.** Delete two files + their registration. Zero coupling.
 
@@ -231,7 +472,7 @@ scheduler cached roots, live/creating rows — each with its own counter. Adapt 
 users. Grace is still checked **first**.
 
 > **v2 (condition 3) — the drain is restructured so no proof ever runs under the reclaim-queue lock.**
-> `reclaim_deferred_process_resources` (`task/process_task.rs:375-392`) currently evaluates
+> `reclaim_deferred_process_resources` (`task/process_task.rs:375-391`) currently evaluates
 > `retirement_grace_elapsed(&reclaim.after_epoch) && !reclaim.root_is_live()` **while holding**
 > `PENDING_PROCESS_RECLAIMS`. Both terms are lock-free atomic reads today, so `main` is legal — but
 > `RootProof` adds *scheduler cached roots* and *live rows*, which take SCHEDULER and PM. Acquiring
@@ -239,23 +480,116 @@ users. Grace is still checked **first**.
 > until P8" is not an exemption. P1 therefore ships the cycle as:
 >
 > ```
-> 1. QUEUE LOCK ONLY:  scan for a candidate whose fence has elapsed AND whose
->                      lock-free blockers (hardware/shadow) are clear; swap_remove it
->                      into a local fixed slot.                        -> DROP QUEUE LOCK
+> -1. UNPARK SWEEP first (parked-list lock alone): return to the live queue every parked
+>     entry satisfying ANY of the three arms — epoch / ROW_REMOVAL_EPOCH bump / age
+>     backstop.                                                (v3 repair, closure C)
+> 0. bump PASS_ID once per drain invocation.                            (v3, closure C)
+> 1. QUEUE LOCK ONLY:  scan for a candidate whose last_pass != PASS_ID, whose fence has
+>                      elapsed, AND whose lock-free blockers (hardware/shadow) are clear;
+>                      stamp last_pass = PASS_ID; swap_remove it into a local fixed slot.
+>                      No candidate -> the pass is DONE.               -> DROP QUEUE LOCK
 > 2. NO LOCK:          RetirementSnapshot (acquire fence) + hardware/shadow re-read.
 > 3. SCHEDULER ONLY:   cached-root blocker.                            -> DROP
 > 4. PM ONLY:          live/creating-row blocker.                      -> DROP
 > 5. proof passed  -> free with NO lock held.
->    proof refused -> bump that blocker's counter, re-acquire the QUEUE LOCK ALONE,
->                     re-insert, rotate.
+>    proof refused -> bump that blocker's counter; if the blocker was a LIVENESS one
+>                     (cached-root or live-row) increment proof_failures, else leave it;
+>                     if proof_failures == K (3): PARKED LIST LOCK ALONE -> take a NEW
+>                     RetirementSnapshot AT THIS INSTANT and park with a ParkRecord holding
+>                     the fence derived from it (never the receipt's own after_epoch, which
+>                     step 1 already proved elapsed; and never step 2's snapshot, which
+>                     predates the three refusals), the current ROW_REMOVAL_EPOCH, and
+>                     age_epoch_sum_at_park = sum of that fence's epochs over its own
+>                     online_mask;                     (v3 repair + v3 tranche pass)
+>                     otherwise QUEUE LOCK ALONE ->
+>                     re-insert (still stamped, so this pass will not re-select it).
 > ```
 >
 > The under-queue-lock predicate is permanently restricted to lock-free reads; `PROOF_UNDER_QUEUE_LOCK`
-> (P0) asserts it. A candidate detached and then refused is re-inserted, never dropped — the
-> re-insertion path is part of this PR's tests, not a later phase's.
+> (P0) asserts it. A candidate detached and then refused is re-inserted or parked, never dropped — the
+> re-insertion and park/unpark paths are part of this PR's tests, not a later phase's.
+
+> **v3 (closure C) — the refusal path is given a progress argument, because v2's had none.** The
+> re-ratification's third FATAL: v2 said a refused candidate is "re-inserted and rotated", but there
+> is no rotation in the live code — the scan is `position()` from index 0 over the whole vector
+> (`task/process_task.rs:379-383`) and the drain loops until no candidate is found. A receipt whose
+> epoch and shadow checks pass but whose live-row blocker persists is therefore re-selected
+> immediately and forever: a single-entry livelock in the first behaviour-preserving phase, which
+> would have been shipped as "hardening". Two fields on `PendingProcessReclaim` fix it:
+>
+> - **`last_pass: u32` — a pass cursor.** The drain bumps a monotonic pass id once per invocation and
+>   stamps every entry it selects. The under-lock scan skips entries already stamped with the current
+>   pass. **No candidate can be selected twice in one pass**, so a pass terminates in at most *queue
+>   length* selections regardless of what the proofs say. Counted `RECLAIM_PASS_SKIPPED`.
+> - **`proof_failures: u8` + `parked: Option<ParkRecord>` — bounded retry, then park.** After
+>   `K = 3` consecutive refusals attributable to a **liveness** blocker (`blocked_cached` or
+>   `blocked_live_row` — the only two whose answer can change without time passing), the entry moves
+>   to a side list `PARKED_PROCESS_RECLAIMS` and is **not scanned at all** until unparked.
+>   Grace/hardware/shadow refusals do **not** increment `proof_failures`: those clear with time, and
+>   re-checking them is the drain's whole job. Counted `RECLAIM_PARKED` /
+>   `RECLAIM_UNPARKED{epoch|row|age}`, gauge `RECLAIM_PARK_RESIDENT`.
+>
+> **v3 repair — the park rule as first written had two defects, and both would have been shipped.**
+>
+> **(i) `parked_at` was never said to be fresh, and reusing the retirement fence makes the park
+> inert.** The cycle said "park with `parked_at` = the captured fence" and DESIGN §1.8 said "the
+> fence captured at parking" — both readable as reusing `reclaim.after_epoch`. That fence is, by
+> construction, **already elapsed**: step 1 will not even select an entry whose fence has not
+> elapsed. An unpark predicate keyed on it is true at the instant of parking, so the entry unparks on
+> the very next sweep and the livelock returns with two extra counter bumps per cycle. The park
+> therefore takes a **NEW `RetirementSnapshot` at the parking instant** and stores the fence derived
+> from it — new acquire-fenced epoch read, new online mask — inside `ParkRecord` (DESIGN §1.4).
+> *(v3 tranche pass: "fresh" is specified as a fresh **snapshot**, because there are two wrong
+> implementations and both are "a fence" — reusing `reclaim.after_epoch`, and reusing the
+> `RetirementSnapshot` step 2 of this same cycle already took. Step 2's snapshot predates the three
+> refusals that caused the park, so a fence built from it is stale by exactly the interval that
+> matters, and gate 5 below would pass against it while the park stayed near-inert.)* Gated by
+> `RECLAIM_PARK_IMMEDIATE_UNPARK == 0`: a parked entry that unparks in the same drain invocation that
+> parked it is a bug, not a race.
+>
+> **(ii) An all-CPU epoch advance is NOT "the one event that can change a liveness blocker's
+> answer" — that is false for `blocked_live_row`.** A live row is PM-owned and disappears when the
+> reap/retire join (P6a) or today's `remove_process` removes it. That can happen on another CPU with
+> **no scheduling-epoch advance anywhere** — a parent calling `waitpid` while every CPU in the
+> captured mask sits in WFI — so an epoch-only unpark can wait for an event that never arrives.
+> Unpark becomes a **disjunction of three arms**, any one of which returns the entry to the live
+> queue for a full re-proof:
+>
+> | Arm | Fires when | Clears |
+> |---|---|---|
+> | **epoch** | a `RetirementSnapshot` shows every CPU in `fence_at_park`'s captured online mask advanced its scheduling epoch | `blocked_cached` |
+> | **row** | the global `ROW_REMOVAL_EPOCH` differs from `row_epoch_at_park`. Bumped by **one relaxed increment** inside the PM acquisition that already performs the row removal — no extra lock, no list walk, no knowledge of the parked list, so no ordering is inverted; the sweep reads it with no lock held | `blocked_live_row` |
+> | **age** | the epochs of the CPUs in `fence_at_park.online_mask`, **summed**, have advanced by at least `PARK_AGE_BACKSTOP_EPOCHS = 64` since `age_epoch_sum_at_park` | *nothing specific* — a safety net so a parked entry is **always** eventually re-proved even if both keyed arms are missed |
+>
+> **The age backstop's unit: 64 SCHEDULING EPOCHS, summed over the captured mask — never wall time**
+> *(v3 tranche pass; the pre-check's residual MINOR was that gate 3(c) required completion "within the
+> stated backstop" while no backstop was ever stated)*. The sweep re-reads the same epoch words the
+> park captured, sums them over the *same* captured mask, and fires at `sum_now - age_epoch_sum_at_park
+> >= 64`. It needs no extra state (the key is derived from `fence_at_park`, so `ParkRecord` carries no
+> timestamp), it is strictly weaker than the `epoch` arm (which needs *every* captured CPU to advance,
+> where this accepts 64 advances anywhere in the mask), and it cannot be starved on this kernel — the
+> 1 kHz tick drives a scheduler pass on every online CPU including the idle loop, so the sum is
+> monotone and unbounded above. *(Informative, and deliberately not the definition: ~tens of ms at 4
+> online CPUs. No gate is written against a millisecond figure.)*
+>
+> The sweep runs at the **head of every drain invocation** (step -1 above), fork's pre-allocation
+> drain included, so a row removal is followed by a sweep at the next drain rather than needing one
+> of its own. **The age arm is not a cap:** it only ever *adds* work — it makes a parked entry
+> eligible again and never stops examining, skips or drops anything — which is what makes R-20 a
+> bounded stall rather than a possibly-permanent one.
+>
+> **This is an exclusion rule, not a cap — stated explicitly because three bounded drains were
+> reverted in r23 and phasing rule 1 forbids reintroducing that class.** A cap stops examining
+> entries that are *ready*; this stops **re-examining an entry already examined in this pass** and
+> defers entries whose blocker provably cannot have changed. Fork's pre-allocation drain keeps full
+> semantics — an unpark sweep followed by one complete pass over every live entry — and **no cap
+> parameter is introduced anywhere in this PR**. The parked list is a leaf lock taken alone, never
+> with PM, SCHEDULER or the live queue held (DESIGN §4.3).
 
 **Files.** `kernel/src/task/scheduler.rs`, `kernel/src/task/process_task.rs`,
-`kernel/src/arch_impl/aarch64/ttbr0.rs`, tracing provider, targeted tests. **~190 lines, 2 commits.**
+`kernel/src/arch_impl/aarch64/ttbr0.rs`, tracing provider, targeted tests. **~210 lines, 3 commits —
+near the ceiling; the named split seam is {fence + RootProof taxonomy} / {drain restructure + pass
+cursor + park list}.**
 
 **Gate extras.** Unit injection with a zero online mask refuses reclaim; wrap-safe epoch comparison
 test; the existing epoch-before-stack-liveness ordering becomes a structural test; every refusal in a
@@ -264,13 +598,62 @@ richer proof live; a forced refusal at each of the four blocker classes proves t
 cycle preserves the entry (queue length returns to its prior value, the same receipt is retried and
 eventually retires) — asserted at a **nonzero** refusal count, not at zero.
 
+**v3 gate extras (closure C) — the livelock must be shown to be impossible, not merely unlikely:**
+1. **Bounded-pass assertion.** Instrument the drain to record selections per invocation and assert
+   `selections <= queue_length_at_pass_start` over a workload that forces refusals. Before the
+   cursor this assertion fails by construction (the same entry is selected repeatedly); the PR body
+   records that pre-image, so the test is proven to be a real test rather than a tautology.
+2. **The exact livelock scenario, replayed.** Inject one receipt whose epoch and shadow blockers
+   clear immediately but whose `blocked_live_row` persists. Assert: `RECLAIM_PASS_SKIPPED > 0`, the
+   drain **returns** (does not spin), `RECLAIM_PARKED == 1` after the third refusal, and no other
+   ready receipt is starved — a second receipt enqueued behind it retires in the same pass.
+3. **All three unpark arms are exercised separately** *(v3 repair — one aggregate `RECLAIM_UNPARKED`
+   cannot show that an arm is dead).*
+   (a) **epoch:** release the injected cached-root blocker, advance the scheduling epoch on every CPU
+   in the captured mask, assert `RECLAIM_UNPARKED{epoch} == 1` and the receipt retires.
+   (b) **row:** park an entry on `blocked_live_row`, then remove the blocking row via a reap **while
+   every other CPU is held off the scheduler (no epoch advance anywhere)**; assert
+   `RECLAIM_UNPARKED{row} == 1` and the receipt retires. **Under an epoch-only unpark rule this test
+   hangs** — the PR body records that pre-image, so the arm is proven to be load-bearing.
+   (c) **age:** park on an injected blocker that neither keyed arm can clear, **and suppress both
+   keyed arms by construction**: hold every CPU in the captured mask *except one* off the scheduler,
+   so the `epoch` arm (which needs all of them to advance) cannot fire, and remove no row, so the
+   `row` arm cannot fire. Let the one running CPU accumulate scheduling epochs. Assert
+   `RECLAIM_UNPARKED{age} == 1` **once the captured mask's epoch sum has advanced by
+   `PARK_AGE_BACKSTOP_EPOCHS = 64`** — a counted quantity the test reads directly, not a wall-clock
+   wait *(v3 tranche pass: the backstop now has a unit, so this assertion is checkable)* — and that
+   the entry is re-proved (not dropped, not freed). Assert the *negative* in the same test: at a sum
+   advance of 63 the entry is still parked.
+   In all three, `RECLAIM_PARK_RESIDENT` returns to **0** at quiesce, having been **observably
+   nonzero mid-run** (both halves asserted — a gauge that is always zero proves nothing).
+4. **Not-a-cap assertion.** Fork-pressure test proves a *full* eligible drain: with N ready receipts
+   and no refusals, one pass retires all N. A cap would fail this; the cursor does not. The **age**
+   unpark arm is covered by the same assertion in reverse: it only ever returns entries to the queue,
+   so no workload can show it removing an entry from consideration.
+5. **The fence is a fresh SNAPSHOT, proven negatively against both wrong implementations** *(v3
+   repair; second half added by the v3 tranche pass).* (a) Park a receipt whose retirement fence
+   elapsed long ago and assert the very next sweep does **not** unpark it, with no epoch advance, no
+   row removal and no age expiry: `RECLAIM_PARK_IMMEDIATE_UNPARK == 0` and `RECLAIM_UNPARKED == 0` at
+   that point. Reusing `reclaim.after_epoch` as the park fence fails this by construction. (b) Force
+   an epoch advance on every captured CPU **between step 2's snapshot and the third refusal**, then
+   park; assert the entry does **not** unpark on the next sweep. An implementation that reuses the
+   cycle's earlier `RetirementSnapshot` instead of taking a new one at park time passes (a) and fails
+   (b) — which is why (b) exists.
+
 **Strictly better.** Grace can no longer elapse on an unordered or empty observation; reclaim
 refusals stop being a single opaque boolean; the local hardware register enters the proof (closing the
 local half of the shadow/hardware gap `main` has today); the drain stops being a place where a future
-proof could nest locks.
+proof could nest locks. *(v3: and the drain acquires a termination argument it did not have before —
+today's loop only terminates because its predicate is cheap and monotone; the moment a richer proof
+is added, it needs the cursor. Shipping the proof without the cursor is the defect the re-ratification
+caught, and it would have been a livelock in the first phase of the round.)*
 
-**Revert.** Restore the bare arrays, the boolean predicate and the in-lock scan; counters in P0 go
-unused but harmless (they are read by the reader, not dead).
+**Revert.** Restore the bare arrays, the boolean predicate and the in-lock scan; delete the three
+`PendingProcessReclaim` fields (`last_pass`, `proof_failures`, `parked`), the `ParkRecord` type with
+its park-time snapshot and its `age_epoch_sum_at_park` key, the parked list and the one-line
+`ROW_REMOVAL_EPOCH` bump. Counters in P0 go unused but harmless (they are
+read by the reader, not dead). The cursor and park list revert **with** the richer proof, which is
+correct — neither is needed without the other.
 
 ---
 
@@ -279,57 +662,179 @@ unused but harmless (they are read by the reader, not dead).
 **Scope.** Rewrite the SIGKILL arm at `syscall/signal.rs:162` to: validate under the existing PM
 guard, capture `pid`, mutate **nothing**, `drop(guard)`; then
 `with_scheduler(|s| s.terminate_process_threads(pid))`; then **broadcast** `SGI_RESCHEDULE` to every
-other online CPU (no `cpu_state[].current_thread` residency predicate — that read is stale-prone and
-was a fatal panel finding); then `with_process_manager(|pm| pm.exit_process(pid, -9))`, whose
+other online CPU via the new teardown-only `send_exit_expedite_sgi(pid, batch)` helper (no
+`cpu_state[].current_thread` residency predicate — that read is stale-prone and was a fatal panel
+finding; and no reuse of the generic `send_resched_ipi*` helpers, so the expedite evidence is
+teardown-attributable — closure F). **That helper also publishes the victim's `EXIT_KICK` bucket
+before it broadcasts, and the peer scheduler pass that declines to dispatch a quarantined victim
+consumes it with one `compare_exchange`** — the P2-era observation half of closure F's pairing,
+specified in DESIGN §2.7 and deleted in P8 (v3 tranche pass). Then `exit_process_and_retire(pid, -9)`, whose
 merged aarch64 path already grace-defers the page table **before** `terminate()` runs. Keep the
 existing `set_need_resched()` tail. Additionally install the **durable report/SIGCHLD obligation seed**:
 one row obligation moved `Absent → Pending` at first commit and redeemed exactly once outside PM by
 whichever of {commit path, `handle_thread_exit`} **claims** it first (the four-state machine of
-DESIGN §1.6 — the seed uses it from day one; P6b generalizes it, it does not upgrade a bool) — because
-`btrt::on_process_exit` has exactly one call site at `task/process_task.rs:267` inside
-`handle_thread_exit`, which a remotely-marked victim may never run.
+DESIGN §1.6 — the seed uses transitions T1/T2/T3 from day one; P6b generalizes it, it does not
+upgrade a bool) — because `btrt::on_process_exit` has exactly one call site at
+`task/process_task.rs:267` inside `handle_thread_exit`, which a remotely-marked victim may never run.
+
+> **v3 repair — what the seed does NOT ship, stated so the two documents agree.** DESIGN §1.6 as
+> first written said P2's `Report` seed ships "with its effect marker and the split
+> `claim_exit_slot`/`record_exit` API from day one"; this PLAN keeps `btrt::on_process_exit` intact
+> and ratcheted to its single call site until **P6b** performs the split. Both cannot be true, and
+> the version where P2 ships a class-B obligation *claiming* a recovery marker it does not have is
+> the dangerous one. **This PLAN's sequencing is what holds**, and the design has been corrected to
+> match it:
+>
+> - P2 ships the seed's **shape** — the four-state machine, transitions T1/T2/T3, never a bool — and
+>   calls `btrt::on_process_exit` **unchanged**. No `report_marker`, no btrt split, no new file.
+> - **T4 does not exist at P2.** T4 is performed only by the S4 retire/reap gate, which arrives in
+>   P6b; P6a's removal join runs with a vacuously-true ledger term and performs no recovery. An
+>   obligation nothing ever recovers needs no marker — the marker exists solely to tell T4 which
+>   destination to take.
+> - **Exactly-once still holds at P2** by the sole-redeemer invariant alone: the commit path and
+>   `handle_thread_exit` race under PM and exactly one claims.
+> - **The cost is declared, not hidden.** Between P2 and P6b a claimer that dies between T2 and T3
+>   loses that one `btrt` report — precisely what `main` does today for a remotely-marked victim, so
+>   phasing rule 1 holds at every commit.
+> - **P6b introduces T4 and the `claim_exit_slot`/`record_exit` split in the same PR**, because a
+>   recovery rule and the marker it reads must never be separated by a merge boundary.
 
 > **v2 (condition 3) — the retirement receipt is enqueued only after the PM guard drops.**
-> `exit_process` becomes:
+> `exit_process` stops calling `enqueue_process_reclaim` at `manager.rs:1152` inside its own PM
+> guard; the enqueue happens after the guard drops. The move allocates nothing (`core::mem::take` on
+> the existing `pending_old_page_tables` `Vec` leaves it empty without allocating). The **second**
+> PM-nested enqueue, `handle_thread_exit` phase 1 at `task/process_task.rs:244`, is converted in the
+> same PR: the receipt rides out through the existing `phase1_result` value and is enqueued in
+> phase 2, where PM is already dropped. The `#[allow(dead_code)]` marker on `exit_process`
+> (`process/manager.rs:1119-1120`) comes off — P2 is its first live caller.
+
+> **v3 (closure A) — and NO caller is ever handed a receipt, because that is the only thing that
+> actually closes the hole.** v2's mechanism was "return `#[must_use] Option<RetirementReceipt>` and
+> adapt two callers". The re-ratification's first FATAL is correct: `#[must_use]` is defeated by
+> `let _ =`, and **seven further live call sites** would have been handed a value they were never
+> written to carry. A dropped receipt destructs a root with **no grace and no RootProof** — strictly
+> worse than `main`, in the phase whose entire purpose is closing a UAF. The API is restructured:
 >
 > ```rust
-> #[must_use]
-> pub fn exit_process(&mut self, pid: ProcessId, exit_code: i32) -> Option<RetirementReceipt>
+> pub(crate) struct RetirementReceipt { /* fixed size; NO public constructor */ }
+>
+> pub(crate) fn exit_process_locked(pm: &mut ProcessManager, pid: ProcessId, exit_code: i32)
+>     -> Option<RetirementReceipt>;              // crate-private; ratchet: exactly ONE caller
+>
+> pub fn exit_process_and_retire(pid: ProcessId, exit_code: i32) -> ExitOutcome {
+>     let receipt = with_process_manager(|pm| exit_process_locked(pm, pid, exit_code));
+>     // PM guard provably dropped here (with_process_manager owns its scope)
+>     if let Some(r) = receipt { enqueue_process_reclaim(r); }
+>     ...
+> }
+>
+> impl Drop for RetirementReceipt {           // self-healing: re-enqueue, never free
+>     fn drop(&mut self) { RECEIPT_DROPPED_UNRETIRED.inc(); reenqueue(self.take_contents()); }
+> }
 > ```
 >
-> It still stamps the grace epoch and takes the root under PM, but **returns** the receipt instead of
-> calling `enqueue_process_reclaim` at `manager.rs:1152`. The caller enqueues after
-> `with_process_manager(...)` returns, with no guard live. The move allocates nothing
-> (`core::mem::take` on the existing `pending_old_page_tables` `Vec` leaves it empty without
-> allocating). The **second** PM-nested enqueue, `handle_thread_exit` phase 1 at
-> `task/process_task.rs:244`, is converted in the same PR: the receipt rides out through the existing
-> `phase1_result` value and is enqueued in phase 2, where PM is already dropped. Both `#[allow(dead_code)]`
-> markers on `exit_process` come off — P2 is its first live caller.
+> **All nine ADAPTED SITES move in THIS PR**, in the three disjoint classes of DESIGN §1.7. Rows 1-7
+> are **class 1** (`exit_process` callers — the seven, and only the seven, that a `git grep` finds at
+> `985881a6`); row 9 is **class 2** (the new SIGKILL arm); row 8 is **class 3** (the PM-nested enqueue,
+> which does **not** call the wrapper). The eight class-1+2 rows call `exit_process_and_retire`; the
+> seven class-1 rows currently call `exit_process` **inside a live PM guard or `with_process_manager`
+> closure**, so each needs the call lifted out of the closure, not merely renamed:
+>
+> | # | Class | Call site (verified at `985881a6`) | Shape today | Required adaptation |
+> |---|---|---|---|---|
+> | 1 | **1** | `arch_impl/aarch64/exception.rs:778` | `pm.exit_process(pid, -11)` inside `with_process_manager(...)`, after the `terminate_process_threads` call at `:768` | close the closure after the victim lookup, call `exit_process_and_retire(pid, -11)` outside it; the mandatory tails (`terminate_current_scheduler_thread`, `set_need_resched`, frame redirect to `idle_loop_arm64`, `set_idle_stack_for_eret`, `switch_to_idle`) stay **unconditional** and are not reordered |
+> | 2 | **1** | `arch_impl/aarch64/exception.rs:1146` | same, paired with `:1135` | same |
+> | 3 | **1** | `arch_impl/aarch64/exception.rs:1233` | same, paired with `:1230` | same |
+> | 4 | **1** | `arch_impl/aarch64/exception.rs:1336` | same, paired with `:1333` | same |
+> | 5 | **1** | `interrupts.rs:1429` (x86_64) | `pm.exit_process(pid, -11)` inside `with_process_manager(...)`, with `faulting_thread_id` captured in the same closure | capture the pid/tid in the closure, call the wrapper after it; the `with_thread_mut` tail is unchanged |
+> | 6 | **1** | `interrupts.rs:1735` (x86_64) | same | same |
+> | 7 | **1** | `process/mod.rs:264` (`exit_current`, fn at `:258`) | `manager.exit_process(pid, code)` with `*manager()` held live across the call by an `if let Some(ref mut manager)` binding | end the binding's scope before the call; `exit_current` becomes a thin wrapper over `exit_process_and_retire` |
+> | 8 | **3** | `task/process_task.rs:244` (`handle_thread_exit` phase 1) | `enqueue_process_reclaim(reclaim)` under PM | receipt rides out through `phase1_result`, enqueued in phase 2 (v2's fix, unchanged). **This site does NOT call `exit_process_and_retire`** — it already owns its PM guard and its two-phase shape, and folding it into the wrapper would mean taking PM twice. It is an adapted site, not a wrapper caller, and no exact-set gate counts it as one |
+> | 9 | **2** | `syscall/signal.rs:162` (the SIGKILL arm this phase rewrites) | `process.terminate(-9)` under PM | becomes `exit_process_and_retire(pid, -9)` after `drop(guard)` |
+>
+> Plus the internal `manager.rs:1152` enqueue, which is **deleted** (it moves into the wrapper).
+> Four properties make this custody rather than advice: the type is crate-private with no public
+> constructor; `exit_process_locked` has exactly one permitted caller (ratcheted); `Drop` re-enqueues
+> instead of freeing; and a receipt exists in only two provably PM-free places (inside the wrapper
+> between guard-drop and enqueue, and P1's local detach slot), so `Drop` can never nest the queue lock
+> under PM. DESIGN §1.7.
 
 **Files.** `kernel/src/syscall/signal.rs`, `kernel/src/process/manager.rs`,
-`kernel/src/task/scheduler.rs`, `kernel/src/task/process_task.rs`, tests. **~210 lines, 3 commits —
-seam for splitting if it crosses the ceiling is {receipt-return refactor} / {SIGKILL arm + seed}.**
+`kernel/src/task/scheduler.rs`, `kernel/src/task/process_task.rs`, plus the six fault sites in
+`kernel/src/arch_impl/aarch64/exception.rs`, `kernel/src/interrupts.rs` and
+`kernel/src/process/mod.rs`, tests. **~230 lines, 3 commits — AT the ceiling and over the 5-file
+target; the named split seam is {receipt custody + all nine adapted sites} / {SIGKILL arm +
+expedite helper + obligation seed}, and this PR is expected to take it.** *(v3 honesty: closure A
+made this phase bigger, and the plan says so up front rather than discovering it at review. Split
+before review, per rule 4.)*
 
 **Gate extras.** New `sigkill_teardown_test` (userspace): parent forks a child spinning at EL0;
 parent `kill(child, SIGKILL)`. Assert (a) `waitpid` reaps **-9**; (b) SIGCHLD arrived at kill time
 (parent's `pause()` returns); (c) `TEARDOWN_QUARANTINE`/`TEARDOWN_DEFER`/`TEARDOWN_RECLAIM` all
 increment for that pid; (d) `TEARDOWN_MASKED_FRAMES_WALKED == 0` **for kill paths** (the baseline
-recorded in P0 must drop, not merely stay flat); (e) `EXIT_SGI_SENT > 0` and the peer observes it;
+recorded in P0 must drop, not merely stay flat); (e) **(v3 — closure F; the observation half specified by the v3
+tranche pass)** `EXIT_SGI_SENT{pid}` is nonzero **for the test's own victim pid**, recorded by the new
+teardown-only `Scheduler::send_exit_expedite_sgi(victim_pid, batch)` and by no other site; **the
+peer's observation is recorded with the same pid as `EXIT_KICK_OBSERVED{pid}`, via the `EXIT_KICK`
+bucket table of DESIGN §2.7** — published by the helper before the broadcast, consumed by one
+`compare_exchange` at the peer scheduler pass that declines to dispatch the quarantined victim; and
+the send→observe interval carried by that CAS is **measured strictly shorter than the victim's tick
+period**. A bare "`EXIT_SGI_SENT > 0`" gate is explicitly rejected, because the P0 baseline proves the
+generic reschedule IPIs alone would satisfy it. Three sub-assertions keep the proxy honest:
+`EXIT_KICK_PUBLISHED == EXIT_KICK_OBSERVED == 1` for this single-victim workload;
+`EXIT_KICK_BUCKET_COLLISION == 0`; and `EXIT_REQUEST_OBSERVED == 0`, since the boundary hook does not
+exist until P8 and any nonzero value would mean the gate is reading a counter it was told is
+unavailable. **What this asserts is stated as what it is:** *the expedite reached the peer and the
+peer stopped dispatching this victim, faster than a tick.* It is **not** "the victim observed a
+latched exit request" — that claim needs P8's hook, arrives with it, and is where the bucket table is
+deleted (residual R-21);
 (f) exactly one `btrt` report; (g) zero fault markers over the 10-boot Parallels streak; **(h)
 `RECLAIM_ENQUEUE_UNDER_PM == 0` — the P0 baseline was nonzero at both sites, so this is a measured
 drop, not a vacuous zero.** Repeat with the child inside a CLONE_VM group — the **sibling must
 survive** (this phase does not sweep the group). Repeat as self-kill `kill(getpid(), SIGKILL)`.
 **Soak + retention measurement.**
 
+**v3 gate extras (closure A) — receipt custody is proven, not asserted:**
+1. **Ratchet — the three exact sets from P0's post-P2 inversion, asserted together** *(v3 tranche
+   pass: the earlier phrasing, "the pinned nine-site `exit_process` list from P0 is replaced by 'all
+   nine now call `exit_process_and_retire`', asserted as an exact set", was unsatisfiable — P0 pins
+   **seven** `exit_process` callers, not nine, and the ninth adapted site, `handle_thread_exit`, does
+   not call the wrapper at all)*:
+   (i) `exit_process_and_retire` — **exactly 8** call sites: the seven former `exit_process` callers
+   named in P0 rule 1, plus the new SIGKILL arm;
+   (ii) `exit_process_locked` — **exactly 1** call site, the wrapper;
+   (iii) `enqueue_process_reclaim` — **exactly 3** call sites (wrapper post-guard, `handle_thread_exit`
+   phase 2, `RetirementReceipt::drop`), up from the P0 baseline of 2 and with `manager.rs:1152` gone;
+   plus `RetirementReceipt` has zero public constructors and is not nameable outside the crate, and
+   `ProcessManager::exit_process` has zero public call sites.
+2. **Per-call-site retirement proof.** A fault injected at each of the nine adapted sites (six EL0/x86
+   fault paths, `exit_current`, `handle_thread_exit`, SIGKILL) still shows that pid's root entering
+   the reclaim queue **exactly once** — `TEARDOWN_DEFER{pid} == TEARDOWN_RECLAIM{pid} == 1`, per-pid
+   paired exactly like P0's fork/exit gate, never as a global total.
+3. **`RECEIPT_DROPPED_UNRETIRED == 0`** on every boot, plus a deliberate drop injected in a unit test
+   proving the `Drop` impl **re-enqueues** (queue length increases, the counter increments, and no
+   frame is freed) rather than destructing.
+4. *(v3 repair — the seed's declared limit is asserted, not just written down.)*
+   **`LEDGER_CLAIM_ORPHANED == 0`** for the whole run: no recovery path exists before P6b, so any
+   nonzero value means a T4 was added unnoticed. Plus the P0 ratchet re-asserted: `on_process_exit`
+   still has **exactly one** call site and `claim_exit_slot`/`record_exit` do not yet exist.
+
 **Strictly better.** The confirmed-live eager `cleanup_cow_frames`-while-remote-runs UAF class is
 gone; quarantine, expedited reschedule, and SIGCHLD arrive for the first time on this path; and both
-pre-existing reclaim-queue-under-PM nestings are removed. *Honest bound:* the exit is still remotely
+pre-existing reclaim-queue-under-PM nestings are removed. *(v3: and the round's most dangerous
+possible self-inflicted wound — a receipt-loss channel opened by the very refactor meant to close a
+UAF — is closed by construction rather than by a lint. Nine adapted sites move together, which is
+larger, but a partial migration here is the one shape that would have been worse than `main`.)* *Honest bound:* the exit is still remotely
 marked (upgraded in P8/P9/P10a-c), and FD closure still happens inside `exit_process` under PM —
 unchanged from today's SIGKILL, which does that **plus** the full CoW walk. Not a regression; not yet
 a fix. Fixed in P7.
 
-**Revert.** Restore the four-line `process.terminate(-9)` arm, the in-PM enqueues and the `void`
-return; drop the obligation. The exact pre-image is preserved in the commit body.
+**Revert.** Restore the four-line `process.terminate(-9)` arm (class 2), the in-PM enqueues at
+`manager.rs:1152` and `process_task.rs:244` (class 3 plus the deleted one), and the public
+`exit_process` signature with its **seven** original call sites (class 1); drop the obligation, the
+expedite helper, the kick-bucket table and the receipt type. The exact pre-image of every one of the
+nine adapted sites is preserved in the commit body — that is what makes a nine-site change revertable
+alone (rule 5), and it is why the split seam puts the custody refactor in its own commit.
 
 ---
 
@@ -369,7 +874,8 @@ carrying a stale `inherited_cr3` past an exec would present a root it does not o
 scheduler copy", then apply it to the paths that never got it: fresh spawn (`creation.rs` ×2),
 direct init, `boot/test_disk.rs`, alongside the already-fixed fork and clone. A `Process` row can no
 longer synchronously drop a published stack — today the original thread's stack is freed ungated by
-`remove_process` at `waitpid` reap (`syscall/wait.rs:385` → `manager.rs:1101-1104`). Drop PM before
+`remove_process` at `waitpid` reap (`syscall/wait.rs:386` → `manager.rs:1102-1104`; *v3: both
+anchors corrected by one line*). Drop PM before
 every scheduler registration (removing the existing PM→scheduler nesting in the spawn/test-disk paths).
 
 **Files.** `kernel/src/process/creation.rs`, `kernel/src/main_aarch64.rs`,
@@ -401,12 +907,39 @@ PID 1** for the explicit init constructor; ordinary/test allocation starts at 2 
 → ticket returned → PM validates the ticket names a live PID 1 → `designated_init` set → thread
 published to the run queue. Production designation is **validated == PID 1 and refuses otherwise**.
 Migrate the three production literals (`manager.rs:1178`, `process_task.rs:226`, `:285`) and
-`signal.rs`'s `INIT_PID` to the accessor. **No `#[cfg]` anywhere.** `init_shell.rs:1028` is not
-touched.
+`signal.rs`'s `INIT_PID` (`syscall/signal.rs:26`, read at `:124` and `:397`) to the accessor.
+**No `#[cfg]` anywhere.** `init_shell.rs:1028` is not touched.
+
+> **v3 (closure E, end 1) — `sys_clone` refuses to publish into the designated init's thread group.**
+> The re-ratification found a FATAL composition hole: P9 makes fatal signals **thread-group scoped**
+> while v2's P12 dropped only signals aimed at the designated-init **row**, so a `CLONE_VM` sibling
+> sharing init's effective TGID could be targeted and the seal would kill the whole group, init
+> included. It is closed at both ends, and **this is the end that must ship first** — see the new
+> `P5 → P9` graph edge, which exists because without it P9 would introduce a way to kill init that
+> `main` does not have.
+>
+> `sys_clone` (`syscall/clone.rs:36`) already derives the parent's effective TGID at `:84`
+> (`process.thread_group_id.unwrap_or(pid.as_u64())`) **inside the live PM guard taken at `:60`**.
+> Immediately after that derivation, if `designated_init()` is `Some(init)` and the derived TGID
+> equals init's effective TGID, return **`EINVAL`**. Two or three lines, in the guard that is already
+> held, with the authority this phase introduces.
+>
+> **This is a deliberate, documented ABI restriction:** *the designated init cannot acquire `CLONE_VM`
+> siblings.* Nothing in-tree clones from init; a multi-threaded init would need its own design pass
+> for group-scoped death regardless. There is exactly **one** production write of a non-`None`
+> `thread_group_id` (`syscall/clone.rs:210`), so this refusal is the complete admission surface, and
+> P0's ratchet pins that write site by name so a second one cannot appear unnoticed. Recorded as
+> residual **R-18** with the maintenance obligation attached.
+>
+> *Not dormant (rule 2):* the refusal has a live caller and a live test in this PR (`clone()` from
+> init returns `EINVAL`; `clone()` from any non-init process is unaffected), and it is observable
+> from the moment it lands rather than "activated by P9".
 
 **Files.** `kernel/src/process/manager.rs`, `kernel/src/process/mod.rs`,
-`kernel/src/main_aarch64.rs`, `kernel/src/syscall/signal.rs`, `kernel/src/task/process_task.rs`.
-**~180 lines, 2 commits.**
+`kernel/src/main_aarch64.rs`, `kernel/src/syscall/signal.rs`, `kernel/src/task/process_task.rs`,
+`kernel/src/syscall/clone.rs` (the admission refusal). **~200 lines, 2 commits — six production
+files, one over the target; the named split seam is {PID-1 reservation + held-publication ticket} /
+{literal migration + clone admission}.**
 
 **Gate extras.** Failure injection at **each** fallible stage after provisional PID selection:
 `designated_init() == None`, no row, and a retry succeeds as PID 1. Boot test: designated pid == 1 ==
@@ -414,23 +947,44 @@ the pid `init_shell` observes via `getpid()`. A build with no real init leaves d
 does **not** treat whichever process got a low PID as init. Existing orphan-reparent test still green.
 P0 ratchet allowlist shrinks to the three named test sites.
 
+**v3 gate extras (closure E, end 1).** `clone()` issued from the designated init returns **`EINVAL`**
+and creates no row; `clone()` from a non-designated process is unaffected (the existing CLONE_VM
+tests stay green unchanged); and **over a full boot, no row other than init itself ever carries
+init's effective TGID** — asserted by walking the process map at quiesce, not by a source grep. A
+build with no designated init exercises the `None` arm and refuses nothing.
+
 **Strictly better.** Converts AC-5 from "convention plus a boot log line" into a structural guarantee,
 and makes a failed init creation deterministically retryable. Ships **no** behaviour change on init
 death — deliberately, because bundling identity with policy is what killed four prior attempts.
+*(v3: it also makes the init-sibling state unconstructible before any group-scoped kill exists, which
+is what keeps P9 strictly better than `main`. The refusal is an admission rule, not a death policy —
+bundling is still avoided.)*
 
-**Revert.** Restore the literals and the `next_pid` base; the ticket is additive.
+**Revert.** Restore the literals and the `next_pid` base; delete the clone refusal. The ticket is
+additive. *(Note: reverting P5 after P9 has merged would reopen the init group hole, so the revert
+story is "revert P5 only while P9 is unmerged" — recorded in the PR body per rule 5.)*
 
 ---
 
 ## Phase 6a — Reap/tombstone retention gate *(NEW in v2 — condition 2)*
 
+> ⚠ **DEBT-4 — the x86 reap path bypasses this phase's gate, and this phase owns the closure.**
+> `kernel/src/syscall/handlers.rs:3101` removes the process row **directly** on the live x86 reap
+> path, so the two-event join below is not the only remover: the retention gate can pass on aarch64
+> while x86 still frees a row out from under an un-retired receipt. Before this phase's tranche
+> ratifies, that site either routes through the join or the gate is honestly re-scoped to aarch64
+> with the divergence named in AC-12's evidence, a ratchet pinning `handlers.rs:3101`, and a stated
+> closing phase. See the DESIGN-DEBT REGISTER.
+
 **Scope.** Make a process row outlive its reap so that row-resident obligations cannot be destroyed
-before they are discharged. Today `waitpid`'s `complete_wait` physically removes the row
-(`kernel/src/syscall/wait.rs:385` → `ProcessManager::remove_process`, `manager.rs:1101-1104`), which
+before they are discharged. Today `waitpid`'s `complete_wait` (`kernel/src/syscall/wait.rs:335`)
+physically removes the row at `wait.rs:386` → `ProcessManager::remove_process`
+(`manager.rs:1102-1104`) — *(v3: both anchors corrected by one line against `985881a6`)* — which
 is exactly the seam the ratification flagged: P6b's `Resources` obligation **by construction outlives
 reap** (grace + RootProof are still pending when the parent collects the status — R-13).
 
-- Add `RowState { Live, Zombie, Tombstone { reaped_by, status } }` to the process row.
+- Add `RowState { Live, Zombie, Tombstone }` to the process row, **plus the two join flags**
+  `reaped: Option<(ProcessId, i32)>` and `retired: bool` *(v3, closure B)*.
 - `complete_wait` no longer calls `remove_process`; it records the reap and transitions
   `Zombie → Tombstone`. The parent's `children` retain is unchanged.
 - A `Tombstone` row is **invisible** to every "live process" query: `find_process_by_pid/thread/cr3`,
@@ -442,8 +996,40 @@ reap** (grace + RootProof are still pending when the parent collects the status 
   yet, so the gate's ledger term is vacuously true and is asserted to become live in P6b.
 - `TOMBSTONE_RESIDENT` (gauge with a reader) and `TOMBSTONE_REMOVED` counters.
 
+> **v3 (closure B) — the removal TRIGGER, which v2 never specified.** v2 stated the *condition* for
+> removal (ledger complete **and** receipt retired) but named no trigger, and the row carried only the
+> reap. If retirement finished first, nothing revisited the row when the reap arrived; if the reap
+> finished first, nothing revisited it when retirement landed. Either order could strand a permanent
+> tombstone — the MAJOR the re-ratification raised — and an implementer patching around it would
+> reach for premature removal. Removal becomes an explicit **two-event join**:
+>
+> ```
+> reap(pid)   [PM]: row.reaped = Some((by, status));
+>                   if row.retired && ledger_settled(pid) { remove_row(pid); JOIN{reap_second}++ }
+>
+> retire(pid) [PM]: row.retired = true;
+>                   if row.reaped.is_some() && ledger_settled(pid) { remove_row(pid); JOIN{retire_second}++ }
+> ```
+>
+> - **Both writes happen under PM**, so the write, the read of the other flag, the ledger check and
+>   the removal are all in **one acquisition**. PM serializes the two writers, exactly one observes
+>   the other flag already set, and **removal happens exactly once whichever order occurs**.
+> - **The join is not a one-shot edge trigger.** If `ledger_settled` is false when the second event
+>   lands, neither writer removes; the S4 drain re-evaluates the join for every tombstone it passes,
+>   so a late-settling ledger still gets its row removed.
+> - **Rows with no receipt** (`Resources` will be `Absent` — e.g. an x86_64 exit that released
+>   synchronously) get `retired = true` written at the same moment that is determined, so the ordinary
+>   reap removes them immediately. The join degenerates correctly instead of stalling.
+> - **Rows that are never reaped** (no parent, or the parent exits first) are covered by the reparent
+>   cursor handing them to the designated init before the parent's own row tombstones; a build with no
+>   designated init sets `reaped` at commit through an explicit, named `auto_reap` branch.
+> - **Both arms are gated nonzero** — see the gate extras. An unreachable join arm is dormant code
+>   wearing a different hat (rule 2).
+
 **Files.** `kernel/src/syscall/wait.rs`, `kernel/src/process/manager.rs`,
-`kernel/src/process/process.rs`, `kernel/src/task/process_task.rs`, tests. **~170 lines, 2 commits.**
+`kernel/src/process/process.rs`, `kernel/src/task/process_task.rs`, tests. **~190 lines, 2 commits —
+near the ceiling; the named split seam is {`RowState` + liveness-predicate migration of the lookup
+call sites} / {two-event join + removal gate}.**
 
 **Gate extras.** (a) `waitpid` still returns the correct status and the parent's `children` list is
 still pruned — existing wait/orphan tests green unchanged. (b) `TOMBSTONE_RESIDENT` returns to **0**
@@ -454,17 +1040,48 @@ not returned by any live-process lookup: negative tests for `kill(pid)` → `ESR
 accounting re-run (allocated == freed) now that reap no longer drops the row. **Soak + retention
 measurement** (this phase changes retention by construction).
 
+**v3 gate extras (closure B) — both join orders must be observed in one run:**
+*(v3 repair — the two workloads were attached to the opposite counters. The counter incremented
+inside `reap()` is `{reap_second}`: **the reap was the second event and retirement had already
+landed.** The one incremented inside `retire()` is `{retire_second}`. A prompt reap therefore drives
+`{retire_second}`, and a delayed reap drives `{reap_second}` — the reverse of what v3 asserted, which
+no run could have satisfied.)*
+(f) `TOMBSTONE_JOIN{retire_second} > 0` — produced naturally by the 64-child fork/exit/reap workload,
+where the parent reaps **promptly, before grace has elapsed**, so the reap lands first and the retire
+gate is the second writer that performs the removal. Assert the removal happens at retirement, not at
+the reap, and that `waitpid` had already returned the correct status.
+(g) `TOMBSTONE_JOIN{reap_second} > 0` — produced by a deliberate **delayed-reap** workload: the
+child exits, the test sleeps past two grace epochs so **retirement completes first**, and only then
+does the parent call `waitpid`, making the reap the second writer. Assert the row is removed at the
+reap, exactly once, with the correct status still returned.
+(h) A **repeat-retire** and a **repeat-reap** injection each remove the row exactly once
+(`TOMBSTONE_REMOVED` increments by exactly 1 per pid over the whole run, per-pid keyed).
+(i) A row whose `Resources` is `Absent` (x86_64 synchronous release) is removed at reap with no
+retirement event at all — the degenerate arm.
+
 **Strictly better.** Row lifetime stops being shorter than the lifetime of the work the row owns — the
 precondition every later phase's row-resident state depends on. It also converts today's "reap frees
 the row and whatever is still attached to it" into a proof-gated removal, which is the same discipline
 already applied to page tables and stacks.
 
-**Revert.** Restore the `remove_process` call in `complete_wait` and delete `RowState::Tombstone`;
-P6b is not yet merged, so nothing depends on it.
+**Revert.** Restore the `remove_process` call in `complete_wait` and delete `RowState::Tombstone`
+together with the two join flags; P6b is not yet merged, so nothing depends on it.
 
 ---
 
 ## Phase 6b — Exactly-once ledger: four-state obligations + first status *(AC-12)*
+
+> ⚠ **DEBT-1 — `Report` is NOT exactly-once as specified, and this phase owns the closure.** Two
+> passes sustained it: when the effect marker reads `started == 1 && finished == 0`, T4 cannot tell
+> whether `record_exit` landed, and the ruling `→ Completed` + `LEDGER_EFFECT_AMBIGUOUS{report}`
+> means a *possibly missing* report — at-most-once, not exactly-once (DESIGN §6 R-19). Before this
+> phase's tranche ratifies: either the window is closed by a mechanism that makes the record step
+> itself recoverable, **or** an explicit operator acceptance is carried that this is the round's
+> single at-most-once obligation. Restating exactly-once while shipping at-most-once is the thing the
+> pre-check rejected twice and is not available. The same debt covers the `on_process_exit` split
+> phasing: `claim_exit_slot`/`record_exit` must be shown not to reorder the registry-slot clear
+> relative to `finalize()`'s serial emission, and must land in the **same PR** as T4. See the
+> DESIGN-DEBT REGISTER.
 
 **Scope.** Generalize Phase 2's obligation seed into the row-resident `ExitLedger` of DESIGN §1.6:
 six obligations (`Sigchld, ParentWake, Report, Reparent, Fds, Resources`), each carrying
@@ -479,13 +1096,73 @@ six obligations (`Sigchld, ParentWake, Report, Reparent, Fds, Resources`), each 
 > The sole-redeemer invariant — at most one control path is ever `Claimed` — falls out of read-then-write
 > inside one PM acquisition, so the commit path and `handle_thread_exit` can no longer both redeem.
 
+> **v3 (closure B) — the class split, which is what makes "exactly once" true rather than intended.**
+> The re-ratification's second FATAL: v2's T4 moved `Claimed{dead} → Pending` **without any way to
+> observe whether the effect had already fired between T2 and T3**, so reopening could duplicate and
+> not reopening could lose. A recovery rule that cannot see the effect is a coin flip. Two steps:
+>
+> **Step 1 — four of the six obligations never enter `Claimed` at all.** An obligation is **class A**
+> when its effect is a write to PM-owned state; for those, the effect and `→ Completed` are performed
+> **in the same PM acquisition** (transition T2·3), so T4 is *structurally unreachable*:
+>
+> | Obligation | Class | Effect and where it commits |
+> |---|---|---|
+> | `Sigchld` | **A** | parent's pending-SIGCHLD bit — PM-owned; same acquisition as `Completed` |
+> | `ParentWake` | **A** | publish the status as collectable in the parent's wait state — PM-owned; same acquisition. **The scheduler kick is NOT part of the obligation**: `unblock_for_child_exit` is idempotent, so it is declared a *repeatable* side effect issued after PM drops and counted separately as `PARENT_WAKE_KICKS` (which MAY exceed the exactly-once count — declared, not hidden). `PARENT_WAKE_COMPLETED` counts the PM transition |
+> | `Reparent` | **A** | one fixed-size batch per acquisition, with `reparent_cursor` advanced in that same acquisition — a stopped claimer leaves a resumable position and re-running a batch skips children already re-parented |
+> | `Resources` (take half) | **A** | `page_table.take()` into the receipt — PM-owned; same acquisition. The enqueue half is not an obligation at all, because closure A makes take-and-enqueue one indivisible public operation |
+> | `Fds` | **B** | endpoint close — pipe/PTY/TCP locks must not be held under PM |
+> | `Report` | **B** | `btrt::on_process_exit` reaches `finalize()` → `ktap::emit_summary` → `serial_println!`, i.e. **SERIAL** (`test_framework/btrt.rs:393`) — verified in the tree, and the whole reason class B exists |
+>
+> **Step 2 — each class-B obligation carries a marker written by the effect itself, and the marker
+> outranks the ledger.**
+>
+> - **`Fds` — custody, and the descriptor never leaves the row** *(v3 repair)*. v3 as first written
+>   had `take_next_for_exit` **retain** the descriptor in the row's `fd_in_flight` slot *and* return
+>   that same value for an unlocked close. Those are mutually exclusive; cloning to make both true is
+>   exactly the second copy that "a double close is not representable" depends on not existing, and
+>   it reopens double-close / endpoint-refcount corruption — the failure class the obligation exists
+>   to prevent. The operation is therefore split in three (DESIGN §1.6, §2.5):
+>   `begin_fd_close(pid)` **[PM]** moves one `(fd, desc)` into the row's slot (or re-tickets one
+>   already there) and returns a **non-owning `CloseTicket`** — a clone of the *endpoint handle*,
+>   with no close operation on it, so it cannot close anything; `endpoint_hangup(&ticket)`
+>   **[no lock]** performs the only step that needs an endpoint lock and is idempotent by a CAS on
+>   the endpoint; `finish_fd_close(pid)` **[PM]** drops the owning descriptor and clears the slot in
+>   one acquisition — the single destructive step. A dead claimer leaves the descriptor in the slot
+>   and the next claimer replays only the idempotent half. **A double close is not representable**
+>   because the owning value is in exactly one place at every instant and is destroyed exactly once;
+>   `Fds` still needs no started/finished bits and no ruling, because there is no ambiguous window.
+>   `hangup_done` is diagnostic (`FD_HANGUP_REPLAYED`), never load-bearing.
+> - **`Report` — two lock-free bits plus the btrt token.** `on_process_exit` is split so the ledger
+>   can see inside it: `btrt::claim_exit_slot(pid) -> Option<u16>` (a `compare_exchange` on the
+>   registry slot; pure atomics, **no SERIAL**) is called **inside the T2 acquisition** and its result
+>   is stored as `report_marker.token`; `btrt::record_exit(test_id, code)` (`pass`/`fail`, the
+>   completed increment, possibly `finalize()`) runs with **no lock held**, setting
+>   `report_marker.started` (CAS 0→1; a loser returns without recording) before and
+>   `report_marker.finished` (release store) after.
+>
+>   **T4's ruling for `Report` — written down so it is not a judgement call at implementation time:**
+>
+>   | Marker observed | Meaning | T4 destination | Why |
+>   |---|---|---|---|
+>   | `finished == 1` | effect completed, only the ledger write was lost | **`Completed`** | re-running double-counts `tests_completed` and can double-`finalize()` |
+>   | `started == 0` | effect never began | **`Pending`**, token preserved | safe to redo, and no new btrt slot is needed |
+>   | `started == 1, finished == 0` | **ambiguous** — the claimer died inside `record_exit` | **`Completed`** + `LEDGER_EFFECT_AMBIGUOUS{report}` | **the marker wins over the ledger**: a duplicate corrupts the test ledger, while a missing report is caught loudly by the AC-12 equality |
+>
+> The general rule for any future obligation: *class B requires a marker the effect itself writes and
+> an explicit statement of which side wins.* An obligation with neither a PM-committable effect nor a
+> marker does not belong in the ledger. DESIGN §1.6.
+
 A repeat request returns the stored batch/status and creates no second obligation and no second status
 write. `ExitLedger`'s `Resources` obligation subsumes design A's proposed separate
 `ResourceState{Held,HandedOff}` field. Both already-terminated branches (`manager.rs:1137`,
 `process_task.rs:234`) re-key onto the ledger state.
 
 **Files.** `kernel/src/process/process.rs`, `kernel/src/process/manager.rs`,
-`kernel/src/task/process_task.rs`, tracing provider, tests. **~190 lines, 2 commits.**
+`kernel/src/task/process_task.rs`, `kernel/src/test_framework/btrt.rs` (the
+`claim_exit_slot`/`record_exit` split), tracing provider, tests. **~210 lines, 3 commits — at the
+ceiling; the named split seam is {class-A fused transitions + ledger array} / {class-B markers +
+btrt split + T4 ruling}.**
 
 **Gate extras.** Repeat matrix — exit→fault, SIGKILL→fault, fault→SIGKILL, repeated request/wait:
 exactly one SIGCHLD, one parent wake, one `btrt` report, and `waitpid` returns the **first** status.
@@ -499,23 +1176,76 @@ not assumed). **Orphan-recovery test:** inject a claimer that dies between T2 an
 delivered exactly once rather than lost. `TOMBSTONE_RESIDENT` still returns to 0 at quiesce with the
 ledger term of the removal gate now live. CoW frame accounting unchanged vs P5 for the same workload.
 
+**v3 gate extras (closure B) — every branch of the exactly-once argument is exercised:**
+1. **Class A has no `Claimed` state, observably.** Instrument the ledger reader to sample obligation
+   states across the 64-child workload and assert `Sigchld`, `ParentWake`, `Reparent` and
+   `Resources` are **never observed in `Claimed`** — the structural claim is measured, not asserted.
+2. **T4's three `Report` destinations, one injection each.** (a) kill the claimer after `finished` →
+   assert `→ Completed`, exactly one btrt report total, `LEDGER_EFFECT_AMBIGUOUS == 0`; (b) kill it
+   before `started` → assert `→ Pending`, the token is preserved, the next claimer records, exactly
+   one report total; (c) kill it between the two → assert `→ Completed`,
+   `LEDGER_EFFECT_AMBIGUOUS{report} == 1`, and **still exactly one report** (never two). Assertion
+   (c) is the one that would have failed under v2's rule, and the PR body records that.
+3. **`Fds` custody** *(v3 repair — assertions restated against the three-step API).* Kill a claimer
+   between `begin_fd_close` and `endpoint_hangup`, and again between `endpoint_hangup` and
+   `finish_fd_close`; in both cases assert the descriptor is still owned by `fd_in_flight`, that the
+   recovering claimer re-tickets **that** descriptor rather than taking a new one, that
+   `endpoint_hangup` replays as a no-op (`FD_HANGUP_REPLAYED > 0`, endpoint close count unchanged),
+   that the descriptor is destroyed **exactly once** by `finish_fd_close`, and that endpoint refcount
+   accounting balances. A double close is proven unrepresentable at compile time by a unit test
+   asserting `CloseTicket` exposes no close/consume operation, and at run time by an injection that
+   calls `finish_fd_close` twice and finds an empty slot on the second call.
+4. **`PARENT_WAKE_KICKS >= PARENT_WAKE_COMPLETED`** is asserted as an inequality, with a comment
+   naming the kick as deliberately repeatable — so a future reviewer does not "fix" the inequality
+   into an equality and reintroduce a lost wake.
+5. **Both join arms nonzero** (P6a's `TOMBSTONE_JOIN{reap_second}`/`{retire_second}`) now that the
+   ledger term of the removal gate is live rather than vacuous.
+
 **Strictly better.** Closes PR #418's own declared follow-up ("duplicate SIGCHLD / stale exit code on
 the already-terminated path") **with a mechanism, not a convention**. Explicitly **not** notification
 suppression (disproven in review): the obligation is shared by every producer, so a later pass claims
 and redeems it rather than being skipped.
 
-**Revert.** Re-key the two branches onto `is_terminated()` and drop the ledger; P6a's tombstone gate
-survives independently (its ledger term becomes vacuously true again).
+**Revert.** Re-key the two branches onto `is_terminated()` and drop the ledger, the markers and the
+btrt split; P6a's tombstone gate survives independently (its ledger term becomes vacuously true
+again, and both join arms still fire).
 
 ---
 
 ## Phase 7 — FD closure leaves the PM lock *(AC-9)*
 
-**Scope.** Add `FdTable::take_next_for_exit()` — take exactly **one** descriptor under PM, drop PM,
-close it, repeat. Retire the existing allocating `Process::take_fd_entries() -> alloc::vec::Vec`
-(`process.rs:335`) rather than reusing it. Apply at both convergence points and at Phase 2's SIGKILL
-commit. The `Fds` obligation brackets the loop (`T2` before the first take, `T3` when the table is
-proven empty under PM) — the explicit control flow is in DESIGN §2.5.
+> ⚠ **DEBT-2 — the endpoint-CAS idempotence below is REJECTED and must not be built as written.**
+> The `CloseTicket` repair makes `endpoint_hangup` idempotent by a **CAS on the shared endpoint**.
+> Live close accounting in the pipe/PTY/TCP endpoints is **per-descriptor**: a `dup`'d descriptor is a
+> second *legitimate* decrement on the same endpoint, and an endpoint-level CAS would suppress it —
+> trading a double-close for an endpoint that never hangs up. This phase owns the replacement: a
+> replay token unique to the `(row, fd)` pair being closed, surviving the unlocked window, so a
+> replayed exit-close of the same descriptor is suppressed while a legitimate close of a *different*
+> descriptor on the same endpoint still decrements. The scope and gate below are retained as the
+> shape of the phase, **not** as a ratified mechanism, and this phase's tranche cannot ratify until
+> they are rewritten and pre-checked. See the DESIGN-DEBT REGISTER.
+
+**Scope.** *(v3 repair — the API is three calls, not one, because a single `take_next_for_exit()`
+returning the descriptor cannot also retain custody of it.)* Add the three-step exit-close API:
+
+- **`FdTable::begin_fd_close(pid) -> Option<CloseTicket>` [PM]** — if the row's single `fd_in_flight`
+  slot is empty, move exactly **one** `(fd, FileDescriptor)` out of the table into it; if the slot is
+  already occupied (a claimer died mid-close), re-ticket **that** descriptor and take nothing new.
+  Returns a `CloseTicket { fd, endpoint: EndpointRef }` — a clone of the *endpoint handle*, **not**
+  the descriptor, with **no close/consume operation defined on the type**. Returns `None` only when
+  the table and the slot are both empty. Allocates nothing.
+- **`endpoint_hangup(&CloseTicket)` [no lock held]** — the only step that takes a pipe/PTY/TCP lock.
+  **P7 must make this idempotent and gate it**: the hangup is a CAS-guarded state transition on the
+  endpoint, so a replay after a dead claimer is a no-op. This is an obligation of this PR, not an
+  assumption inherited from elsewhere.
+- **`FdTable::finish_fd_close(pid)` [PM]** — set `hangup_done`, then drop the owning descriptor out
+  of the slot and clear it, in one acquisition. This is the **single destructive step**, and its
+  refcount decrement takes no endpoint lock because the hangup already ran.
+
+Retire the existing allocating `Process::take_fd_entries() -> alloc::vec::Vec` (`process.rs:335`)
+rather than reusing it. Apply at both convergence points and at Phase 2's SIGKILL commit. The `Fds`
+obligation brackets the loop (`T2` before the first `begin_fd_close`, `T3` when the table **and the
+slot** are proven empty under PM) — the explicit control flow is in DESIGN §2.5.
 
 **Files.** `kernel/src/ipc/fd.rs`, `kernel/src/process/process.rs`,
 `kernel/src/process/manager.rs`, `kernel/src/task/process_task.rs`, tests.
@@ -524,7 +1254,12 @@ proven empty under PM) — the explicit control flow is in DESIGN §2.5.
 **Gate extras.** `FD_CLOSES_UNDER_PM == 0` — a **measured drop** from the nonzero P0 baseline, not a
 zero that was always zero. 256-FD test with a large process set: measure and assert a bounded PM hold
 (one descriptor per acquisition). P0 ratchet forbids any close/reclaim call inside a request/commit
-transaction body. Soak.
+transaction body. Soak. *(v3, closure B — restated by the v3 repair against the three-step API: also assert
+`fd_in_flight` holds at most one descriptor at any sampled instant and is `None` at quiesce for every
+row; that the owning `FileDescriptor` is **never** observed outside the table or the slot; that a
+replayed `endpoint_hangup` leaves the endpoint's close count unchanged while `FD_HANGUP_REPLAYED`
+increments; and that `CloseTicket` exposes no close/consume operation — the custody invariant that
+makes `Fds` exactly-once by ownership rather than by a flag.)*
 
 **Strictly better.** Removes the pipe/PTY/TCP endpoint locks *and* a heap allocation from under
 PM+DAIF-masked on **every** exit path — a pre-existing violation on `main` that predates all of this
@@ -564,9 +1299,16 @@ pivot to neutral stack → mark **only self** `Terminated` → schedule away.
 > `sys_exit` performing no teardown inline is what makes the hook load-bearing rather than dormant.
 > **Tombstone control flow:** the victim marks its row `Zombie` and never removes it; `Zombie →
 > Tombstone` is the parent's reap (P6a) and removal is the retire gate's. **FD-acquisition control
-> flow:** `T2: Fds→Claimed` inside the commit, then `take_next_for_exit()` one descriptor per PM
-> acquisition with every close performed PM-dropped, then `T3: Fds→Completed` under a fresh
-> acquisition once the table is proven empty (DESIGN §2.5).
+> flow:** `T2: Fds→Claimed` inside the commit, then P7's three-step loop — `begin_fd_close()`
+> **[PM]** per descriptor, `endpoint_hangup(&ticket)` with PM dropped, `finish_fd_close()` **[PM]** —
+> then `T3: Fds→Completed` under a fresh acquisition once the table **and the slot** are proven empty
+> (DESIGN §2.5). *(v3, closure B, restated by the v3 repair: the descriptor lands in the ROW's
+> single-slot `fd_in_flight` and **stays there** — the unlocked step receives a non-owning
+> `CloseTicket`, and `finish_fd_close` is the one place the owning value is destroyed, in the same PM
+> acquisition that clears the slot. The earlier shape, in which one call both retained custody and
+> returned the descriptor for an unlocked close, is not a state that exists. A descriptor is
+> therefore in exactly one place at every instant and a double close is unrepresentable, which is
+> what lets `Fds` be a class-B obligation with no started/finished bits.)*
 
 **Files.** new `kernel/src/task/teardown.rs`; `kernel/src/task/process_task.rs`,
 `kernel/src/arch_impl/aarch64/context_switch.rs` (Tier-2), `kernel/src/arch_impl/aarch64/syscall_entry.rs`,
@@ -605,7 +1347,7 @@ and is withdrawn.
 > **v2 (condition 1): this phase moved AHEAD of the killable-wait families.** The ratification's first
 > FATAL was that v1's wait-family PRs (old P9a/b/c) consumed a request/wake mechanism that did not
 > exist until old P10 — no producer. The order is inverted here: P9 publishes the mechanism and
-> suppresses the victim-owned commit's remote counterpart; P10a/b/c consume it, one family per PR.
+> suppresses the victim-owned commit's remote counterpart; P10a/b/c/d consume it, one family per PR.
 
 **Scope.** `terminate_process_threads` is redefined to **request and wake**: publish
 `ThreadExitRequest` on each member's scheduler thread, return `ExitKickPlan`, and **never set a remote
@@ -630,13 +1372,61 @@ fn exit_request_is_boundary_reachable(t: &SchedThread) -> bool
   regression for blocked victims. Counted `EXIT_LEGACY_REMOTE_MARK{family}`.
 
 At P9 the "false" set is **every wait family** (none is migrated yet); it is a named allowlist in the
-P0 ratchet that may only shrink. P10a/b/c shrink it; **P10c empties it and deletes the arm.** Both
+P0 ratchet that may only shrink. P10a/b/c shrink it; **P10d empties it and deletes the arm.** Both
 arms are exercised by this PR's own tests (rule 2), so nothing dormant lands.
 
+> **v3 (closure D) — the no-new-block admission interlock ships HERE, with the predicate.** The
+> re-ratification's fourth FATAL is that the predicate is a *classification at an instant*: a victim
+> classified `true` because it is running can, one instruction later, enter an unmigrated wait — the
+> request is published, the remote mark was suppressed, and nothing ever forces it to a boundary. It
+> is not enough for the predicate to be right when evaluated; the world must not change under it.
+>
+> **Every blocking primitive gains a pre-block acquire-load of the calling thread's own exit-request
+> word and refuses to block when it is latched**, returning a refusal that the caller maps to
+> `EINTR` or its family's existing cancel path. The check lives **inside the primitives**, so no wait
+> site can forget it and no future wait site can be added without it. The nine entry points are
+> complete at `985881a6` and are pinned by a P0 ratchet rule:
+>
+> | Primitive | file:line |
+> |---|---|
+> | `Scheduler::block_current` | `task/scheduler.rs:1726` |
+> | `Scheduler::block_current_for_signal` | `task/scheduler.rs:1897` |
+> | `Scheduler::block_current_for_signal_with_context` | `task/scheduler.rs:1916` |
+> | `Scheduler::block_current_for_child_exit` | `task/scheduler.rs:2065` |
+> | `Scheduler::block_current_for_timer` | `task/scheduler.rs:2153` |
+> | `Scheduler::block_current_for_io` | `task/scheduler.rs:2218` |
+> | `Scheduler::block_current_for_io_with_timeout` | `task/scheduler.rs:2227` |
+> | `Scheduler::block_current_for_compositor` | `task/scheduler.rs:2386` |
+> | `WaitQueueHead::prepare_to_wait` | `task/waitqueue.rs:52` |
+>
+> **The classification becomes a one-way door.** From the moment a request is latched, entering an
+> unmigrated family is impossible; a victim can only move from the false set to the true set (by
+> waking), never back. That is what makes the predicate sound rather than merely plausible.
+>
+> The check costs one acquire-load of a per-thread atomic and takes **no new lock**, so it cannot
+> deadlock and cannot invert any ordering (DESIGN §4.3).
+>
+> **v3 repair — the interlock is PERMANENT, and `EXIT_BLOCK_REFUSED{family}` does not fall to zero.**
+> v3 as first written said the interlock "is **not** redundant after migration" and, in the same
+> sentence, that its counter "falls to zero as each family lands". Those cannot both hold — a guard
+> that never fires *is* redundant — and the second half is wrong about what migration changes.
+> Migration changes the fate of a victim **already blocked** when the request lands (remote mark →
+> victim-owned cancellation). It changes nothing for a victim whose request is **already latched**
+> and which then tries to *enter* that wait: it must still be refused admission, in a migrated family
+> exactly as in an unmigrated one, because letting it block would manufacture the very cancellation
+> work the interlock exists to avoid and would reopen a lost-wakeup window between the block and the
+> cancel. P9's own per-family admission-race test (gate extra 1 below) constructs exactly that
+> scenario, and it is **re-run unchanged inside each P10x PR and must still pass**. So:
+> `EXIT_BLOCK_REFUSED{family}` is asserted **nonzero before and after** migration and is never
+> asserted at zero; the counters that actually move at migration are
+> `EXIT_LEGACY_REMOTE_MARK{family}` (nonzero → 0) and the new `EXIT_WAIT_CANCELLED{family}`
+> (0 → nonzero).
+
 **Files.** `kernel/src/task/scheduler.rs`, `kernel/src/syscall/signal.rs`,
-`kernel/src/task/teardown.rs`, `kernel/src/process/manager.rs`, `kernel/src/syscall/clone.rs`.
-**~220 lines, 3 commits — at the ceiling; seam is {request API + kick plan + predicate} / {group
-scope + seal}.**
+`kernel/src/task/teardown.rs`, `kernel/src/process/manager.rs`, `kernel/src/syscall/clone.rs`,
+`kernel/src/task/waitqueue.rs` (the ninth interlock site). **~230 lines, 3 commits — AT the ceiling
+and six production files; the named split seam is {request API + kick plan + predicate + interlock} /
+{group scope + seal}, and this PR is expected to take it.**
 
 **Gate extras.** Two-CPU aarch64: kill a thread running remotely at EL0 and prove **its own TID**
 executes the exit commit, with zero post-request EL0 trace for the victim and `EXIT_VICTIM_OWNED > 0`.
@@ -645,20 +1435,54 @@ via the legacy arm, `EXIT_LEGACY_REMOTE_MARK{futex} > 0` — **the fallback is t
 Deterministic clone-vs-seal barrier: the child is either in the batch or `sys_clone` returns `EAGAIN`
 — never a runnable unrequested member. No resource claim before the batch commits. Soak.
 
+**v3 gate extras (closure D) — the race the predicate must survive, run deliberately:**
+1. **The exact instability scenario.** A victim spins at EL0, is classified `true`, and then attempts
+   to enter `sys_futex` / `pause` / `nanosleep` / a `WaitQueueHead` read — one test per family.
+   Assert in each case that the syscall returns `EINTR` **without** the thread ever reaching
+   `Blocked*`, that `EXIT_BLOCK_REFUSED{family} > 0`, and that the victim reaches the boundary hook
+   and commits its own exit. **Without the interlock this test hangs** — the PR body records that
+   pre-image so the test is proven to be a real test.
+2. **All nine primitives are covered**, not just the four with a syscall entry point: a unit-level
+   injection calls each primitive with a latched request and asserts refusal, including
+   `block_current_for_compositor` and `block_current_for_io_with_timeout`, which no userspace test
+   reaches directly.
+3. **Ratchet:** the blocking-primitive set is exactly the nine above; adding a tenth without the
+   interlock fails CI. ⚠ **DEBT-3 must be closed before this phase's tranche ratifies:**
+   `syscall/futex.rs:115` and `task/scheduler.rs:2175-2194` are live blocking publications outside
+   the nine, and a victim can still block after request publication through either. This gate as
+   written would pass while the hole stands.
+4. *(closure F; observation half named by the v3 tranche pass)* the group cutover's expedite evidence
+   is **batch-attributed**: every `EXIT_SGI_SENT` event for a group kill carries the same batch id,
+   the count matches the number of kicked members, and no event from an unrelated reschedule appears —
+   the generic send helpers are still unwired and P0's zero-baseline assertion still holds for them.
+   P9 runs **before** P8's boundary hook exists in the phase order only if the tranche is built that
+   way; as ordered here P8 precedes P9, so the observation half of this gate is
+   `EXIT_REQUEST_OBSERVED{pid}` and the `EXIT_KICK` table is already deleted. **If P9 is ever
+   re-sequenced ahead of P8, this gate reverts to `EXIT_KICK_OBSERVED{pid}` and must additionally
+   assert `EXIT_KICK_BUCKET_COLLISION == 0` for the batch** — a group kill of more than one victim is
+   exactly the workload that can alias two pids into one 64-entry bucket, which is why the collision
+   counter exists rather than being argued away.
+
 **Strictly better.** Nothing that can reach a return boundary is torn down remotely any more; group
 membership is atomic by construction; #471's seal ships. *Honest bound (R-16):* victims blocked in
 unmigrated wait families are still torn down remotely — that is P10's job, it is counted per family,
-and it is unchanged from what P2 already shipped rather than a new regression.
+and it is unchanged from what P2 already shipped rather than a new regression. *(v3: and a victim can
+no longer slip from the reachable set into an unmigrated family after classification, which was a
+correctness hole rather than a bound. Note also the new `P5 → P9` edge: this phase introduces
+group-scoped kill, so the init-sibling refusal must already be merged or P9 would hand userspace a
+way to kill init that `main` does not have.)*
 
 **Revert.** Restore the remote-marking body and pid-scoped SIGKILL — i.e. fall back to Phase 2's
 already-safe behaviour, not to `main`.
 
 ---
 
-## Phase 10 (a/b/c) — Killable-wait contract, one family per PR *(was Phase 9)*
+## Phase 10 (a/b/c/d) — Killable-wait contract, one family per PR *(was Phase 9)*
 
-**Scope.** 10a futex; 10b `WaitQueueHead` + stdin/TTY readers; 10c child-wait + timer/nanosleep +
-completion/I-O. Each sub-phase: on a fatal request the victim is made **runnable with its saved
+**Scope — v3 (closure D): the inventory is CLOSED at four families, not three.** 10a futex;
+10b `WaitQueueHead` + stdin/TTY readers; **10c `BlockedOnSignal` — `pause`/`sigsuspend` (NEW: v2
+omitted this live family while simultaneously claiming the allowlist reaches empty)**; 10d child-wait
++ timer/nanosleep + completion/I-O **and the deletion of the legacy arm**. Each sub-phase: on a fatal request the victim is made **runnable with its saved
 continuation and `blocked_in_syscall` intact**; the resumed continuation gives the latched fatal
 request priority over ordinary success, unregisters itself through the existing `finish_wait`/
 unregister path, and only then branches to the trampoline. **No `ExitPending` state** — dequeuing a
@@ -672,29 +1496,53 @@ mark* to *victim-owned exit* in the same PR. The live futex loop is the named ha
 unrelated wake can take the success branch before the signal check and leave the TID registered; the
 resumed loop must be reordered.
 
-**10c additionally deletes the legacy arm**: with the allowlist empty, `exit_request_is_boundary_reachable`
+**10c — the `BlockedOnSignal` family** *(new in v3, closure D)*. Live at `985881a6` in four
+functions with two architecture variants each way: `syscall/signal.rs:819`
+(`sys_pause_with_frame`, x86), `:1314` (`sys_sigsuspend_with_frame`, x86), `:1815`
+(`sys_pause_with_frame_aarch64`), `:2097` (`sys_sigsuspend_with_frame_aarch64`), plus the legacy
+`sys_pause` at `:769`; the wake side is `Scheduler::unblock_for_signal` (`task/scheduler.rs:1970`),
+and `tty/driver.rs:602-603` documents that the TTY unblock path already spans both `Blocked` (stdin
+read) and `BlockedOnSignal`. Each of the four blocking functions runs its own HLT/re-check loop, so
+the migration is "the resumed loop gives a latched fatal request priority over the ordinary
+signal-arrived branch, deregisters, then branches to the trampoline" — the same shape as the other
+families, applied four times. *(Why it is not folded into 10b despite the TTY adjacency: four
+syscall entry points across both architectures would put 10b well over the ~150-line/4-file target.
+OQ-8 records the batching alternative for the operator.)*
+
+**10d additionally deletes the legacy arm**: with the allowlist empty, `exit_request_is_boundary_reachable`
 becomes total, the remote-marking body of `terminate_process_threads` is deleted, and
 `EXIT_LEGACY_REMOTE_MARK` must read 0 for a full run. **This is where #491 is complete and AC-11 is
-fully discharged** — v1 claimed that at the cutover phase, which was premature.
+fully discharged** — v1 claimed that at the cutover phase, which was premature; v2 claimed it at
+P10c, which was one family short.
 
 **Files (per sub-phase).** the family's own file(s) + `kernel/src/task/scheduler.rs` +
-`kernel/src/task/teardown.rs` + its test. **~150 lines each (10c ~180), 1-2 commits each.**
+`kernel/src/task/teardown.rs` + its test. **~150 lines each (10c ~170, 10d ~180), 1-2 commits each.**
 
 **Gate extras.** Per family: inject an exit request and prove the family's registry/heap **no longer
 contains the TID before the exit commit runs** (deregistration-before-commit is the load-bearing
 assertion the ratification asked for); SIGKILL of a victim blocked in that family reaps the right
 status; `EXIT_VICTIM_OWNED` increments for that family and `EXIT_LEGACY_REMOTE_MARK{family}` drops to
-0 while remaining nonzero for families not yet migrated (both halves asserted). Families not yet
-migrated are **reported by counter** — never silently advertised as killable. **10c only:** allowlist
+0 while remaining nonzero for families not yet migrated (both halves asserted); **(v3 repair — the
+migration evidence is a *pair* of counters, and `EXIT_BLOCK_REFUSED` is not one of them)**
+`EXIT_WAIT_CANCELLED{family}` rises from 0 to nonzero — a victim found **already blocked** in this
+family at request time and cancelled by its own resumed continuation, which is the observable
+difference between "torn down remotely" and "cancelled cleanly"; and **P9's admission-race test for
+this family is re-run unchanged, still asserting `EXIT_BLOCK_REFUSED{family} > 0`**. The interlock is
+permanent: an already-latched victim is still refused admission to a *migrated* family, so a gate
+demanding this counter reach 0 would be demanding a regression. Families not yet migrated are
+**reported by counter** — never silently advertised as killable. **10c only:** all four `BlockedOnSignal` entry points tested on **both** architectures
+(two prior rounds shipped accidental x86 divergences), including the documented pause/kill race at
+`signal.rs:834` where the signal can arrive before the thread reaches `BlockedOnSignal`.
+**10d only:** allowlist
 empty asserted as an exact set, `EXIT_LEGACY_REMOTE_MARK == 0` over a full run including the group and
-CLONE_VM stress, and the ratchet asserts the remote-marking body is gone by name. Soak on 10c.
+CLONE_VM stress, and the ratchet asserts the remote-marking body is gone by name. Soak on 10d.
 
 **Strictly better.** Each family converts from "torn down remotely by the legacy arm" to "dies
 promptly, on its own thread, with its wait registration cleanly removed". Unmigrated families are
 unchanged and visible.
 
-**Revert.** Per family, independently: return the family to the allowlist (10a/10b), or restore the
-legacy arm plus the family (10c).
+**Revert.** Per family, independently: return the family to the allowlist (10a/10b/10c), or restore
+the legacy arm plus the family (10d).
 
 ---
 
@@ -727,6 +1575,11 @@ stack-slot cross-check, CR3 as root-consistency only, divergence counted and nev
 `interrupts/context_switch.rs:1021` (x86_64) converges. **`Process::terminate` is deleted** with its
 last caller.
 
+**Dependency note (v3, closure D).** `Process::terminate` cannot be deleted until **P10d** has landed:
+the legacy remote-mark arm is one of its live callers, so deleting the function while the arm exists
+would break the fallback that R-16 depends on. v2's graph permitted P11 before the deleting subphase;
+the `P10d → P11` edge is now explicit in §0.
+
 **Files.** `kernel/src/signal/delivery.rs`, `kernel/src/arch_impl/aarch64/exception.rs`,
 `kernel/src/arch_impl/aarch64/context_switch.rs`, `kernel/src/interrupts/context_switch.rs` (Tier-2),
 `kernel/src/process/process.rs`. **~220 lines, 3 commits — split by architecture if it crosses.**
@@ -752,6 +1605,17 @@ four inlined fault bodies (preserved in the commit bodies); `Process::terminate`
 
 ## Phase 12 — Init death policy *(#464 part 2 — separate PR by construction)*
 
+> ⚠ **DEBT-6 — the group-membership drop is scoped to EXTERNALLY-ORIGINATED SIGNALS ONLY, and
+> inverting that scope fails silently.** The drop applies to `ExitIntent.origin == Signal` and only
+> that — sender-agnostic, so a self-directed `kill(getpid())`/`raise` from init is still a signal and
+> is still dropped (Linux's `sig_task_ignore` consults `SIGNAL_UNKILLABLE` and disposition, never the
+> sender). **`ExitSyscall` (init's own `exit_group`, or the exit of its last member) and `FatalFault`
+> BYPASS the membership test entirely**, so init's own exit still seals, latches and reaches the
+> kernel-fatal panic. An unscoped check makes that panic path unreachable and the system hangs with
+> init alive — no assertion fires, nothing logs. This phase's gate must carry all three negatives (a
+> deliberate init `exit_group` still panics; a `FatalFault` injection still panics; an ordinary group
+> kill still works) and record the unscoped-check pre-image. See the DESIGN-DEBT REGISTER.
+
 **Scope — v2 (condition 7): Linux-faithful protected init. No `EPERM`.**
 
 - A **user-originated** signal to the designated init whose effective disposition is the default fatal
@@ -763,6 +1627,39 @@ four inlined fault bodies (preserved in the commit bodies); `Process::terminate`
   disposition-scoped, not signal-scoped.
 - Kernel-fatal, and only these: init's **own** `exit`/`exit_group`, an **unhandleable** synchronous
   fatal fault taken by init, or a nonviability invariant.
+- **v3 (closure E, end 2): the drop check is a GROUP-MEMBERSHIP test, not a row test.** S1's
+  group-seal transaction asks *"is the designated init a member of the target effective thread
+  group?"* — not *"is the target row the designated init?"*. If it is, the **entire request is
+  dropped**: nothing is sealed, no member is marked, no obligation is created, and the send returns
+  0, counted `INIT_FATAL_SIGNAL_DROPPED{group}`. The membership test runs in the **same PM
+  acquisition** as the seal it guards, so a racing clone cannot slip past it (the clone either
+  published before the transaction and is a member the test sees, or acquires PM afterwards and
+  finds a sealed group). This is defence in depth behind P5's clone-admission refusal, which already
+  makes an init sibling unconstructible; **neither end is load-bearing alone and both are separately
+  tested**, so neither can rot in the other's shadow (residual R-18).
+- **v3 repair: the drop is scoped by REQUEST ORIGIN, or it swallows init's own `exit_group`.** As
+  first written the membership test dropped *any* request whose target group contains the designated
+  init — which includes init's own `exit_group`, the very thing the bullet above declares
+  kernel-fatal. The unscoped check would silently discard it and make the required panic path
+  unreachable, inverting the policy it was added to protect. Every `ExitIntent` therefore carries an
+  explicit `origin`, set by its producer, and the drop applies to exactly one value:
+
+  | `ExitIntent.origin` | Produced by | Init-group drop? |
+  |---|---|---|
+  | `Signal` | a default-fatal signal reaching disposition with no handler installed — `sys_kill`, `sys_tgkill`, `sys_killpg`, **including a self-directed `kill(getpid(), …)` / `raise`** | **YES** — dropped, nothing sealed, send returns 0, `INIT_FATAL_SIGNAL_DROPPED{group}`++ |
+  | `ExitSyscall` | `sys_exit_group`, or `sys_exit` of the group's last member | **NO** — the seal proceeds, the request commits, `INIT_DEATH_LATCH` is set, S5 panics |
+  | `FatalFault` | an unhandleable synchronous fatal fault taken by a member (P11's converged path) | **NO** — same; this is the second kernel-fatal producer |
+
+  The `Signal` drop is deliberately **sender-agnostic**, which is both Linux-faithful and stricter
+  than "externally-originated": Linux's `sig_task_ignore` consults `SIGNAL_UNKILLABLE` and the
+  disposition, never the sender, so `kill(1, SIGKILL)` issued *by init itself* is dropped too — only
+  `force`d kernel-only signals bypass, which is exactly the `FatalFault` row. `ExitSyscall` and
+  `FatalFault` **bypass the membership test entirely**, so the kernel-fatal path is preserved by
+  construction rather than by the check happening not to fire. Note that P5's clone-admission refusal
+  makes init's group a singleton, so an `ExitSyscall`-origin request inside init's group can only
+  have come from init — no sibling exists that could issue `exit_group` on init's behalf.
+  A P0-style ratchet rule pins that `origin` is set at every `ExitIntent` construction site and that
+  the drop branch tests `origin == Signal` explicitly, never by default.
 - S1 sets `INIT_DEATH_LATCH` with one relaxed store, **only** for a committed, certainly-attributed
   victim. Because external kills are dropped at send, the latch's only producers are init's own exit
   commit (P8) and the unhandleable-fault path (P11) — a strictly smaller producer set than v1's.
@@ -772,8 +1669,8 @@ four inlined fault bodies (preserved in the commit bodies); `Process::terminate`
   `interactive = ["testing"]` cannot invert anything.
 
 **Files.** `kernel/src/syscall/signal.rs`, `kernel/src/signal/delivery.rs`,
-`kernel/src/task/teardown.rs`, `kernel/src/process/manager.rs`, tracing reader, tests.
-**~120 lines, 2 commits.**
+`kernel/src/task/teardown.rs`, `kernel/src/process/manager.rs` (the group-membership test), tracing
+reader, tests. **~140 lines, 2 commits.**
 
 **Gate extras.** `kill(1, SIGKILL)` from userspace **returns 0**, init survives, its pending signal
 set is unchanged, `INIT_FATAL_SIGNAL_DROPPED == 1`, and `INIT_DEATH_LATCH == 0`. **No test asserts
@@ -785,12 +1682,35 @@ state. `INIT_PANIC_WITH_LOCK == 0`. A normal boot asserts the latch stays 0 for 
 **including the `smoke_hello_time` harness** — the exact build all four prior attempts broke. A
 test-build PID-1 process that is *not* designated exits normally.
 
+**v3 gate extras (closure E, end 2) — the group path is tested, not assumed unreachable:**
+1. A **group-scoped** fatal request naming the effective TGID that contains the designated init is
+   dropped: `INIT_FATAL_SIGNAL_DROPPED{group} == 1`, **nothing is sealed** (the group lifecycle stays
+   `Open`, asserted directly), no member is marked, the send returns 0, and init survives.
+2. The **sibling** attack is proven unconstructible end-to-end rather than argued: the test attempts
+   `clone()` from init (refused with `EINVAL` by P5), then walks the process map at quiesce and
+   asserts **no row other than init carries init's effective TGID**. The two ends are asserted
+   separately so a regression in either is attributed correctly.
+3. A group kill aimed at an **ordinary** group is unaffected — the whole group dies, proving the
+   membership test is scoped to the designated init and is not a blanket group-kill disable.
+4. *(v3 repair — the origin carve-out is proven, not assumed.)* **Init's own `exit_group` still
+   panics through the group path.** The deliberate init-death test is re-run as an `ExitSyscall`-origin
+   group request naming init's own effective TGID: assert `INIT_FATAL_SIGNAL_DROPPED{group}` does
+   **not** increment, the group **is** sealed, `INIT_DEATH_LATCH == 1`, and S5's panic reports
+   completely with PM owner `None`. Under the unscoped membership test this request is dropped and
+   the test hangs with init alive — the PR body records that pre-image, so the carve-out is proven to
+   be load-bearing. Paired with a `FatalFault`-origin injection (init takes an unhandleable fault)
+   asserting the same latch-and-panic outcome, and with a self-directed `kill(getpid(), SIGKILL)`
+   **from init** asserting the opposite: dropped, returns 0, init survives, `INIT_DEATH_LATCH == 0`.
+
 **Strictly better.** Closes #464 with the runtime flag the issue asked for, on the fifth attempt,
 without the cfg landmine that killed the first four — and with Linux's actual semantics rather than an
-undocumented ABI divergence.
+undocumented ABI divergence. *(v3: and the protection is scoped to the group the seal actually
+operates on, so it cannot be walked around through a sibling — the composition hole the
+re-ratification found between P9's group scope and v2's row-scoped check.)*
 
-**Revert.** Delete the latch, the drop rule and the escalation call; identity (P5) survives
-independently.
+**Revert.** Delete the latch, the drop rule, the group-membership test and the escalation call;
+identity and the clone-admission refusal (P5) survive independently — which is the point of putting
+closure E's first end in P5.
 
 ---
 
@@ -800,25 +1720,29 @@ independently.
 |---|---|---|---|---|
 | P0 | — | — | — | Bypass surface pinned; #492 overflow visible; two pre-existing lock violations measured |
 | P1 | — | — | — | + grace cannot elapse unordered/empty; refusals attributable; no proof under the queue lock |
-| **P2** | **live UAF closed** (remote-mark strength) | — | — | + quarantine, expedite, SIGCHLD on kill; + no reclaim enqueue under PM |
+| P1 *(v3)* | — | — | — | + the drain cannot livelock: bounded pass + park-until-epoch-advance |
+| **P2** | **live UAF closed** (remote-mark strength) | — | — | + quarantine, expedite, SIGCHLD on kill; + no reclaim enqueue under PM; **+ receipts cannot be dropped by any of the nine adapted sites (7 callers + SIGKILL arm + `handle_thread_exit`); + expedite evidence is teardown-attributed** |
 | P3 | ↑ | — | **detach done** | + wrong-victim-after-exec impossible |
 | P4 | ↑ | — | ↑ | + all three creation paths grace-protected |
-| P5 | ↑ | **identity done** | ↑ | + AC-1/4/5 structural |
-| **P6a** | ↑ | ↑ | ↑ | + a row outlives its reap; removal is proof-gated |
-| P6b | ↑ | ↑ | ↑ | + exactly-once notification with a claim protocol (#418's own follow-up) |
+| P5 | ↑ | **identity done** | ↑ | + AC-1/4/5 structural; **+ init can never acquire a CLONE_VM sibling** |
+| **P6a** | ↑ | ↑ | ↑ | + a row outlives its reap; removal is proof-gated **and has an explicit two-event trigger in both orders** |
+| P6b | ↑ | ↑ | ↑ | + exactly-once notification with a claim protocol (#418's own follow-up); **+ four obligations commit their effect with their completion, and the two that cannot carry effect markers with a stated winner** |
 | P7 | ↑ | ↑ | ↑ | + no FD/endpoint lock or alloc under PM on any exit |
 | P8 (needs OQ-5) | ↑ | ↑ | ↑ | + normal exit is victim-owned, through the boundary hook |
-| **P9** | **nothing boundary-reachable dies remotely** | ↑ | **seal done** | + atomic group membership; legacy arm counted per family |
-| P10a/b/c | **complete at 10c** | ↑ | ↑ | + each wait family becomes promptly killable; legacy arm deleted at 10c |
+| **P9** | **nothing boundary-reachable dies remotely** | ↑ | **seal done** | + atomic group membership; legacy arm counted per family; **+ a latched victim can no longer enter a new wait, so the classification is a one-way door** |
+| P10a/b/c/d | **complete at 10d** | ↑ | ↑ | + each of the **four** wait families becomes promptly killable; legacy arm deleted at 10d |
 | P11 | ↑ | ↑ | ↑ | + one machine for all five paths; one notifier; live livelock fixed |
-| P12 | ↑ | **complete** | ↑ | + Linux-faithful init protection without the cfg landmine |
+| P12 | ↑ | **complete** | ↑ | + Linux-faithful init protection without the cfg landmine, **scoped to the group the seal operates on** |
 
-Stopping anywhere is a shippable, defensible state. **P2, P3, P5, P9, P10c, P12 are the six points
+Stopping anywhere is a shippable, defensible state. **P2, P3, P5, P9, P10d, P12 are the six points
 where an issue's headline claim actually changes** — those are the PR bodies that must be written most
 carefully, and the ones where an overstated commit message would be a blocking finding. *(v2: #491's
-"complete" milestone moved from the cutover phase to P10c, because the legacy remote-mark arm is still
-live until then. Claiming completion at P9 would be exactly the kind of overstatement the round-level
-stop rule exists to catch.)*
+"complete" milestone moved from the cutover phase to the family-deleting subphase, because the legacy
+remote-mark arm is still live until then. Claiming completion at P9 would be exactly the kind of
+overstatement the round-level stop rule exists to catch. **v3: that milestone moves once more, from
+P10c to P10d, because the `BlockedOnSignal` family was missing from v2's inventory — the completion
+point is wherever the allowlist actually empties, and it moved because the inventory was wrong, not
+because the criterion changed.*)**
 
 ## 2. Merge discipline
 
@@ -834,7 +1758,34 @@ consecutive** fix rounds, or a fix round is net-negative (closes N, introduces �
 divergence signal — **hard stop and escalate to the operator** rather than a third round. The r23
 round proved a third round on a diverging phase costs more than it closes.
 
-**Ratification gate (condition 7 of the refusal).** These revised documents must obtain a **new
-ratification pass** before implementation begins. No phase — including P0 and P1, which the reviewer
-called "the correct first two behaviour-preserving PRs" once the conditions are incorporated — is
-cleared for build until that pass returns.
+**Ratification gate — this IS condition 7, correctly labelled** *(v3, closure G)*. The seventh
+condition of the first refusal was **"close conditions 1-6 and obtain a NEW ratification pass before
+implementation begins"**. Both the v2 DESIGN and PLAN changelogs mislabelled that row as the OQ-1
+init-policy decision, which the re-ratification flagged as acceptance-contract drift; the OQ-1
+adoption is a **coordinator decision** and is now recorded as such, separately, in both changelogs.
+
+The gate itself is unchanged in force and binding: **no phase is cleared for build until a
+ratification pass returns `ENDORSE: YES` for the tranche that contains it.** Condition 7 **cannot be
+closed by the document that seeks the ratification**; it is listed as OPEN in both changelogs by
+construction, and the re-ratification was right that a document claiming to have closed it is
+claiming the wrong thing.
+
+**What the v3 tranche pass changed is the gate's SCOPE, not its strength.** Two full ratification
+passes and two pre-checks refused these documents as a whole, each time on items owned by phases far
+downstream of the ones ready to build; a single whole-document bar makes P0's readiness hostage to
+P12's argument. The gate is therefore **discharged per tranche**:
+
+- **Tranche 1 = P0 + P1 + P2** — submitted for ratification now. P0 and P1 are the two
+  behaviour-preserving PRs the first reviewer called "the correct first two"; P2 is the phase that
+  closes #491's live UAF. They are cleared for build when **tranche 1's** pass returns `ENDORSE: YES`,
+  and not before.
+- **Every later phase remains uncleared** until its own tranche is submitted, pre-checked and
+  ratified. Ratifying tranche 1 grants nothing to P3 and beyond.
+- **The DESIGN-DEBT REGISTER gates the later tranches.** A tranche containing a debt's owner phase
+  cannot be ratified until that debt's closure is *written into these documents and pre-checked*.
+  Tranche 1 owns none of the six debts, which is the entire reason it can be submitted while they
+  stand open. A tranche that contains P6a, P6b, P7, P9, P10 or P12 arrives carrying its debt closure
+  or it does not arrive.
+
+The condition is applied **more** times under this model, not fewer, and no phase ever builds on an
+unratified argument.


### PR DESCRIPTION
## Summary
- Replaces the whole-document ratification bar (refused twice by Codex Sol adversarial review) with a **tranche-ratification model**: phases are grouped into tranches that are pre-checked and ratified independently, so Tranche 1 (P0+P1+P2) can proceed while later-phase issues are tracked rather than blocking everything.
- Adds a normative **DESIGN-DEBT REGISTER** — the complete list of open items these documents do not close, each bound to the phase that owns its closure, with a binding rule: a tranche containing a debt's owner phase cannot ratify until that debt's closure is written and passes pre-check.
- Six registered debts (owners in parens): exactly-once `Report` degrading to at-most-once in one window (P6b); rejected endpoint-CAS `CloseTicket` design for `Fds` close replay, needs per-descriptor token (P7); blocking-primitive inventory not closed at nine — futex.rs and scheduler.rs paths bypass the admission interlock (P9); x86 reap path bypasses the tombstone gate (P6a); `EXIT_BLOCK_REFUSED` must never be asserted to zero post-migration (P10, repaired in v3 text); P12 group-membership drop must be scoped to externally-originated signals only, not init's own exit_group/FatalFault (P12, repaired in v3 text).
- Re-verified all file:line anchors against `main` at `985881a6`.

## Test plan
- [x] Design-only doc change; no code/runtime impact
- [x] Files copied verbatim from ratified v3 scratchpad sources