### PR TITLE
teardown-unification P0: observability ratchet

### DIFF
--- a/docker/qemu/run-aarch64-boot-test-native.sh
+++ b/docker/qemu/run-aarch64-boot-test-native.sh
@@ -90,12 +90,13 @@ run_single_test() {
     #   "breenix>" or "bsh " - shell prompt on serial (legacy/direct mode)
     #   "[bwm] Display:" - BWM window manager initialized (shell runs inside PTY)
     #   "[bcheck] Complete:" - bcheck self-test suite finished (headless/no-VirGL mode)
+    #   "[heartbeat]" - the default ARM64 init service executed in userspace
     # DO NOT accept "Interactive Shell" - that's the KERNEL FALLBACK when userspace FAILS
     local BOOT_COMPLETE=false
     local CRASH_TYPE=""
     for i in $(seq 1 10); do
         if [ -f "$OUTPUT_DIR/serial.txt" ]; then
-            if grep -qE "(breenix>|bsh |\[bwm\] Display:|\[bcheck\] Complete:)" "$OUTPUT_DIR/serial.txt" 2>/dev/null; then
+            if grep -qE "(breenix>|bsh |\[bwm\] Display:|\[bcheck\] Complete:|\[heartbeat\])" "$OUTPUT_DIR/serial.txt" 2>/dev/null; then
                 BOOT_COMPLETE=true
                 break
             fi

--- a/docker/qemu/run-aarch64-full-test.sh
+++ b/docker/qemu/run-aarch64-full-test.sh
@@ -11,10 +11,11 @@
 # prompt, this test waits for the full 84-test suite to complete and then
 # monitors sustained operation under GPU load.
 #
-# Usage: ./run-aarch64-full-test.sh [--rebuild]
+# Usage: ./run-aarch64-full-test.sh [--rebuild] [--boot-tests-only]
 #
 # Options:
-#   --rebuild   Force rebuild of the kernel before testing
+#   --rebuild          Force rebuild of the kernel before testing
+#   --boot-tests-only  Stop after the registered boot-test suite passes
 
 set -e
 
@@ -23,9 +24,11 @@ BREENIX_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Parse args
 REBUILD=false
+BOOT_TESTS_ONLY=false
 for arg in "$@"; do
     case "$arg" in
         --rebuild) REBUILD=true ;;
+        --boot-tests-only) BOOT_TESTS_ONLY=true ;;
     esac
 done
 
@@ -80,7 +83,7 @@ echo ""
 
 # Start QEMU in background (120s total timeout — 84 tests need time)
 timeout 120 qemu-system-aarch64 \
-    -M virt -cpu cortex-a72 -m 512 -smp 4 \
+    -M virt,gic-version=3 -cpu max -m 512 -smp 4 \
     -kernel "$KERNEL" \
     -display none -no-reboot \
     -device virtio-gpu-device \
@@ -176,7 +179,7 @@ if ! $PHASE1_OK && [ -z "$FAIL_REASON" ]; then
 fi
 
 # --- Phase 2: Verify services (10s) ---
-if [ -z "$FAIL_REASON" ]; then
+if [ -z "$FAIL_REASON" ] && ! $BOOT_TESTS_ONLY; then
     echo "Phase 1: PASS (${TESTS_PASSED}/${TESTS_TOTAL} tests)"
     echo ""
     echo "Phase 2: Checking services..."
@@ -213,7 +216,7 @@ fi
 # --- Phase 3: Sustained operation under GPU load (15s) ---
 # This catches the crashes that only manifest under sustained GPU rendering
 # (e.g., bounce demo, btop updating, BWM rendering test progress).
-if [ -z "$FAIL_REASON" ]; then
+if [ -z "$FAIL_REASON" ] && ! $BOOT_TESTS_ONLY; then
     echo ""
     echo "Phase 3: Sustained operation soak (15 seconds)..."
     for check in $(seq 1 5); do
@@ -250,10 +253,16 @@ TOTAL_LINES=${TOTAL_LINES:-0}
 
 if [ -z "$FAIL_REASON" ]; then
     echo "========================================="
-    echo "ARM64 FULL SYSTEM TEST: PASSED"
+    if $BOOT_TESTS_ONLY; then
+        echo "ARM64 BOOT TESTS: PASSED"
+    else
+        echo "ARM64 FULL SYSTEM TEST: PASSED"
+    fi
     echo "========================================="
     echo "Tests: ${TESTS_PASSED}/${TESTS_TOTAL} passed"
-    echo "Stability: 15s soak clean"
+    if ! $BOOT_TESTS_ONLY; then
+        echo "Stability: 15s soak clean"
+    fi
     echo "Serial: ${TOTAL_LINES} lines"
     echo "Log: $OUTPUT_DIR/serial.txt"
     exit 0

--- a/docs/planning/teardown-unification/PLAN.md
+++ b/docs/planning/teardown-unification/PLAN.md
@@ -247,10 +247,13 @@ as its own subphase makes the true figure **17 PRs**. Every one is listed; there
    - `cargo build --release --features testing,external_test_bins --bin qemu-uefi`
    - `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64`
    - the aarch64 `ec0_fault_inject` config
-2. **QEMU boot/regression:** `./docker/qemu/run-boot-parallel.sh` (x86) + the aarch64 native/strict
-   boot test. Tests must reach the real `KERNEL_POST_TESTS_COMPLETE` marker — a marker printed before
-   the behaviour under test is never accepted as evidence. **QEMU concurrency capped at 4** per
-   standing operator rule (batch 4 and 4, never 8+).
+2. **QEMU boot/regression:** `./docker/qemu/run-boot-parallel.sh` (x86) +
+   `./docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only` (aarch64 `boot_tests`
+   runtime gates) plus the aarch64 native/strict boot test. The aarch64 runtime gate must reach
+   `[BOOT_TESTS:PASS]`; the ordinary boot paths must reach the
+   real `KERNEL_POST_TESTS_COMPLETE` marker. A marker printed before the behaviour under test is never
+   accepted as evidence. **QEMU concurrency capped at 4** per standing operator rule (batch 4 and 4,
+   never 8+).
 3. **Phase-specific assertions** below — every one an observed outcome (counter equality, actual
    `waitpid` status, zero fault markers). "The process was created" is never evidence, and **a
    counter equality that holds at zero is never evidence** (condition 6): every equality gate names
@@ -475,6 +478,11 @@ declarations in the same new provider file and the added ratchet rules are asser
 test file, so the file count does not grow.)*
 
 **Gate extras.** *(v2 — condition 6: no vacuous zero-baseline gate.)*
+The two P0 runtime extras below are registered in the parallel boot-test framework and execute under
+the aarch64 standard-gate command above: `run-aarch64-full-test.sh --rebuild --boot-tests-only`
+enables `boot_tests`, runs the EarlyBoot and PostScheduler stages, and accepts only the final
+`[BOOT_TESTS:PASS]` result.
+
 1. **`fork_exit_defer_reclaim_pairing_test` (the causally-paired nonzero gate).** Fork and exit **64**
    children in a loop, then quiesce. Assert (a) `TEARDOWN_ENTRY{exit} >= 64`; (b) `TEARDOWN_DEFER >= 64`;
    (c) after the drain, `TEARDOWN_DEFER == TEARDOWN_RECLAIM` **at a value ≥ 64** — the equality is only

--- a/docs/planning/teardown-unification/PLAN.md
+++ b/docs/planning/teardown-unification/PLAN.md
@@ -30,8 +30,8 @@ it un-skippable.
 > not enough; it must survive the same adversarial pre-check that produced the debt. A tranche may be
 > submitted while debts owned by *later* phases remain open, and only while that is true.
 >
-> **Tranche 1 = P0 + P1 + P2. It owns none of the six debts below** (their owners are P6a, P6b, P7,
-> P9, P10 and P12), which is precisely why it is submitted for ratification now.
+> **Tranche 1 = P0 + P1 + P2. It owns none of the seven debts below** (their owners are P6a, P6b,
+> P7, P8, P9, P10 and P12), which is precisely why it is submitted for ratification now.
 
 | Debt | Owner phase | What must be true before that phase's tranche can ratify | Source finding |
 |---|---|---|---|
@@ -41,6 +41,7 @@ it un-skippable.
 | **DEBT-4 — the x86 reap path bypasses the tombstone gate** | **P6a** | P6a's whole claim is that a row is removed only by the **two-event join** (`reaped` ∧ `retired`, whichever writer sees the other flag set performs the removal). **`kernel/src/syscall/handlers.rs:3101` removes the row directly on the live x86 reap path**, so the join is not the only remover and the retention gate can pass on aarch64 while x86 still frees a row out from under an un-retired receipt. Before P6a's tranche: that site routes through the join, **or** P6a's retention gate is honestly re-scoped to aarch64 with the x86 divergence named in AC-12's evidence column, a ratchet pinning `handlers.rs:3101` by name, and a stated phase that closes it. Scoping the gate narrowly to avoid tripping on it, without naming it, is not available | v3 pre-check and re-check, item **B NOT-CLOSED** (second half, both passes): *"P6a omits the live x86 reap at `kernel/src/syscall/handlers.rs:3101`, which still removes the row directly"*. PLAN P6a |
 | **DEBT-5 — `EXIT_BLOCK_REFUSED` post-migration semantics: it is NEVER asserted to zero** | **P10** *(a/b/c/d)* | The admission interlock is **permanent**, not scaffolding. Migration changes only the fate of a victim *already* blocked; it does not change the refusal owed to an already-latched victim trying to **enter** a migrated wait — which must stay refused, or migration manufactures cancellation work and reopens a lost-wakeup window between block and cancel. Therefore: **no gate anywhere may assert `EXIT_BLOCK_REFUSED{family} == 0`**, before or after migration. `EXIT_BLOCK_REFUSED{family}` is asserted **nonzero** in P9's own admission-race test and **re-asserted nonzero** in each of P10a-d; the migration evidence is the *pair* `EXIT_LEGACY_REMOTE_MARK{family} → 0` and `EXIT_WAIT_CANCELLED{family} → nonzero`. This debt is **repaired in the v3 text**; it is registered because it is a standing guard that a later phase can silently break, and because the failure mode (a "tidy-up" that asserts the counter to zero once migration is done) reads like cleanup | v3 pre-check, MAJOR item 5: *"P10's requirement that `EXIT_BLOCK_REFUSED{family}` hits zero post-migration contradicts the permanent admission interlock"*. DESIGN §1.5, §3 AC-11; PLAN P0 counter table, P9, P10a-d |
 | **DEBT-6 — P12's group-membership drop is scoped to EXTERNALLY-ORIGINATED signals only** | **P12** | The S1 group-seal check drops a fatal request when the designated init is a member of the **target group**. That drop applies to **`ExitIntent.origin == Signal` only** — sender-agnostic (a self-directed `kill(getpid())`/`raise` is still a signal and is still dropped, matching Linux's `sig_task_ignore`, which consults `SIGNAL_UNKILLABLE` and disposition and never the sender). **`ExitSyscall`** (init's own `exit_group`, or the exit of its last member) **and `FatalFault` BYPASS the membership test entirely**, so init's own exit still seals, latches and reaches the kernel-fatal panic. An unscoped check makes that panic path unreachable and the system hangs with init alive — a silent inversion of the policy. P12's gate must include the negative (a deliberate init `exit_group` still panics; a `FatalFault` injection still panics; an ordinary group kill still works) and record the unscoped-check pre-image. This debt is **repaired in the v3 text** and is registered because the failure is silent | v3 pre-check, MAJOR item 6: *"P12's group-membership signal drop isn't scoped to externally-originated signals; as written it would also suppress init's own `exit_group`, contradicting the required panic path"*. DESIGN §2.2 (End 2); PLAN P12 |
+| **DEBT-7 — P0 defer/reclaim evidence is aggregate-only, not per-PID causal pairing** | **P8** | P0's `TraceCounter` substrate stores only per-CPU scalar totals, so its nonzero workload delta can prove aggregate balancing but cannot prove that process X's defer is followed by process X's reclaim. Sampling live `TRACE_BUFFERS` is not an acceptable substitute: `iter_events()` requires tracing to be disabled, and disabling every provider during a boot test drops unrelated live-boot evidence. Before P8's tranche can ratify, add a race-free, bounded correlation mechanism keyed by PID and restore the stronger gate: every one of the test's 64 child PIDs has exactly one defer followed by exactly one reclaim. The mechanism must not sample live trace rings, disable tracing or providers system-wide, or add unbounded test storage; P8 owns this because it introduces the round's real per-PID boundary-observation infrastructure | P0 observability STRIP+SIMPLIFY review round 2, S1. `tracing/providers/teardown.rs`; `tracing/buffer.rs::iter_events`; PLAN P0 gate extra 1 and P8 |
 
 **Not in this register, and why.** Items the pre-checks raised that are *closed in the v3 text* and
 carry no further obligation are recorded in the changelogs, not here: the seven-vs-nine caller count
@@ -169,7 +170,7 @@ P10a/b/c/d, so "P10c empties the allowlist" reads **P10d** today, and "16 PRs" r
 | **3** | **P1** restructures the reclaim drain to *detach → drop queue lock → prove → free-or-reinsert*; the under-queue-lock predicate stays lock-free. **P2** changes `exit_process` to return a `#[must_use] RetirementReceipt` and converts **both** existing PM-nested `enqueue_process_reclaim` sites | P1, P2 |
 | **4** | **P8** now states the hook-activation control flow explicitly (the hook is the *only* entry to `do_exit_current`, so normal exit exercises it in this PR), plus the tombstone and one-at-a-time FD-acquisition control flow Codex's P8 note called for | P8 |
 | **5** | **P11** deletes `DeliverResult::Terminated` **and** its caller-side parent-notification action in the same PR, replacing it with intent-only `DeliverResult::FatalIntent` | P11 |
-| **6** | **P0** names every existing teardown write-site (file:line) each counter attaches to, marks which counters are legitimately zero until a later phase, and adds a **nonzero causally-paired** defer/reclaim test. The **honest PR count is 13 numbered phases / 16 PRs**, enumerated below. The false "P3/P4/P5 are file-disjoint from P2, so they can merge in parallel" claim is **deleted** — the file lists overlap and all phases merge sequentially | P0, §0 PR ledger, §0 graph |
+| **6** | **P0** names every existing teardown write-site (file:line) each counter attaches to, marks which counters are legitimately zero until a later phase, and adds a **nonzero aggregate-delta** defer/reclaim test. The stronger per-PID causal claim originally written here is not supported by P0's aggregate counters and is now registered as **DEBT-7**, owned by P8. The **honest PR count is 13 numbered phases / 16 PRs**, enumerated below. The false "P3/P4/P5 are file-disjoint from P2, so they can merge in parallel" claim is **deleted** — the file lists overlap and all phases merge sequentially | P0, §0 PR ledger, §0 graph, DEBT-7 |
 | **7** | *(corrected in v3 — closure G)* The real condition 7 is **"close conditions 1-6 and obtain a NEW ratification pass before implementation begins"**. v2 mislabelled this row as the OQ-1 decision. It is **OPEN by construction** and is closed only when a fresh pass returns `ENDORSE: YES`. *(v3 tranche pass: the gate is now **tranche-scoped** — condition 7 is discharged per tranche, not once for the whole document. Tranche 1 (P0+P1+P2) is submitted; P0/P1/P2 are cleared for build when **that tranche's** pass returns `ENDORSE: YES`, and every later phase stays uncleared until its own tranche ratifies, with the DESIGN-DEBT REGISTER's rule gating any tranche that contains a debt owner. The condition itself is not weakened — it is applied more times, not fewer.)* | §2 ratification gate, **DESIGN-DEBT REGISTER** |
 
 **Coordinator decision recorded separately (NOT a ratification condition — closure G).** **P12**
@@ -253,7 +254,13 @@ as its own subphase makes the true figure **17 PRs**. Every one is listed; there
    `[BOOT_TESTS:PASS]`; the ordinary boot paths must reach the
    real `KERNEL_POST_TESTS_COMPLETE` marker. A marker printed before the behaviour under test is never
    accepted as evidence. **QEMU concurrency capped at 4** per standing operator rule (batch 4 and 4,
-   never 8+).
+   never 8+). **Known pre-existing flake:** the `timer:time` family, currently emitted as
+   `timer:timer_quantum_reset_aarch64`, reproduced against plain-main kernel sources with this GICv3
+   gate runner in three consecutive runs: **PASS 84/84; PASS 84/84; FAIL 84/84** with
+   `[TEST:timer:timer_quantum_reset_aarch64:FAIL:reset_quantum did not increment counter - ARM64 reset is a no-op]`.
+   On that named failure only, retry the full command up to **two** times; any other failure, or the
+   same failure after both retries, is a hard failure. A tracking issue for the underlying timer
+   flake is still required.
 3. **Phase-specific assertions** below — every one an observed outcome (counter equality, actual
    `waitpid` status, zero fault markers). "The process was created" is never evidence, and **a
    counter equality that holds at zero is never evidence** (condition 6): every equality gate names
@@ -376,7 +383,7 @@ the *exact current* bypass surface so any regression fails CI immediately.
 | `TEARDOWN_ENTRY{fault}` | `task/process_task.rs:369` (`handle_thread_exit(tid, -11)` inside `drain_deferred_fault_sigsegv_exits`, `:363`) + the four EL0 fault sites `arch_impl/aarch64/exception.rs:768,1135,1230,1333` | yes under the fault tests |
 | `TEARDOWN_ENTRY{signal}` | `syscall/signal.rs:162`, `signal/delivery.rs:224`, `:258` | yes under the signal tests |
 | `TEARDOWN_ENTRY{group}` | *(no group path exists on `main`)* | **declared zero until P9** — not part of any equality gate before then |
-| `EXIT_FIRST_REQUESTS` / `EXIT_REPEAT_REQUESTS` | the `already_terminated` reads at `process/manager.rs:1121` and `task/process_task.rs:222`, plus `Process::terminate_minimal`'s repeat early-return (`process/process.rs:320`) | yes (first); repeat is exercised by the P0 repeat test |
+| `EXIT_FIRST_REQUESTS` / `EXIT_REPEAT_REQUESTS` | the `already_terminated` reads at `process/manager.rs:1121` and `task/process_task.rs:222` | yes (first); repeat is exercised by the P0 repeat test |
 | `TEARDOWN_QUARANTINE` | `task/scheduler.rs:2599 terminate_process_threads` (five call sites: `exception.rs:768,1135,1230,1333`, and `signal.rs` from P2) | yes under the fault tests |
 | `EXIT_SGI_SENT` *(re-wired in v3 — closure F)* | **NOT** the generic sends. `task/scheduler.rs:1857` is inside `send_resched_ipi` (`:1843`), which wakes **idle** CPUs, and `:1886` is inside `send_resched_ipi_to_cpu` (`:1868`), which targets the CPU that got a **newly runnable task** — neither knows a victim, so wiring them makes every ordinary wakeup satisfy a "> 0" gate. The counter is written **only** by the teardown-specific `Scheduler::send_exit_expedite_sgi(victim_pid, batch)` that P2 introduces, carrying the victim pid in the `trace_event!` payload | **declared zero until P2** — the write site does not exist before then; excluded from every gate until P2 |
 | `EXIT_REQUEST_OBSERVED` *(new, closure F)* | the boundary hook's first observation of a latched request, carrying the observed pid — i.e. the paired consumer side of `EXIT_SGI_SENT{pid}` **from P8 onward** | **declared zero until P8** (the hook does not exist before then). P2 and P9 pair against the **`EXIT_KICK` bucket proxy** specified in DESIGN §2.7 — *not* against this counter, and not against an unnamed "P2-era proxy" *(v3 tranche pass: the proxy is now a specified mechanism; the earlier wording pointed at gates that pointed back at it)* |
@@ -483,23 +490,21 @@ the aarch64 standard-gate command above: `run-aarch64-full-test.sh --rebuild --b
 enables `boot_tests`, runs the EarlyBoot and PostScheduler stages, and accepts only the final
 `[BOOT_TESTS:PASS]` result.
 
-1. **`fork_exit_defer_reclaim_pairing_test` (the causally-paired nonzero gate).** Fork and exit **64**
+1. **`fork_exit_defer_reclaim_pairing_test` (the aggregate-delta nonzero gate).** Fork and exit **64**
    children in a loop, then quiesce. Assert (a) `TEARDOWN_ENTRY{exit} >= 64`; (b) `TEARDOWN_DEFER >= 64`;
    (c) after the drain, `TEARDOWN_DEFER == TEARDOWN_RECLAIM` **at a value ≥ 64** — the equality is only
-   accepted at a nonzero, workload-explained value; (d) **per-pid pairing**: each deferred pid recorded
-   by a `trace_event!` payload appears exactly once in a later reclaim event, so the equality cannot be
-   satisfied by two unrelated streams that happen to have equal totals.
+   accepted at a nonzero, workload-explained value. This proves aggregate balancing only; the current
+   counters have no PID dimension and therefore cannot prove per-PID causality. **DEBT-7** assigns that
+   stronger proof to P8, where real per-PID observation infrastructure enters the round.
 2. Ring-overflow injection drives `DEFERRED_FAULT_RING_DROPPED` nonzero and back to a quiescent read.
 3. Baseline snapshot of `TEARDOWN_MASKED_FRAMES_WALKED`, `FD_CLOSES_UNDER_PM` and
    `RECLAIM_ENQUEUE_UNDER_PM` on `main` — these are **expected nonzero** and are the pre-existing
    defects later phases drive to zero; recording the baseline is what makes those later gates meaningful.
 4. `TEARDOWN_LOCK_ORDER_SUSPECT == 0`, `PROOF_UNDER_QUEUE_LOCK == 0`, and every counter has a reader
    (no write-only counters).
-5. *(v3 — closure F)* **A negative assertion that `EXIT_SGI_SENT` is zero on a normal boot**, proving
-   it is not wired to the generic send helpers. A boot performs many reschedule IPIs; if the counter
-   moves at P0, the wiring is wrong and the phase fails. This is the inverse of a vacuous-zero gate:
-   the zero is the *evidence*, and it is explained by a named workload (every boot sends reschedule
-   IPIs) rather than by absence of activity.
+5. *(v3 — closure F)* **`EXIT_SGI_SENT` is declaration-only until P2 and is excluded from P0 runtime
+   gates.** The structural ratchet forbids it in the generic reschedule helpers and pins its eventual
+   producer to the teardown-only helper; P0 deliberately does not use equality-at-zero as evidence.
 6. *(v3 — closures A, D, E)* The five new ratchet rules pass on `main` unchanged, and each is proven
    to be a real constraint by a deliberately-broken variant in the test: adding a tenth blocking
    primitive, a second `thread_group_id` write, an **eighth** `exit_process` caller *(v3 repair — the
@@ -1904,9 +1909,9 @@ P12's argument. The gate is therefore **discharged per tranche**:
   ratified. Ratifying tranche 1 grants nothing to P3 and beyond.
 - **The DESIGN-DEBT REGISTER gates the later tranches.** A tranche containing a debt's owner phase
   cannot be ratified until that debt's closure is *written into these documents and pre-checked*.
-  Tranche 1 owns none of the six debts, which is the entire reason it can be submitted while they
-  stand open. A tranche that contains P6a, P6b, P7, P9, P10 or P12 arrives carrying its debt closure
-  or it does not arrive.
+  Tranche 1 owns none of the seven debts, which is the entire reason it can be submitted while they
+  stand open. A tranche that contains P6a, P6b, P7, P8, P9, P10 or P12 arrives carrying its debt
+  closure or it does not arrive.
 
 The condition is applied **more** times under this model, not fewer, and no phase ever builds on an
 unratified argument.

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -317,7 +317,11 @@ fn terminate_current_scheduler_thread() {
     }
 }
 
-fn defer_current_user_thread_sigsegv_exit(label: &str, frame_addr: u64) {
+fn defer_current_user_thread_sigsegv_exit(
+    label: &str,
+    frame_addr: u64,
+    entry_already_counted: bool,
+) {
     use crate::arch_impl::aarch64::context_switch::{raw_uart_dec, raw_uart_str};
 
     // Publish the deferred exit only after this CPU has left the retiring root
@@ -336,6 +340,9 @@ fn defer_current_user_thread_sigsegv_exit(label: &str, frame_addr: u64) {
     });
 
     if let Some(tid) = victim_tid {
+        if !entry_already_counted {
+            crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_FAULT);
+        }
         let queued = crate::task::process_task::defer_fault_sigsegv_exit(tid);
         raw_uart_str(label);
         raw_uart_str(" deferred_tid=");
@@ -346,6 +353,49 @@ fn defer_current_user_thread_sigsegv_exit(label: &str, frame_addr: u64) {
     } else {
         raw_uart_str(label);
         raw_uart_str(" deferred_tid=none\n");
+    }
+}
+
+/// Resolve an EL0 fault victim and record whether the CR3 and dispatched-TID
+/// evidence agree. The dispatched TID is read from the existing lock-free
+/// per-CPU dispatch record so this exception path never acquires SCHEDULER.
+fn resolve_el0_fault_victim(page_table_phys: u64) -> Option<(crate::process::ProcessId, bool)> {
+    let cpu_id = crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as usize;
+    let dispatched_tid =
+        crate::arch_impl::aarch64::context_switch::last_dispatched_tid(cpu_id);
+    let resolution = crate::process::with_process_manager(|pm| {
+        let tid_owner = dispatched_tid.and_then(|tid| {
+            pm.find_process_by_thread(tid)
+                .map(|(pid, _process)| pid)
+        });
+        let cr3_victim = pm
+            .find_process_by_cr3_mut(page_table_phys)
+            .map(|(pid, process)| (pid, process.is_terminated()));
+        (tid_owner, cr3_victim)
+    });
+
+    let (tid_owner, cr3_victim) = resolution.unwrap_or((None, None));
+    if cr3_victim.is_none() {
+        crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_CR3_MISS);
+    }
+
+    match (tid_owner, cr3_victim) {
+        (Some(tid_pid), Some((cr3_pid, was_terminated))) => {
+            if tid_pid != cr3_pid {
+                crate::trace_count!(
+                    crate::tracing::providers::teardown::TEARDOWN_VICTIM_DIVERGENCE
+                );
+            }
+            Some((cr3_pid, was_terminated))
+        }
+        (None, Some(victim)) => Some(victim),
+        (Some(_), None) => None,
+        (None, None) => {
+            crate::trace_count!(
+                crate::tracing::providers::teardown::EXIT_ATTRIBUTION_UNCERTAIN
+            );
+            None
+        }
     }
 }
 
@@ -759,17 +809,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 // across the scheduler-side non-runnable transition.
                 let mut terminated = false;
                 let mut already_terminated = false;
-                let victim = crate::process::with_process_manager(|pm| {
-                    pm.find_process_by_cr3_mut(page_table_phys)
-                        .map(|(pid, process)| (pid, process.is_terminated()))
-                })
-                .flatten();
-                if victim.is_none() {
-                    crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_CR3_MISS);
-                    crate::trace_count!(
-                        crate::tracing::providers::teardown::EXIT_ATTRIBUTION_UNCERTAIN
-                    );
-                }
+                let victim = resolve_el0_fault_victim(page_table_phys);
                 if let Some((pid, was_terminated)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
@@ -814,7 +854,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 use crate::arch_impl::aarch64::context_switch::raw_uart_str;
                 raw_uart_str("[DATA_ABORT] kernel-mode fault, deferring process cleanup\n");
             }
-            defer_current_user_thread_sigsegv_exit("[DATA_ABORT]", frame as u64);
+            defer_current_user_thread_sigsegv_exit("[DATA_ABORT]", frame as u64, from_el0);
             dump_fatal_postmortem_once("DATA_ABORT");
             drop(fatal_uart_guard);
 
@@ -1133,17 +1173,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 let mut terminated = false;
                 let mut already_terminated = false;
                 let mut killed_pid: u64 = 0;
-                let victim = crate::process::with_process_manager(|pm| {
-                    pm.find_process_by_cr3_mut(page_table_phys)
-                        .map(|(pid, process)| (pid, process.is_terminated()))
-                })
-                .flatten();
-                if victim.is_none() {
-                    crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_CR3_MISS);
-                    crate::trace_count!(
-                        crate::tracing::providers::teardown::EXIT_ATTRIBUTION_UNCERTAIN
-                    );
-                }
+                let victim = resolve_el0_fault_victim(page_table_phys);
                 if let Some((pid, was_terminated)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
@@ -1192,7 +1222,11 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 use crate::arch_impl::aarch64::context_switch::raw_uart_str;
                 raw_uart_str("[INSTRUCTION_ABORT] deferring process cleanup\n");
             }
-            defer_current_user_thread_sigsegv_exit("[INSTRUCTION_ABORT]", frame as u64);
+            defer_current_user_thread_sigsegv_exit(
+                "[INSTRUCTION_ABORT]",
+                frame as u64,
+                from_el0,
+            );
             terminate_current_scheduler_thread();
             crate::task::scheduler::set_need_resched();
             frame_ref.elr = crate::arch_impl::aarch64::idle_loop_arm64 as *const () as u64;
@@ -1235,17 +1269,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 }
                 let page_table_phys = ttbr0 & !0xFFFF_0000_0000_0FFF;
                 super::quiesce_ttbr0_for_exit();
-                let victim = crate::process::with_process_manager(|pm| {
-                    pm.find_process_by_cr3_mut(page_table_phys)
-                        .map(|(pid, process)| (pid, process.is_terminated()))
-                })
-                .flatten();
-                if victim.is_none() {
-                    crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_CR3_MISS);
-                    crate::trace_count!(
-                        crate::tracing::providers::teardown::EXIT_ATTRIBUTION_UNCERTAIN
-                    );
-                }
+                let victim = resolve_el0_fault_victim(page_table_phys);
                 if let Some((pid, _)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
@@ -1345,17 +1369,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 }
                 let page_table_phys = ttbr0 & !0xFFFF_0000_0000_0FFF;
                 super::quiesce_ttbr0_for_exit();
-                let victim = crate::process::with_process_manager(|pm| {
-                    pm.find_process_by_cr3_mut(page_table_phys)
-                        .map(|(pid, process)| (pid, process.is_terminated()))
-                })
-                .flatten();
-                if victim.is_none() {
-                    crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_CR3_MISS);
-                    crate::trace_count!(
-                        crate::tracing::providers::teardown::EXIT_ATTRIBUTION_UNCERTAIN
-                    );
-                }
+                let victim = resolve_el0_fault_victim(page_table_phys);
                 if let Some((pid, _)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -676,6 +676,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
             }
 
             if from_el0 {
+                crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_FAULT);
                 // Page table walk diagnostic: dump L0-L3 entries for the fault VA
                 // to understand why the mapping is missing or has wrong permissions.
                 {
@@ -763,6 +764,12 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                         .map(|(pid, process)| (pid, process.is_terminated()))
                 })
                 .flatten();
+                if victim.is_none() {
+                    crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_CR3_MISS);
+                    crate::trace_count!(
+                        crate::tracing::providers::teardown::EXIT_ATTRIBUTION_UNCERTAIN
+                    );
+                }
                 if let Some((pid, was_terminated)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
@@ -1115,6 +1122,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
             drop(fatal_uart_guard);
 
             if from_el0 {
+                crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_FAULT);
                 // From userspace - terminate the process with SIGSEGV
                 let page_table_phys = ttbr0 & !0xFFFF_0000_0000_0FFF;
 
@@ -1130,6 +1138,12 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                         .map(|(pid, process)| (pid, process.is_terminated()))
                 })
                 .flatten();
+                if victim.is_none() {
+                    crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_CR3_MISS);
+                    crate::trace_count!(
+                        crate::tracing::providers::teardown::EXIT_ATTRIBUTION_UNCERTAIN
+                    );
+                }
                 if let Some((pid, was_terminated)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
@@ -1214,6 +1228,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 raw_uart_str("\n");
             }
             if from_el0 {
+                crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_FAULT);
                 let ttbr0: u64;
                 unsafe {
                     core::arch::asm!("mrs {}, ttbr0_el1", out(reg) ttbr0, options(nomem, nostack));
@@ -1225,6 +1240,12 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                         .map(|(pid, process)| (pid, process.is_terminated()))
                 })
                 .flatten();
+                if victim.is_none() {
+                    crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_CR3_MISS);
+                    crate::trace_count!(
+                        crate::tracing::providers::teardown::EXIT_ATTRIBUTION_UNCERTAIN
+                    );
+                }
                 if let Some((pid, _)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
@@ -1317,6 +1338,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 raw_uart_str("\n");
             }
             if from_el0 {
+                crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_FAULT);
                 let ttbr0: u64;
                 unsafe {
                     core::arch::asm!("mrs {}, ttbr0_el1", out(reg) ttbr0, options(nomem, nostack));
@@ -1328,6 +1350,12 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                         .map(|(pid, process)| (pid, process.is_terminated()))
                 })
                 .flatten();
+                if victim.is_none() {
+                    crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_CR3_MISS);
+                    crate::trace_count!(
+                        crate::tracing::providers::teardown::EXIT_ATTRIBUTION_UNCERTAIN
+                    );
+                }
                 if let Some((pid, _)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -743,7 +743,7 @@ fn handle_cow_fault(faulting_addr: VirtAddr, error_code: PageFaultErrorCode, cr3
 
 /// Handle CoW fault through the process manager (normal path)
 fn handle_cow_with_manager(
-    guard: &mut spin::MutexGuard<'static, Option<crate::process::ProcessManager>>,
+    guard: &mut crate::process::TryProcessManagerGuard,
     faulting_addr: VirtAddr,
     cr3: u64,
 ) -> bool {

--- a/kernel/src/interrupts/context_switch.rs
+++ b/kernel/src/interrupts/context_switch.rs
@@ -340,7 +340,7 @@ fn save_current_thread_context_with_guard(
     thread_id: u64,
     saved_regs: &mut SavedRegisters,
     interrupt_frame: &mut InterruptStackFrame,
-    manager_guard: &mut spin::MutexGuard<'static, Option<crate::process::ProcessManager>>,
+    manager_guard: &mut crate::process::TryProcessManagerGuard,
 ) -> bool {
     if let Some(ref mut manager) = **manager_guard {
         if let Some((pid, process)) = manager.find_process_by_thread_mut(thread_id) {
@@ -378,7 +378,7 @@ fn save_kernel_context_with_guard(
     thread_id: u64,
     saved_regs: &SavedRegisters,
     interrupt_frame: &InterruptStackFrame,
-    manager_guard: &mut spin::MutexGuard<'static, Option<crate::process::ProcessManager>>,
+    manager_guard: &mut crate::process::TryProcessManagerGuard,
 ) {
     if let Some(ref mut manager) = **manager_guard {
         if let Some((_pid, process)) = manager.find_process_by_thread_mut(thread_id) {
@@ -471,9 +471,7 @@ fn switch_to_thread(
     thread_id: u64,
     saved_regs: &mut SavedRegisters,
     interrupt_frame: &mut InterruptStackFrame,
-    process_manager_guard: Option<
-        spin::MutexGuard<'static, Option<crate::process::ProcessManager>>,
-    >,
+    process_manager_guard: Option<crate::process::TryProcessManagerGuard>,
 ) {
     // Debug marker: entering switch_to_thread (raw serial, no locks)
     raw_serial_str("[SW]");
@@ -962,9 +960,7 @@ fn restore_userspace_thread_context(
     thread_id: u64,
     saved_regs: &mut SavedRegisters,
     interrupt_frame: &mut InterruptStackFrame,
-    process_manager_guard: Option<
-        spin::MutexGuard<'static, Option<crate::process::ProcessManager>>,
-    >,
+    process_manager_guard: Option<crate::process::TryProcessManagerGuard>,
 ) {
     log::trace!("restore_userspace_thread_context: thread {}", thread_id);
 
@@ -1154,9 +1150,7 @@ fn setup_first_userspace_entry(
     thread_id: u64,
     interrupt_frame: &mut InterruptStackFrame,
     saved_regs: &mut SavedRegisters,
-    process_manager_guard: Option<
-        spin::MutexGuard<'static, Option<crate::process::ProcessManager>>,
-    >,
+    process_manager_guard: Option<crate::process::TryProcessManagerGuard>,
 ) {
     log::info!("setup_first_userspace_entry: thread {}", thread_id);
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -380,6 +380,7 @@ fn kernel_main(boot_info: &'static mut bootloader_api::BootInfo) -> ! {
     // Initialize DTrace-style tracing framework
     // This must be after per_cpu::init() and time::init() for timestamps
     tracing::init();
+    tracing::providers::init();
     // Enable tracing and all providers for kernel observability
     tracing::enable();
     tracing::providers::enable_all();

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -1122,6 +1122,7 @@ impl ProcessManager {
             Some(process) => process.is_terminated(),
             None => return,
         };
+        crate::tracing::providers::teardown::record_exit_request(already_terminated);
 
         // Get parent PID before we borrow the process mutably
         let parent_pid = self.processes.get(&pid).and_then(|p| p.parent);

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -36,6 +36,35 @@ pub struct ProcessManagerGuard {
     saved_daif: u64,
 }
 
+/// Non-blocking process-manager guard with the same owner instrumentation as
+/// `manager()`, but without changing interrupt state.
+pub struct TryProcessManagerGuard {
+    guard: core::mem::ManuallyDrop<spin::MutexGuard<'static, Option<ProcessManager>>>,
+}
+
+impl Drop for TryProcessManagerGuard {
+    fn drop(&mut self) {
+        unsafe {
+            core::mem::ManuallyDrop::drop(&mut self.guard);
+        }
+        note_process_manager_lock_released();
+    }
+}
+
+impl core::ops::Deref for TryProcessManagerGuard {
+    type Target = Option<ProcessManager>;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.guard
+    }
+}
+
+impl core::ops::DerefMut for TryProcessManagerGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.guard
+    }
+}
+
 impl Drop for ProcessManagerGuard {
     fn drop(&mut self) {
         // CRITICAL: Release the lock BEFORE restoring interrupts.
@@ -80,6 +109,7 @@ fn note_process_manager_lock_acquired() {
     let (cpu, tid) = current_process_manager_owner_identity();
     PROCESS_MANAGER_OWNER_TID.store(tid, Ordering::Relaxed);
     PROCESS_MANAGER_OWNER_CPU.store(cpu, Ordering::Release);
+    crate::tracing::providers::teardown::note_process_manager_acquire();
 }
 
 #[inline(always)]
@@ -109,6 +139,13 @@ pub fn process_manager_owner_snapshot() -> Option<(u64, u64)> {
     }
     let tid = PROCESS_MANAGER_OWNER_TID.load(Ordering::Relaxed);
     Some((cpu, tid))
+}
+
+/// Whether this CPU currently owns the process-manager lock.
+#[inline(always)]
+pub fn process_manager_held_on_current_cpu() -> bool {
+    process_manager_owner_snapshot()
+        .is_some_and(|(cpu, _)| cpu == current_process_manager_owner_identity().0)
 }
 
 /// Initialize the process management system
@@ -157,7 +194,11 @@ where
 {
     x86_64::instructions::interrupts::without_interrupts(|| {
         let mut manager_lock = PROCESS_MANAGER.lock();
-        manager_lock.as_mut().map(f)
+        note_process_manager_lock_acquired();
+        let result = manager_lock.as_mut().map(f);
+        drop(manager_lock);
+        note_process_manager_lock_released();
+        result
     })
 }
 
@@ -170,13 +211,21 @@ where
 {
     crate::arch_impl::aarch64::cpu::without_interrupts(|| {
         let mut manager_lock = PROCESS_MANAGER.lock();
-        manager_lock.as_mut().map(f)
+        note_process_manager_lock_acquired();
+        let result = manager_lock.as_mut().map(f);
+        drop(manager_lock);
+        note_process_manager_lock_released();
+        result
     })
 }
 
 /// Try to get the process manager without blocking (for interrupt contexts)
-pub fn try_manager() -> Option<spin::MutexGuard<'static, Option<ProcessManager>>> {
-    PROCESS_MANAGER.try_lock()
+pub fn try_manager() -> Option<TryProcessManagerGuard> {
+    let guard = PROCESS_MANAGER.try_lock()?;
+    note_process_manager_lock_acquired();
+    Some(TryProcessManagerGuard {
+        guard: core::mem::ManuallyDrop::new(guard),
+    })
 }
 
 /// Per-process info for lockup diagnostics (small, stack-allocated).
@@ -260,12 +309,21 @@ pub fn exit_current(exit_code: i32) {
 
     if let Some(pid) = current_pid() {
         log::debug!("Current PID is {}", pid.as_u64());
-        if let Some(ref mut manager) = *manager() {
-            manager.exit_process(pid, exit_code);
-        } else {
-            log::error!("Process manager not available!");
-        }
+        exit_process_by_pid(pid, exit_code);
     } else {
         log::error!("No current PID set!");
     }
+}
+
+fn exit_process_by_pid(pid: ProcessId, exit_code: i32) {
+    if let Some(ref mut manager) = *manager() {
+        manager.exit_process(pid, exit_code);
+    } else {
+        log::error!("Process manager not available!");
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub(crate) fn exit_process_for_teardown_test(pid: ProcessId, exit_code: i32) {
+    exit_process_by_pid(pid, exit_code);
 }

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -126,10 +126,14 @@ fn current_process_manager_owner_identity() -> (u64, u64) {
     (cpu, 0)
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(target_arch = "x86_64")]
 #[inline(always)]
 fn current_process_manager_owner_identity() -> (u64, u64) {
-    (0, 0)
+    use crate::arch_impl::current::percpu::X86PerCpu;
+    use crate::arch_impl::PerCpuOps;
+
+    // x86 is currently single-CPU, so the real CPU id is provably zero today.
+    (X86PerCpu::cpu_id(), 0)
 }
 
 /// Snapshot the best-effort PROCESS_MANAGER lock owner.

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -44,10 +44,10 @@ pub struct TryProcessManagerGuard {
 
 impl Drop for TryProcessManagerGuard {
     fn drop(&mut self) {
+        note_process_manager_lock_released();
         unsafe {
             core::mem::ManuallyDrop::drop(&mut self.guard);
         }
-        note_process_manager_lock_released();
     }
 }
 
@@ -67,14 +67,15 @@ impl core::ops::DerefMut for TryProcessManagerGuard {
 
 impl Drop for ProcessManagerGuard {
     fn drop(&mut self) {
+        // Clear owner metadata before the mutex becomes available to another CPU.
+        note_process_manager_lock_released();
+
         // CRITICAL: Release the lock BEFORE restoring interrupts.
         // If we restored DAIF first, there'd be a window where interrupts are enabled
         // but the lock is still held, allowing the exact deadlock we're preventing.
         unsafe {
             core::mem::ManuallyDrop::drop(&mut self._guard);
         }
-
-        note_process_manager_lock_released();
 
         #[cfg(target_arch = "aarch64")]
         unsafe {
@@ -196,8 +197,8 @@ where
         let mut manager_lock = PROCESS_MANAGER.lock();
         note_process_manager_lock_acquired();
         let result = manager_lock.as_mut().map(f);
-        drop(manager_lock);
         note_process_manager_lock_released();
+        drop(manager_lock);
         result
     })
 }
@@ -213,8 +214,8 @@ where
         let mut manager_lock = PROCESS_MANAGER.lock();
         note_process_manager_lock_acquired();
         let result = manager_lock.as_mut().map(f);
-        drop(manager_lock);
         note_process_manager_lock_released();
+        drop(manager_lock);
         result
     })
 }

--- a/kernel/src/process/process.rs
+++ b/kernel/src/process/process.rs
@@ -319,6 +319,7 @@ impl Process {
     /// output lock and framebuffer lock while all CPUs have interrupts disabled.
     pub fn terminate_minimal(&mut self, exit_code: i32) {
         if matches!(self.state, ProcessState::Terminated(_)) {
+            crate::trace_count!(crate::tracing::providers::teardown::EXIT_REPEAT_REQUESTS);
             return;
         }
         self.state = ProcessState::Terminated(exit_code);
@@ -333,7 +334,11 @@ impl Process {
     /// Returns the FD entries without closing them — the caller is responsible
     /// for pipe close_read/close_write, PTY refcounting, etc.
     pub fn take_fd_entries(&mut self) -> alloc::vec::Vec<(usize, crate::ipc::fd::FileDescriptor)> {
-        self.fd_table.take_all()
+        let entries = self.fd_table.take_all();
+        if crate::process::process_manager_held_on_current_cpu() {
+            crate::tracing::providers::teardown::FD_CLOSES_UNDER_PM.add(entries.len() as u64);
+        }
+        entries
     }
 
     /// Close all file descriptors in this process
@@ -349,6 +354,9 @@ impl Process {
 
         for fd in 0..crate::ipc::MAX_FDS {
             if let Ok(fd_entry) = self.fd_table.close(fd as i32) {
+                if crate::process::process_manager_held_on_current_cpu() {
+                    crate::trace_count!(crate::tracing::providers::teardown::FD_CLOSES_UNDER_PM);
+                }
                 match fd_entry.kind {
                     FdKind::PipeRead(buffer) => {
                         buffer.lock().close_read();
@@ -404,6 +412,9 @@ impl Process {
 
         for fd in 0..crate::ipc::MAX_FDS {
             if let Ok(fd_entry) = self.fd_table.close(fd as i32) {
+                if crate::process::process_manager_held_on_current_cpu() {
+                    crate::trace_count!(crate::tracing::providers::teardown::FD_CLOSES_UNDER_PM);
+                }
                 match fd_entry.kind {
                     FdKind::PipeRead(buffer) => {
                         buffer.lock().close_read();

--- a/kernel/src/process/process.rs
+++ b/kernel/src/process/process.rs
@@ -319,7 +319,6 @@ impl Process {
     /// output lock and framebuffer lock while all CPUs have interrupts disabled.
     pub fn terminate_minimal(&mut self, exit_code: i32) {
         if matches!(self.state, ProcessState::Terminated(_)) {
-            crate::trace_count!(crate::tracing::providers::teardown::EXIT_REPEAT_REQUESTS);
             return;
         }
         self.state = ProcessState::Terminated(exit_code);

--- a/kernel/src/signal/delivery.rs
+++ b/kernel/src/signal/delivery.rs
@@ -221,6 +221,7 @@ fn deliver_default_action(process: &mut Process, sig: u32) -> DeliverResult {
             );
             // Exit code for signal termination is typically 128 + signal number
             // But we use negative signal number to indicate signal death
+            crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_SIGNAL);
             process.terminate(-(sig as i32));
 
             // CRITICAL: Also mark the scheduler's copy of the thread as terminated.
@@ -255,6 +256,7 @@ fn deliver_default_action(process: &mut Process, sig: u32) -> DeliverResult {
             );
             // Core dump not implemented, just terminate
             // The 0x80 flag indicates core dump
+            crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_SIGNAL);
             process.terminate(-((sig as i32) | 0x80));
 
             // CRITICAL: Also mark the scheduler's copy of the thread as terminated.

--- a/kernel/src/syscall/signal.rs
+++ b/kernel/src/syscall/signal.rs
@@ -159,6 +159,7 @@ fn send_signal_to_process(target_pid: ProcessId, sig: u32) -> SyscallResult {
                     "SIGKILL sent to process {} - terminating immediately",
                     target_pid.as_u64()
                 );
+                crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_SIGNAL);
                 process.terminate(-9); // Exit code for SIGKILL
                                        // Wake up process if blocked so scheduler removes it
                 if matches!(process.state, crate::process::ProcessState::Blocked) {

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -384,7 +384,6 @@ pub fn drain_deferred_fault_sigsegv_exits() {
         buf.drain(&mut tids);
     }
     for tid in tids {
-        crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_FAULT);
         ProcessScheduler::handle_thread_exit(tid, -11);
     }
 }
@@ -424,12 +423,10 @@ pub fn reclaim_deferred_process_resources() {
 
 #[cfg(feature = "boot_tests")]
 pub fn deferred_fault_ring_overflow_injection() -> bool {
+    // Exercise the production push/drain implementation without touching any
+    // per-CPU ring that live fault handling can concurrently use.
+    let buffer = DeferredFaultExitBuffer::new();
     let mut drained = alloc::vec::Vec::new();
-    let buffer = &DEFERRED_FAULT_EXIT_BUFFERS[0];
-    buffer.drain(&mut drained);
-
-    let before =
-        crate::tracing::providers::teardown::DEFERRED_FAULT_RING_DROPPED.aggregate();
     let mut accepted = 0usize;
     for tid in 1..=17 {
         if buffer.push(u64::MAX - tid) {
@@ -446,8 +443,6 @@ pub fn deferred_fault_ring_overflow_injection() -> bool {
     accepted == DEFERRED_FAULT_EXIT_SLOTS
         && quiescent_count == DEFERRED_FAULT_EXIT_SLOTS
         && drained.is_empty()
-        && crate::tracing::providers::teardown::DEFERRED_FAULT_RING_DROPPED.aggregate()
-            > before
 }
 
 /// Extension trait for Thread to support process operations

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -40,6 +40,9 @@ impl DeferredFaultExitBuffer {
                 return true;
             }
         }
+        crate::trace_count!(
+            crate::tracing::providers::teardown::DEFERRED_FAULT_RING_DROPPED
+        );
         false
     }
 
@@ -62,6 +65,7 @@ static DEFERRED_FAULT_EXIT_BUFFERS: [DeferredFaultExitBuffer; 1] =
 
 #[cfg(target_arch = "aarch64")]
 pub(crate) struct PendingProcessReclaim {
+    pid: u64,
     page_table: Option<alloc::boxed::Box<crate::memory::process_memory::ProcessPageTable>>,
     old_page_tables: alloc::vec::Vec<
         alloc::boxed::Box<crate::memory::process_memory::ProcessPageTable>,
@@ -98,6 +102,11 @@ static PENDING_PROCESS_RECLAIMS: spin::Mutex<alloc::vec::Vec<PendingProcessRecla
     spin::Mutex::new(alloc::vec::Vec::new());
 
 pub(crate) fn release_process_resources(process: &mut crate::process::Process) {
+    if crate::process::process_manager_held_on_current_cpu() {
+        crate::trace_count!(
+            crate::tracing::providers::teardown::TEARDOWN_MASKED_FRAMES_WALKED
+        );
+    }
     process.cleanup_cow_frames();
     process.drain_old_page_tables();
     drop(process.page_table.take());
@@ -129,7 +138,9 @@ pub(crate) fn defer_live_process_resources(
 pub(crate) fn defer_process_resources(
     process: &mut crate::process::Process,
 ) -> PendingProcessReclaim {
+    crate::tracing::providers::teardown::record_defer(process.id.as_u64());
     PendingProcessReclaim {
+        pid: process.id.as_u64(),
         page_table: process.page_table.take(),
         old_page_tables: core::mem::take(&mut process.pending_old_page_tables),
         after_epoch: scheduler::retirement_grace_target(),
@@ -138,6 +149,11 @@ pub(crate) fn defer_process_resources(
 
 #[cfg(target_arch = "aarch64")]
 pub(crate) fn enqueue_process_reclaim(reclaim: PendingProcessReclaim) {
+    if crate::process::process_manager_held_on_current_cpu() {
+        crate::trace_count!(
+            crate::tracing::providers::teardown::RECLAIM_ENQUEUE_UNDER_PM
+        );
+    }
     crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().push(reclaim));
 }
 
@@ -216,11 +232,13 @@ impl ProcessScheduler {
     /// with interrupts disabled on all CPUs) combined with logging (which acquires
     /// SERIAL and framebuffer locks) creates an unbreakable deadlock.
     pub fn handle_thread_exit(thread_id: u64, exit_code: i32) {
+        crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_EXIT);
         // Phase 1: Under PM lock — minimal work only
         let phase1_result = {
             if let Some(ref mut manager) = *crate::process::manager() {
                 if let Some((pid, process)) = manager.find_process_by_thread_mut(thread_id) {
                     let already_terminated = process.is_terminated();
+                    crate::tracing::providers::teardown::record_exit_request(already_terminated);
                     let parent_pid = process.parent;
                     let process_name = process.name.clone();
                     let children = if pid == ProcessId::new(1) {
@@ -366,6 +384,7 @@ pub fn drain_deferred_fault_sigsegv_exits() {
         buf.drain(&mut tids);
     }
     for tid in tids {
+        crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_FAULT);
         ProcessScheduler::handle_thread_exit(tid, -11);
     }
 }
@@ -373,9 +392,19 @@ pub fn drain_deferred_fault_sigsegv_exits() {
 /// Reclaim process frames whose cross-CPU TTBR0 retention has quiesced.
 #[cfg(target_arch = "aarch64")]
 pub fn reclaim_deferred_process_resources() {
+    if crate::process::process_manager_held_on_current_cpu()
+        || crate::tracing::providers::teardown::scheduler_scope_active()
+    {
+        crate::trace_count!(
+            crate::tracing::providers::teardown::RECLAIM_CONTEXT_VIOLATIONS
+        );
+    }
+
     loop {
         let reclaim = crate::arch_without_interrupts(|| {
             let mut pending = PENDING_PROCESS_RECLAIMS.lock();
+            let _proof_scope =
+                crate::tracing::providers::teardown::ReclaimProofScope::enter();
             let ready = pending.iter().position(|reclaim| {
                 scheduler::retirement_grace_elapsed(&reclaim.after_epoch)
                     && !reclaim.root_is_live()
@@ -384,10 +413,41 @@ pub fn reclaim_deferred_process_resources() {
         });
 
         match reclaim {
-            Some(reclaim) => reclaim.reclaim(),
+            Some(reclaim) => {
+                crate::tracing::providers::teardown::record_reclaim(reclaim.pid);
+                reclaim.reclaim();
+            }
             None => break,
         }
     }
+}
+
+#[cfg(feature = "boot_tests")]
+pub fn deferred_fault_ring_overflow_injection() -> bool {
+    let mut drained = alloc::vec::Vec::new();
+    let buffer = &DEFERRED_FAULT_EXIT_BUFFERS[0];
+    buffer.drain(&mut drained);
+
+    let before =
+        crate::tracing::providers::teardown::DEFERRED_FAULT_RING_DROPPED.aggregate();
+    let mut accepted = 0usize;
+    for tid in 1..=17 {
+        if buffer.push(u64::MAX - tid) {
+            accepted += 1;
+        }
+    }
+
+    drained.clear();
+    buffer.drain(&mut drained);
+    let quiescent_count = drained.len();
+    drained.clear();
+    buffer.drain(&mut drained);
+
+    accepted == DEFERRED_FAULT_EXIT_SLOTS
+        && quiescent_count == DEFERRED_FAULT_EXIT_SLOTS
+        && drained.is_empty()
+        && crate::tracing::providers::teardown::DEFERRED_FAULT_RING_DROPPED.aggregate()
+            > before
 }
 
 /// Extension trait for Thread to support process operations

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -2597,6 +2597,22 @@ impl Scheduler {
     /// Make every scheduler-owned thread for a process non-runnable.
     #[cfg(target_arch = "aarch64")]
     pub fn terminate_process_threads(&mut self, owner_pid: u64) {
+        crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_QUARANTINE);
+        if crate::process::process_manager_held_on_current_cpu() {
+            crate::trace_count!(
+                crate::tracing::providers::teardown::TEARDOWN_LOCK_ORDER_SUSPECT
+            );
+        }
+        if self
+            .current_thread()
+            .and_then(|thread| thread.owner_pid)
+            .is_some_and(|current_owner| current_owner != owner_pid)
+        {
+            crate::trace_count!(
+                crate::tracing::providers::teardown::TEARDOWN_VICTIM_DIVERGENCE
+            );
+        }
+
         for thread in self.threads.iter_mut() {
             if thread.owner_pid == Some(owner_pid) {
                 thread.set_terminated();
@@ -3053,6 +3069,8 @@ where
     }
     without_interrupts(|| {
         let mut scheduler_lock = SCHEDULER.lock();
+        let _scheduler_scope =
+            crate::tracing::providers::teardown::SchedulerScope::enter();
         #[cfg(target_arch = "aarch64")]
         {
             use crate::arch_impl::aarch64::timer_interrupt::CPU0_BREADCRUMB_ID;
@@ -3614,4 +3632,12 @@ pub fn run_scheduler_tests() {
         // Clean up
         crate::per_cpu::set_need_resched(false);
     }
+}
+
+/// Drive real scheduler boundaries on every idle online CPU for the Phase-0
+/// teardown grace-period boot test.
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub fn nudge_retirement_grace_for_test() {
+    let _ = with_scheduler(|scheduler| scheduler.send_resched_ipi());
+    set_need_resched();
 }

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -234,6 +234,20 @@ pub fn emit_wake_attribution_counters() {
 /// Global scheduler instance
 static SCHEDULER: Mutex<Option<Scheduler>> = Mutex::new(None);
 
+#[inline(always)]
+fn lock_scheduler() -> spin::MutexGuard<'static, Option<Scheduler>> {
+    let guard = SCHEDULER.lock();
+    crate::tracing::providers::teardown::note_scheduler_acquire();
+    guard
+}
+
+#[inline(always)]
+fn try_lock_scheduler() -> Option<spin::MutexGuard<'static, Option<Scheduler>>> {
+    let guard = SCHEDULER.try_lock()?;
+    crate::tracing::providers::teardown::note_scheduler_acquire();
+    Some(guard)
+}
+
 /// Global need_resched flag for timer interrupt
 static NEED_RESCHED: AtomicBool = AtomicBool::new(false);
 
@@ -319,7 +333,7 @@ pub fn increment_context_switch_count() {
 /// SCHEDULER.lock() while holding this guard (would deadlock).
 #[cfg(target_arch = "aarch64")]
 pub fn lock_for_context_switch() -> spin::MutexGuard<'static, Option<Scheduler>> {
-    SCHEDULER.lock()
+    lock_scheduler()
 }
 
 /// Force-unlock the scheduler mutex after an inline AArch64 context switch.
@@ -395,7 +409,7 @@ pub struct SchedulerLivenessSnapshot {
 /// Returns `None` when the scheduler lock is busy or uninitialized; both are
 /// diagnostic for watchdog output.
 pub fn try_liveness_snapshot(cpu_id: usize) -> Option<SchedulerLivenessSnapshot> {
-    let guard = SCHEDULER.try_lock()?;
+    let guard = try_lock_scheduler()?;
     let sched = guard.as_ref()?;
     let cpu = cpu_id.min(MAX_CPUS.saturating_sub(1));
 
@@ -436,7 +450,7 @@ pub fn try_liveness_snapshot(cpu_id: usize) -> Option<SchedulerLivenessSnapshot>
 /// Returns None if the scheduler lock is held (which is itself diagnostic).
 /// Safe to call from interrupt context.
 pub fn try_dump_state() -> Option<SchedulerDumpInfo> {
-    let guard = SCHEDULER.try_lock()?;
+    let guard = try_lock_scheduler()?;
     let sched = guard.as_ref()?;
 
     let current_thread_id = sched.cpu_state[0].current_thread.unwrap_or(0);
@@ -2603,16 +2617,6 @@ impl Scheduler {
                 crate::tracing::providers::teardown::TEARDOWN_LOCK_ORDER_SUSPECT
             );
         }
-        if self
-            .current_thread()
-            .and_then(|thread| thread.owner_pid)
-            .is_some_and(|current_owner| current_owner != owner_pid)
-        {
-            crate::trace_count!(
-                crate::tracing::providers::teardown::TEARDOWN_VICTIM_DIVERGENCE
-            );
-        }
-
         for thread in self.threads.iter_mut() {
             if thread.owner_pid == Some(owner_pid) {
                 thread.set_terminated();
@@ -2830,7 +2834,7 @@ impl Scheduler {
 /// Initialize the global scheduler
 #[allow(dead_code)]
 pub fn init(idle_thread: Box<Thread>) {
-    let mut scheduler_lock = SCHEDULER.lock();
+    let mut scheduler_lock = lock_scheduler();
     *scheduler_lock = Some(Scheduler::new(idle_thread));
     // CRITICAL: Only log on x86_64 to avoid deadlock on ARM64
     #[cfg(target_arch = "x86_64")]
@@ -2840,7 +2844,7 @@ pub fn init(idle_thread: Box<Thread>) {
 /// Initialize scheduler with the current thread as the idle task (Linux-style)
 /// This is used during boot where the boot thread becomes the idle task
 pub fn init_with_current(current_thread: Box<Thread>) {
-    let mut scheduler_lock = SCHEDULER.lock();
+    let mut scheduler_lock = lock_scheduler();
     let thread_id = current_thread.id();
 
     // Create scheduler with current thread as both idle and current
@@ -2870,7 +2874,7 @@ pub fn init_with_current(current_thread: Box<Thread>) {
 #[cfg(target_arch = "aarch64")]
 pub fn register_cpu_idle_thread(cpu_id: usize, idle_thread: Box<Thread>) {
     without_interrupts(|| {
-        let mut scheduler_lock = SCHEDULER.lock();
+        let mut scheduler_lock = lock_scheduler();
         if let Some(scheduler) = scheduler_lock.as_mut() {
             scheduler.register_idle_thread(cpu_id, idle_thread);
         }
@@ -2881,7 +2885,7 @@ pub fn register_cpu_idle_thread(cpu_id: usize, idle_thread: Box<Thread>) {
 pub fn spawn(thread: Box<Thread>) {
     // Disable interrupts to prevent timer interrupt deadlock
     without_interrupts(|| {
-        let mut scheduler_lock = SCHEDULER.lock();
+        let mut scheduler_lock = lock_scheduler();
         if let Some(scheduler) = scheduler_lock.as_mut() {
             scheduler.add_thread(thread);
             // Ensure a switch happens ASAP (especially in CI smoke runs)
@@ -2906,7 +2910,7 @@ pub fn spawn(thread: Box<Thread>) {
 /// Used for fork children so they run before other queued threads.
 pub fn spawn_front(thread: Box<Thread>) {
     without_interrupts(|| {
-        let mut scheduler_lock = SCHEDULER.lock();
+        let mut scheduler_lock = lock_scheduler();
         if let Some(scheduler) = scheduler_lock.as_mut() {
             scheduler.add_thread_front(thread);
             NEED_RESCHED.store(true, Ordering::Relaxed);
@@ -2930,7 +2934,7 @@ pub fn spawn_front(thread: Box<Thread>) {
 #[cfg(target_arch = "aarch64")]
 pub fn reclaim_terminated_threads() {
     without_interrupts(|| {
-        let mut scheduler_lock = SCHEDULER.lock();
+        let mut scheduler_lock = lock_scheduler();
         if let Some(scheduler) = scheduler_lock.as_mut() {
             scheduler.reclaim_terminated_threads();
         }
@@ -2946,7 +2950,7 @@ pub fn reclaim_terminated_threads() {
 #[allow(dead_code)]
 pub fn spawn_as_current(thread: Box<Thread>) {
     without_interrupts(|| {
-        let mut scheduler_lock = SCHEDULER.lock();
+        let mut scheduler_lock = lock_scheduler();
         if let Some(scheduler) = scheduler_lock.as_mut() {
             scheduler.add_thread_as_current(thread);
             // NOTE: Do NOT set need_resched - we want this thread to run
@@ -2971,7 +2975,7 @@ pub fn schedule() -> Option<(u64, u64)> {
     let result = if interrupts_were_enabled {
         // Normal case: disable interrupts to prevent deadlock
         without_interrupts(|| {
-            let mut scheduler_lock = SCHEDULER.lock();
+            let mut scheduler_lock = lock_scheduler();
             if let Some(scheduler) = scheduler_lock.as_mut() {
                 scheduler.schedule().map(|(old, new)| (old.id(), new.id()))
             } else {
@@ -2980,7 +2984,7 @@ pub fn schedule() -> Option<(u64, u64)> {
         })
     } else {
         // Already in interrupt context - don't try to disable interrupts again
-        let mut scheduler_lock = SCHEDULER.lock();
+        let mut scheduler_lock = lock_scheduler();
         if let Some(scheduler) = scheduler_lock.as_mut() {
             scheduler.schedule().map(|(old, new)| (old.id(), new.id()))
         } else {
@@ -3025,7 +3029,7 @@ pub fn preempt_schedule_irq() {
 #[allow(dead_code)]
 pub fn try_schedule() -> Option<(u64, u64)> {
     // Do not disable interrupts; we only attempt a non-blocking lock here
-    if let Some(mut scheduler_lock) = SCHEDULER.try_lock() {
+    if let Some(mut scheduler_lock) = try_lock_scheduler() {
         if let Some(scheduler) = scheduler_lock.as_mut() {
             return scheduler.schedule().map(|(old, new)| (old.id(), new.id()));
         }
@@ -3039,7 +3043,7 @@ pub fn try_schedule() -> Option<(u64, u64)> {
 pub fn is_current_idle_thread() -> Option<bool> {
     // Try to get the lock without blocking - if we can't, assume not idle
     // to be safe. This prevents deadlock when timer fires during scheduler ops.
-    if let Some(scheduler_lock) = SCHEDULER.try_lock() {
+    if let Some(scheduler_lock) = try_lock_scheduler() {
         if let Some(scheduler) = scheduler_lock.as_ref() {
             return Some(
                 scheduler
@@ -3068,7 +3072,7 @@ where
         }
     }
     without_interrupts(|| {
-        let mut scheduler_lock = SCHEDULER.lock();
+        let mut scheduler_lock = lock_scheduler();
         let _scheduler_scope =
             crate::tracing::providers::teardown::SchedulerScope::enter();
         #[cfg(target_arch = "aarch64")]
@@ -3101,7 +3105,7 @@ where
 /// Safe to call from kernel context; disables interrupts internally.
 pub fn collect_idle_thread_ids(out: &mut [u64]) -> usize {
     without_interrupts(|| {
-        let scheduler_lock = SCHEDULER.lock();
+        let scheduler_lock = lock_scheduler();
         if let Some(sched) = scheduler_lock.as_ref() {
             let count = out.len().min(MAX_CPUS);
             for i in 0..count {
@@ -3121,7 +3125,7 @@ where
     F: FnOnce(&mut super::thread::Thread) -> R,
 {
     without_interrupts(|| {
-        let mut scheduler_lock = SCHEDULER.lock();
+        let mut scheduler_lock = lock_scheduler();
         scheduler_lock
             .as_mut()
             .and_then(|sched| sched.get_thread_mut(thread_id).map(f))
@@ -3145,7 +3149,7 @@ pub fn wake_waitqueue_thread(tid: u64) {
 /// Used by btop monitor to display CPU% per process.
 pub fn get_process_cpu_ticks() -> alloc::vec::Vec<(u64, u64)> {
     without_interrupts(|| {
-        if let Some(scheduler_lock) = SCHEDULER.try_lock() {
+        if let Some(scheduler_lock) = try_lock_scheduler() {
             if let Some(scheduler) = scheduler_lock.as_ref() {
                 let now = crate::time::get_ticks();
                 return scheduler
@@ -3177,7 +3181,7 @@ pub fn get_process_cpu_ticks() -> alloc::vec::Vec<(u64, u64)> {
 /// need the thread-level runtime state to avoid presenting sleepers as CPU-bound.
 pub fn get_process_display_state(owner_pid: u64) -> Option<&'static str> {
     without_interrupts(|| {
-        let scheduler_lock = SCHEDULER.try_lock()?;
+        let scheduler_lock = try_lock_scheduler()?;
         let scheduler = scheduler_lock.as_ref()?;
 
         let mut saw_ready = false;
@@ -3217,7 +3221,7 @@ pub fn get_process_display_state(owner_pid: u64) -> Option<&'static str> {
 /// This function disables interrupts to prevent deadlock with timer interrupt
 pub fn current_thread_id() -> Option<u64> {
     without_interrupts(|| {
-        let scheduler_lock = SCHEDULER.lock();
+        let scheduler_lock = lock_scheduler();
         scheduler_lock
             .as_ref()
             .and_then(|s| s.cpu_state[Scheduler::current_cpu_id()].current_thread)
@@ -3230,7 +3234,7 @@ pub fn current_thread_id() -> Option<u64> {
 #[allow(dead_code)]
 pub fn set_current_thread(thread_id: u64) {
     without_interrupts(|| {
-        let mut scheduler_lock = SCHEDULER.lock();
+        let mut scheduler_lock = lock_scheduler();
         if let Some(scheduler) = scheduler_lock.as_mut() {
             scheduler.set_current_thread(thread_id);
         }
@@ -3438,7 +3442,7 @@ pub fn switch_to_idle() {
 /// next timer interrupt on this CPU will see the idle loop and correct the state.
 #[cfg(target_arch = "aarch64")]
 pub fn switch_to_idle_best_effort() {
-    if let Some(mut scheduler_lock) = SCHEDULER.try_lock() {
+    if let Some(mut scheduler_lock) = try_lock_scheduler() {
         if let Some(sched) = scheduler_lock.as_mut() {
             let cpu_id = Scheduler::current_cpu_id();
             let idle_id = sched.cpu_state[cpu_id].idle_thread;

--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -4969,6 +4969,13 @@ static INTERRUPT_TESTS: &[TestDef] = &[
 /// - userspace_syscall_confirmed: Verify userspace syscalls are working
 static PROCESS_TESTS: &[TestDef] = &[
     TestDef {
+        name: "deferred_fault_ring_overflow_injection",
+        func: crate::tracing::providers::teardown::deferred_fault_ring_overflow_test,
+        arch: Arch::Any,
+        timeout_ms: 5000,
+        stage: TestStage::EarlyBoot,
+    },
+    TestDef {
         name: "process_manager_init",
         func: test_process_manager_init,
         arch: Arch::Any,
@@ -5020,6 +5027,14 @@ static PROCESS_TESTS: &[TestDef] = &[
         arch: Arch::Any,
         timeout_ms: 5000,
         stage: TestStage::ProcessContext,
+    },
+    #[cfg(target_arch = "aarch64")]
+    TestDef {
+        name: "fork_exit_defer_reclaim_pairing_test",
+        func: crate::tracing::providers::teardown::fork_exit_defer_reclaim_pairing_test,
+        arch: Arch::Aarch64,
+        timeout_ms: 30000,
+        stage: TestStage::PostScheduler,
     },
     // Note: Userspace stage tests cannot run from syscall context (would block).
     // The Userspace stage is marked when EL0/Ring3 syscall is confirmed, but

--- a/kernel/src/tracing/counter.rs
+++ b/kernel/src/tracing/counter.rs
@@ -262,7 +262,7 @@ pub static TRACE_COUNTER_COUNT: AtomicU64 = AtomicU64::new(0);
 /// Register a counter in the global registry.
 ///
 /// This is typically called during static initialization.
-/// Returns the slot index if successful, or None if the registry is full.
+/// Returns the slot index if successful. Panics if the registry is full.
 ///
 /// # Safety
 ///
@@ -274,9 +274,6 @@ pub fn register_counter(counter: &'static TraceCounter) -> Option<usize> {
         (count as usize) < MAX_COUNTERS,
         "trace counter registry capacity exhausted"
     );
-    if count as usize >= MAX_COUNTERS {
-        return None;
-    }
 
     // Find an empty slot
     unsafe {
@@ -290,11 +287,8 @@ pub fn register_counter(counter: &'static TraceCounter) -> Option<usize> {
         }
     }
 
-    assert!(
-        TRACE_COUNTER_COUNT.load(Ordering::Acquire) as usize >= MAX_COUNTERS,
-        "trace counter registry count does not match its occupied slots"
-    );
-    None
+    // The leading capacity assertion guarantees that one registry slot is free.
+    unreachable!("counter registry count below capacity but no slot was free")
 }
 
 /// Get a counter by name.

--- a/kernel/src/tracing/counter.rs
+++ b/kernel/src/tracing/counter.rs
@@ -242,7 +242,12 @@ fn current_cpu_id() -> usize {
 // =============================================================================
 
 /// Maximum number of counters that can be registered.
-pub const MAX_COUNTERS: usize = 64;
+///
+/// The built-in providers currently register 106 counters on both x86_64 and
+/// aarch64 (110 when the optional `btrt` feature is enabled). Keep enough
+/// headroom for new observability counters without silently truncating the
+/// registry.
+pub const MAX_COUNTERS: usize = 160;
 
 /// Global registry of trace counters.
 ///
@@ -265,6 +270,10 @@ pub static TRACE_COUNTER_COUNT: AtomicU64 = AtomicU64::new(0);
 /// single-threaded initialization.
 pub fn register_counter(counter: &'static TraceCounter) -> Option<usize> {
     let count = TRACE_COUNTER_COUNT.load(Ordering::Acquire);
+    assert!(
+        (count as usize) < MAX_COUNTERS,
+        "trace counter registry capacity exhausted"
+    );
     if count as usize >= MAX_COUNTERS {
         return None;
     }
@@ -281,6 +290,10 @@ pub fn register_counter(counter: &'static TraceCounter) -> Option<usize> {
         }
     }
 
+    assert!(
+        TRACE_COUNTER_COUNT.load(Ordering::Acquire) as usize >= MAX_COUNTERS,
+        "trace counter registry count does not match its occupied slots"
+    );
     None
 }
 

--- a/kernel/src/tracing/provider.rs
+++ b/kernel/src/tracing/provider.rs
@@ -214,34 +214,6 @@ pub static mut TRACE_PROVIDERS: [Option<&'static TraceProvider>; MAX_PROVIDERS] 
 #[no_mangle]
 pub static TRACE_PROVIDER_COUNT: AtomicU64 = AtomicU64::new(0);
 
-/// Exact enable masks for the providers registered when the snapshot is taken.
-///
-/// This is intended for tests that temporarily change provider filtering while
-/// the rest of the kernel is live. Restoring the snapshot preserves each
-/// provider's individual probe mask instead of blanket-enabling providers.
-pub struct ProviderEnabledStateSnapshot {
-    states: [Option<(&'static TraceProvider, u64)>; MAX_PROVIDERS],
-}
-
-impl ProviderEnabledStateSnapshot {
-    /// Capture every registered provider and its current probe-enable mask.
-    pub fn capture() -> Self {
-        let providers_ptr = core::ptr::addr_of!(TRACE_PROVIDERS);
-        let states = core::array::from_fn(|index| unsafe {
-            (*providers_ptr)[index]
-                .map(|provider| (provider, provider.enabled.load(Ordering::Acquire)))
-        });
-        Self { states }
-    }
-
-    /// Restore every captured provider's exact probe-enable mask.
-    pub fn restore(&self) {
-        for (provider, enabled) in self.states.iter().flatten() {
-            provider.enabled.store(*enabled, Ordering::Release);
-        }
-    }
-}
-
 /// Register a provider in the global registry.
 ///
 /// This is typically called during static initialization.

--- a/kernel/src/tracing/provider.rs
+++ b/kernel/src/tracing/provider.rs
@@ -214,6 +214,34 @@ pub static mut TRACE_PROVIDERS: [Option<&'static TraceProvider>; MAX_PROVIDERS] 
 #[no_mangle]
 pub static TRACE_PROVIDER_COUNT: AtomicU64 = AtomicU64::new(0);
 
+/// Exact enable masks for the providers registered when the snapshot is taken.
+///
+/// This is intended for tests that temporarily change provider filtering while
+/// the rest of the kernel is live. Restoring the snapshot preserves each
+/// provider's individual probe mask instead of blanket-enabling providers.
+pub struct ProviderEnabledStateSnapshot {
+    states: [Option<(&'static TraceProvider, u64)>; MAX_PROVIDERS],
+}
+
+impl ProviderEnabledStateSnapshot {
+    /// Capture every registered provider and its current probe-enable mask.
+    pub fn capture() -> Self {
+        let providers_ptr = core::ptr::addr_of!(TRACE_PROVIDERS);
+        let states = core::array::from_fn(|index| unsafe {
+            (*providers_ptr)[index]
+                .map(|provider| (provider, provider.enabled.load(Ordering::Acquire)))
+        });
+        Self { states }
+    }
+
+    /// Restore every captured provider's exact probe-enable mask.
+    pub fn restore(&self) {
+        for (provider, enabled) in self.states.iter().flatten() {
+            provider.enabled.store(*enabled, Ordering::Release);
+        }
+    }
+}
+
 /// Register a provider in the global registry.
 ///
 /// This is typically called during static initialization.

--- a/kernel/src/tracing/providers/mod.rs
+++ b/kernel/src/tracing/providers/mod.rs
@@ -32,6 +32,7 @@ pub mod net_rx;
 pub mod process;
 pub mod sched;
 pub mod syscall;
+pub mod teardown;
 pub mod virtgpu;
 pub mod xhci;
 // #[cfg(feature = "btrt")]
@@ -43,6 +44,7 @@ pub use net_rx::NET_RX_PROVIDER;
 pub use process::PROCESS_PROVIDER;
 pub use sched::SCHED_PROVIDER;
 pub use syscall::SYSCALL_PROVIDER;
+pub use teardown::TEARDOWN_PROVIDER;
 pub use virtgpu::VIRTGPU_PROVIDER;
 pub use xhci::XHCI_PROVIDER;
 // #[cfg(feature = "btrt")]
@@ -61,6 +63,7 @@ pub fn init() {
     irq::init();
     net_rx::init();
     process::init();
+    teardown::init();
     virtgpu::init();
     xhci::init();
     // #[cfg(feature = "btrt")]
@@ -68,12 +71,13 @@ pub fn init() {
     counters::init();
 
     log::info!(
-        "Tracing providers initialized: syscall={:#x}, sched={:#x}, irq={:#x}, net_rx={:#x}, process={:#x}, virtgpu={:#x}, xhci={:#x}",
+        "Tracing providers initialized: syscall={:#x}, sched={:#x}, irq={:#x}, net_rx={:#x}, process={:#x}, teardown={:#x}, virtgpu={:#x}, xhci={:#x}",
         syscall::PROVIDER_ID,
         sched::PROVIDER_ID,
         irq::PROVIDER_ID,
         net_rx::PROVIDER_ID,
         process::PROVIDER_ID,
+        teardown::PROVIDER_ID,
         virtgpu::PROVIDER_ID,
         xhci::PROVIDER_ID
     );
@@ -87,6 +91,7 @@ pub fn enable_all() {
     IRQ_PROVIDER.enable_all();
     NET_RX_PROVIDER.enable_all();
     PROCESS_PROVIDER.enable_all();
+    TEARDOWN_PROVIDER.enable_all();
     VIRTGPU_PROVIDER.enable_all();
     XHCI_PROVIDER.enable_all();
     // #[cfg(feature = "btrt")]
@@ -101,6 +106,7 @@ pub fn disable_all() {
     IRQ_PROVIDER.disable_all();
     NET_RX_PROVIDER.disable_all();
     PROCESS_PROVIDER.disable_all();
+    TEARDOWN_PROVIDER.disable_all();
     VIRTGPU_PROVIDER.disable_all();
     XHCI_PROVIDER.disable_all();
     // #[cfg(feature = "btrt")]

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -1,0 +1,606 @@
+//! Lock-free teardown observability.
+//!
+//! Phase 0 records existing teardown behavior only. Counters whose producer is
+//! introduced by a later phase are deliberately registered and readable here,
+//! but have no increment site yet.
+
+use crate::tracing::counter::{register_counter, TraceCounter};
+use crate::tracing::provider::{register_provider, TraceProvider};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+pub const PROVIDER_ID: u8 = 0x0a;
+pub const TEARDOWN_DEFER_EVENT: u16 = ((PROVIDER_ID as u16) << 8) | 0x00;
+pub const TEARDOWN_RECLAIM_EVENT: u16 = ((PROVIDER_ID as u16) << 8) | 0x01;
+
+#[no_mangle]
+pub static TEARDOWN_PROVIDER: TraceProvider = TraceProvider {
+    name: "teardown",
+    id: PROVIDER_ID,
+    enabled: AtomicU64::new(0),
+};
+
+macro_rules! counter {
+    ($name:ident, $description:literal) => {
+        crate::define_trace_counter!($name, $description);
+    };
+}
+
+counter!(TEARDOWN_ENTRY_EXIT, "Exit teardown entries");
+counter!(TEARDOWN_ENTRY_FAULT, "Fault teardown entries");
+counter!(TEARDOWN_ENTRY_SIGNAL, "Signal teardown entries");
+counter!(TEARDOWN_ENTRY_GROUP, "Group teardown entries");
+counter!(EXIT_FIRST_REQUESTS, "First exit requests");
+counter!(EXIT_REPEAT_REQUESTS, "Repeated exit requests");
+counter!(TEARDOWN_QUARANTINE, "Scheduler quarantine operations");
+counter!(TEARDOWN_DEFER, "Deferred process-resource retirements");
+counter!(TEARDOWN_RECLAIM, "Reclaimed process-resource retirements");
+counter!(
+    TEARDOWN_MASKED_FRAMES_WALKED,
+    "Frame walks under process manager"
+);
+counter!(
+    FD_CLOSES_UNDER_PM,
+    "File descriptors closed or extracted under process manager"
+);
+counter!(TEARDOWN_VICTIM_DIVERGENCE, "TID and CR3 victim divergence");
+counter!(TEARDOWN_CR3_MISS, "Fault-victim CR3 misses");
+counter!(
+    EXIT_ATTRIBUTION_UNCERTAIN,
+    "Uncertain fault-victim attribution"
+);
+counter!(DEFERRED_FAULT_RING_DROPPED, "Dropped deferred fault exits");
+counter!(
+    RECLAIM_ENQUEUE_UNDER_PM,
+    "Reclaim enqueues under process manager"
+);
+counter!(
+    PROOF_UNDER_QUEUE_LOCK,
+    "PM or scheduler acquisitions during queue proof"
+);
+counter!(
+    RECLAIM_CONTEXT_VIOLATIONS,
+    "Reclaim calls from forbidden contexts"
+);
+counter!(
+    TEARDOWN_LOCK_ORDER_SUSPECT,
+    "Suspect teardown lock ordering"
+);
+
+// Declaration-only until the phase named in PLAN.md. These intentionally have
+// no trace_count! producer in Phase 0.
+counter!(EXIT_SGI_SENT, "Teardown-attributed expedite SGIs");
+counter!(EXIT_REQUEST_OBSERVED, "Observed latched exit requests");
+counter!(EXIT_KICK_PUBLISHED, "Published exit-kick buckets");
+counter!(EXIT_KICK_OBSERVED, "Observed exit-kick victims");
+counter!(EXIT_KICK_BUCKET_COLLISION, "Exit-kick bucket collisions");
+counter!(RECEIPT_DROPPED_UNRETIRED, "Receipts recovered by Drop");
+counter!(
+    RECLAIM_PASS_SKIPPED,
+    "Reclaim candidates skipped in one pass"
+);
+counter!(RECLAIM_PARKED, "Parked reclaim candidates");
+counter!(
+    RECLAIM_UNPARKED_EPOCH,
+    "Reclaims unparked by scheduling epoch"
+);
+counter!(RECLAIM_UNPARKED_ROW, "Reclaims unparked by row removal");
+counter!(RECLAIM_UNPARKED_AGE, "Reclaims unparked by age backstop");
+counter!(
+    RECLAIM_PARK_IMMEDIATE_UNPARK,
+    "Immediately unparked reclaims"
+);
+counter!(RECLAIM_PARK_RESIDENT, "Resident parked reclaims");
+counter!(LEDGER_EFFECT_AMBIGUOUS_REPORT, "Ambiguous report effects");
+counter!(
+    TOMBSTONE_JOIN_REAP_SECOND,
+    "Tombstone joins completed by reap"
+);
+counter!(
+    TOMBSTONE_JOIN_RETIRE_SECOND,
+    "Tombstone joins completed by retire"
+);
+counter!(
+    EXIT_BLOCK_REFUSED_FAMILY,
+    "Latched exits refused by blocking families"
+);
+counter!(
+    EXIT_WAIT_CANCELLED_FAMILY,
+    "Blocked exits cancelled by wait families"
+);
+counter!(INIT_FATAL_SIGNAL_DROPPED, "Fatal signals dropped for init");
+counter!(
+    INIT_FATAL_SIGNAL_DROPPED_GROUP,
+    "Fatal group signals dropped for init"
+);
+
+pub const COUNTER_COUNT: usize = 39;
+
+/// The registration and normal-context reader inventory. Keeping one inventory
+/// makes a write-only counter structurally impossible without changing the P0
+/// source ratchet.
+pub static COUNTERS: [&TraceCounter; COUNTER_COUNT] = [
+    &TEARDOWN_ENTRY_EXIT,
+    &TEARDOWN_ENTRY_FAULT,
+    &TEARDOWN_ENTRY_SIGNAL,
+    &TEARDOWN_ENTRY_GROUP,
+    &EXIT_FIRST_REQUESTS,
+    &EXIT_REPEAT_REQUESTS,
+    &TEARDOWN_QUARANTINE,
+    &TEARDOWN_DEFER,
+    &TEARDOWN_RECLAIM,
+    &TEARDOWN_MASKED_FRAMES_WALKED,
+    &FD_CLOSES_UNDER_PM,
+    &TEARDOWN_VICTIM_DIVERGENCE,
+    &TEARDOWN_CR3_MISS,
+    &EXIT_ATTRIBUTION_UNCERTAIN,
+    &DEFERRED_FAULT_RING_DROPPED,
+    &RECLAIM_ENQUEUE_UNDER_PM,
+    &PROOF_UNDER_QUEUE_LOCK,
+    &RECLAIM_CONTEXT_VIOLATIONS,
+    &TEARDOWN_LOCK_ORDER_SUSPECT,
+    &EXIT_SGI_SENT,
+    &EXIT_REQUEST_OBSERVED,
+    &EXIT_KICK_PUBLISHED,
+    &EXIT_KICK_OBSERVED,
+    &EXIT_KICK_BUCKET_COLLISION,
+    &RECEIPT_DROPPED_UNRETIRED,
+    &RECLAIM_PASS_SKIPPED,
+    &RECLAIM_PARKED,
+    &RECLAIM_UNPARKED_EPOCH,
+    &RECLAIM_UNPARKED_ROW,
+    &RECLAIM_UNPARKED_AGE,
+    &RECLAIM_PARK_IMMEDIATE_UNPARK,
+    &RECLAIM_PARK_RESIDENT,
+    &LEDGER_EFFECT_AMBIGUOUS_REPORT,
+    &TOMBSTONE_JOIN_REAP_SECOND,
+    &TOMBSTONE_JOIN_RETIRE_SECOND,
+    &EXIT_BLOCK_REFUSED_FAMILY,
+    &EXIT_WAIT_CANCELLED_FAMILY,
+    &INIT_FATAL_SIGNAL_DROPPED,
+    &INIT_FATAL_SIGNAL_DROPPED_GROUP,
+];
+
+pub fn init() {
+    register_provider(&TEARDOWN_PROVIDER);
+    for counter in COUNTERS {
+        register_counter(counter);
+    }
+}
+
+/// Read every Phase-0 counter from normal context.
+pub fn snapshot() -> [u64; COUNTER_COUNT] {
+    core::array::from_fn(|index| COUNTERS[index].aggregate())
+}
+
+#[inline(always)]
+pub fn record_defer(pid: u64) {
+    crate::trace_count!(TEARDOWN_DEFER);
+    crate::trace_event!(TEARDOWN_PROVIDER, TEARDOWN_DEFER_EVENT, pid as u32);
+}
+
+#[inline(always)]
+pub fn record_reclaim(pid: u64) {
+    crate::trace_count!(TEARDOWN_RECLAIM);
+    crate::trace_event!(TEARDOWN_PROVIDER, TEARDOWN_RECLAIM_EVENT, pid as u32);
+}
+
+#[inline(always)]
+pub fn record_exit_request(already_terminated: bool) {
+    if already_terminated {
+        crate::trace_count!(EXIT_REPEAT_REQUESTS);
+    } else {
+        crate::trace_count!(EXIT_FIRST_REQUESTS);
+    }
+}
+
+static RECLAIM_PROOF_DEPTH: [AtomicU64; crate::tracing::MAX_CPUS] =
+    [const { AtomicU64::new(0) }; crate::tracing::MAX_CPUS];
+static SCHEDULER_SCOPE_DEPTH: [AtomicU64; crate::tracing::MAX_CPUS] =
+    [const { AtomicU64::new(0) }; crate::tracing::MAX_CPUS];
+
+#[inline(always)]
+fn current_cpu() -> usize {
+    #[cfg(target_arch = "x86_64")]
+    {
+        use crate::arch_impl::current::percpu::X86PerCpu;
+        use crate::arch_impl::PerCpuOps;
+        X86PerCpu::cpu_id() as usize
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        use crate::arch_impl::current::percpu::Aarch64PerCpu;
+        use crate::arch_impl::PerCpuOps;
+        Aarch64PerCpu::cpu_id() as usize
+    }
+}
+
+pub struct ReclaimProofScope {
+    cpu: usize,
+}
+
+impl ReclaimProofScope {
+    #[inline(always)]
+    pub fn enter() -> Self {
+        let cpu = current_cpu().min(crate::tracing::MAX_CPUS - 1);
+        RECLAIM_PROOF_DEPTH[cpu].fetch_add(1, Ordering::Relaxed);
+        Self { cpu }
+    }
+}
+
+impl Drop for ReclaimProofScope {
+    #[inline(always)]
+    fn drop(&mut self) {
+        RECLAIM_PROOF_DEPTH[self.cpu].fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+pub struct SchedulerScope {
+    cpu: usize,
+}
+
+impl SchedulerScope {
+    #[inline(always)]
+    pub fn enter() -> Self {
+        let cpu = current_cpu().min(crate::tracing::MAX_CPUS - 1);
+        if RECLAIM_PROOF_DEPTH[cpu].load(Ordering::Relaxed) != 0 {
+            crate::trace_count!(PROOF_UNDER_QUEUE_LOCK);
+        }
+        SCHEDULER_SCOPE_DEPTH[cpu].fetch_add(1, Ordering::Relaxed);
+        Self { cpu }
+    }
+}
+
+impl Drop for SchedulerScope {
+    #[inline(always)]
+    fn drop(&mut self) {
+        SCHEDULER_SCOPE_DEPTH[self.cpu].fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+#[inline(always)]
+pub fn note_process_manager_acquire() {
+    let cpu = current_cpu().min(crate::tracing::MAX_CPUS - 1);
+    if RECLAIM_PROOF_DEPTH[cpu].load(Ordering::Relaxed) != 0 {
+        crate::trace_count!(PROOF_UNDER_QUEUE_LOCK);
+    }
+}
+
+#[inline(always)]
+pub fn scheduler_scope_active() -> bool {
+    SCHEDULER_SCOPE_DEPTH[current_cpu().min(crate::tracing::MAX_CPUS - 1)].load(Ordering::Relaxed)
+        != 0
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+struct TeardownPairingEvidence {
+    seen: alloc::vec::Vec<(u64, u16, u32, u8)>,
+    events: alloc::vec::Vec<crate::tracing::TraceEvent>,
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl TeardownPairingEvidence {
+    fn new() -> Self {
+        let mut evidence = Self {
+            seen: alloc::vec::Vec::new(),
+            events: alloc::vec::Vec::new(),
+        };
+        evidence.sample_into(false);
+        evidence
+    }
+
+    fn sample(&mut self) {
+        self.sample_into(true);
+    }
+
+    fn sample_into(&mut self, retain: bool) {
+        unsafe {
+            let buffers = core::ptr::addr_of!(crate::tracing::TRACE_BUFFERS);
+            for buffer in &*buffers {
+                for event in buffer.iter_events() {
+                    if event.event_type != TEARDOWN_DEFER_EVENT
+                        && event.event_type != TEARDOWN_RECLAIM_EVENT
+                    {
+                        continue;
+                    }
+                    let key = (
+                        event.timestamp,
+                        event.event_type,
+                        event.payload,
+                        event.cpu_id,
+                    );
+                    if self.seen.contains(&key) {
+                        continue;
+                    }
+                    self.seen.push(key);
+                    if retain {
+                        self.events.push(*event);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub fn defer_reclaim_events_are_paired(
+    pids: &[u64],
+    events: &[crate::tracing::TraceEvent],
+) -> Result<(), &'static str> {
+    let mut defer = alloc::vec![None; pids.len()];
+    let mut reclaim = alloc::vec![None; pids.len()];
+    let mut defer_count = alloc::vec![0u8; pids.len()];
+    let mut reclaim_count = alloc::vec![0u8; pids.len()];
+
+    for event in events {
+        let Some(index) = pids.iter().position(|pid| *pid as u32 == event.payload) else {
+            continue;
+        };
+        if event.event_type == TEARDOWN_DEFER_EVENT {
+            defer_count[index] = defer_count[index].saturating_add(1);
+            defer[index] = Some(event.timestamp);
+        } else if event.event_type == TEARDOWN_RECLAIM_EVENT {
+            reclaim_count[index] = reclaim_count[index].saturating_add(1);
+            reclaim[index] = Some(event.timestamp);
+        }
+    }
+
+    for index in 0..pids.len() {
+        if defer_count[index] == 0 {
+            return Err("per-pid defer event was missing");
+        }
+        if defer_count[index] != 1 {
+            return Err("per-pid defer event was duplicated");
+        }
+        if reclaim_count[index] == 0 {
+            return Err("per-pid reclaim event was missing");
+        }
+        if reclaim_count[index] != 1 {
+            return Err("per-pid reclaim event was duplicated");
+        }
+        if !defer[index]
+            .zip(reclaim[index])
+            .is_some_and(|(deferred, reclaimed)| deferred < reclaimed)
+        {
+            return Err("per-pid reclaim event did not follow its defer event");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "boot_tests")]
+pub fn deferred_fault_ring_overflow_test() -> crate::test_framework::registry::TestResult {
+    use crate::test_framework::registry::TestResult;
+
+    if crate::task::process_task::deferred_fault_ring_overflow_injection()
+        && DEFERRED_FAULT_RING_DROPPED.aggregate() != 0
+    {
+        TestResult::Pass
+    } else {
+        TestResult::Fail("deferred fault ring overflow was not counted and drained")
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry::TestResult {
+    use crate::test_framework::registry::TestResult;
+
+    struct RestoreProviders;
+    impl Drop for RestoreProviders {
+        fn drop(&mut self) {
+            crate::tracing::enable();
+            super::enable_all();
+        }
+    }
+
+    crate::tracing::enable();
+    super::disable_all();
+    TEARDOWN_PROVIDER.enable_all();
+    let _restore_providers = RestoreProviders;
+    let mut pairing_evidence = TeardownPairingEvidence::new();
+
+    let parent_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
+        Ok(page_table) => alloc::boxed::Box::new(page_table),
+        Err(_) => return TestResult::Fail("parent page-table allocation failed"),
+    };
+    let parent_pid = {
+        let manager_guard = crate::process::manager();
+        let Some(manager) = manager_guard.as_ref() else {
+            return TestResult::Fail("process manager unavailable for parent PID");
+        };
+        manager.allocate_pid()
+    };
+    fn test_user_entry() {}
+    let entry = crate::memory::arch_stub::VirtAddr::new(0x0040_0000);
+    let stack_top = crate::memory::arch_stub::VirtAddr::new(0x0080_0000);
+    let stack_bottom = crate::memory::arch_stub::VirtAddr::new(0x007f_0000);
+    let tls = crate::memory::arch_stub::VirtAddr::new(0x0001_0000);
+    let mut parent_process = crate::process::Process::new(
+        parent_pid,
+        alloc::string::String::from("teardown_pairing_parent"),
+        entry,
+    );
+    let mut parent_thread = crate::task::thread::Thread::new(
+        alloc::string::String::from("teardown_pairing_parent_main"),
+        test_user_entry,
+        stack_top,
+        stack_bottom,
+        tls,
+        crate::task::thread::ThreadPrivilege::User,
+    );
+    parent_thread.owner_pid = Some(parent_pid.as_u64());
+    let parent_context = parent_thread.context.clone();
+    parent_process.page_table = Some(parent_page_table);
+    parent_process.set_main_thread(parent_thread);
+    {
+        let mut manager_guard = crate::process::manager();
+        let Some(manager) = manager_guard.as_mut() else {
+            return TestResult::Fail("process manager unavailable for parent insert");
+        };
+        manager.insert_process(parent_pid, parent_process);
+    };
+
+    let mut deferred_pids = alloc::vec::Vec::with_capacity(64);
+    for _ in 0..64 {
+        let child_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
+            Ok(page_table) => alloc::boxed::Box::new(page_table),
+            Err(_) => return TestResult::Fail("pairing fork page-table allocation failed"),
+        };
+        let child = {
+            let mut manager_guard = crate::process::manager();
+            let Some(manager) = manager_guard.as_mut() else {
+                return TestResult::Fail("process manager unavailable during pairing fork");
+            };
+            let child_pid = match manager.fork_process_aarch64(
+                parent_pid,
+                parent_context.clone(),
+                child_page_table,
+            ) {
+                Ok(pid) => pid,
+                Err(_) => return TestResult::Fail("pairing fork failed"),
+            };
+            let Some(child_tid) = manager
+                .get_process(child_pid)
+                .and_then(|process| process.main_thread.as_ref())
+                .map(|thread| thread.id)
+            else {
+                return TestResult::Fail("pairing child has no main thread");
+            };
+            (child_pid, child_tid)
+        };
+
+        crate::process::exit_process_for_teardown_test(child.0, 0);
+        crate::task::process_task::ProcessScheduler::handle_thread_exit(child.1, 0);
+        {
+            let mut manager_guard = crate::process::manager();
+            let Some(manager) = manager_guard.as_mut() else {
+                return TestResult::Fail("process manager unavailable during pairing reap");
+            };
+            manager.remove_process(child.0);
+            if let Some(parent) = manager.get_process_mut(parent_pid) {
+                parent.children.retain(|pid| *pid != child.0);
+            }
+        }
+        deferred_pids.push(child.0.as_u64());
+        pairing_evidence.sample();
+    }
+
+    // Exercise today's immediate-release path as part of the same explained
+    // workload so the three known-under-PM baseline defects cannot pass at zero.
+    let immediate_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
+        Ok(page_table) => alloc::boxed::Box::new(page_table),
+        Err(_) => return TestResult::Fail("baseline fork page-table allocation failed"),
+    };
+    let immediate = {
+        let mut manager_guard = crate::process::manager();
+        let Some(manager) = manager_guard.as_mut() else {
+            return TestResult::Fail("process manager unavailable during baseline fork");
+        };
+        let child_pid =
+            match manager.fork_process_aarch64(parent_pid, parent_context, immediate_page_table) {
+                Ok(pid) => pid,
+                Err(_) => return TestResult::Fail("baseline fork failed"),
+            };
+        let Some(child_tid) = manager
+            .get_process(child_pid)
+            .and_then(|process| process.main_thread.as_ref())
+            .map(|thread| thread.id)
+        else {
+            return TestResult::Fail("baseline child has no main thread");
+        };
+        (child_pid, child_tid)
+    };
+    crate::task::process_task::ProcessScheduler::handle_thread_exit(immediate.1, 0);
+    {
+        let mut manager_guard = crate::process::manager();
+        let Some(manager) = manager_guard.as_mut() else {
+            return TestResult::Fail("process manager unavailable during baseline reap");
+        };
+        manager.remove_process(immediate.0);
+        if let Some(parent) = manager.get_process_mut(parent_pid) {
+            parent.children.retain(|pid| *pid != immediate.0);
+        }
+    }
+
+    let timer_frequency = crate::arch_impl::aarch64::timer::frequency_hz();
+    for _ in 0..4 {
+        crate::task::scheduler::nudge_retirement_grace_for_test();
+        let boundary_deadline =
+            crate::arch_impl::aarch64::timer::rdtsc().saturating_add(timer_frequency / 1000);
+        while crate::arch_impl::aarch64::timer::rdtsc() < boundary_deadline {
+            core::hint::spin_loop();
+        }
+        pairing_evidence.sample();
+    }
+    let quiesce_deadline =
+        crate::arch_impl::aarch64::timer::rdtsc().saturating_add(timer_frequency.saturating_mul(5));
+    loop {
+        crate::task::scheduler::nudge_retirement_grace_for_test();
+        let boundary_deadline =
+            crate::arch_impl::aarch64::timer::rdtsc().saturating_add(timer_frequency / 1000);
+        while crate::arch_impl::aarch64::timer::rdtsc() < boundary_deadline {
+            core::hint::spin_loop();
+        }
+        crate::task::process_task::reclaim_deferred_process_resources();
+        pairing_evidence.sample();
+        if TEARDOWN_DEFER.aggregate() == TEARDOWN_RECLAIM.aggregate()
+            && TEARDOWN_RECLAIM.aggregate() >= 64
+        {
+            break;
+        }
+        if crate::arch_impl::aarch64::timer::rdtsc() >= quiesce_deadline {
+            break;
+        }
+        core::hint::spin_loop();
+    }
+
+    let deferred = TEARDOWN_DEFER.aggregate();
+    let reclaimed = TEARDOWN_RECLAIM.aggregate();
+    if TEARDOWN_ENTRY_EXIT.aggregate() < 64 {
+        return TestResult::Fail("TEARDOWN_ENTRY_EXIT did not reach 64");
+    }
+    if EXIT_FIRST_REQUESTS.aggregate() < 64 || EXIT_REPEAT_REQUESTS.aggregate() < 64 {
+        return TestResult::Fail("first/repeat exit request counters did not reach 64");
+    }
+    if deferred < 64 {
+        return TestResult::Fail("TEARDOWN_DEFER did not reach 64");
+    }
+    if deferred != reclaimed {
+        return TestResult::Fail("TEARDOWN_DEFER did not equal TEARDOWN_RECLAIM");
+    }
+    crate::tracing::disable();
+    pairing_evidence.sample();
+    TEARDOWN_PROVIDER.disable_all();
+    if let Err(message) = defer_reclaim_events_are_paired(&deferred_pids, &pairing_evidence.events)
+    {
+        return TestResult::Fail(message);
+    }
+    if TEARDOWN_MASKED_FRAMES_WALKED.aggregate() == 0
+        || FD_CLOSES_UNDER_PM.aggregate() == 0
+        || RECLAIM_ENQUEUE_UNDER_PM.aggregate() == 0
+    {
+        return TestResult::Fail("expected Phase-0 under-PM baseline remained zero");
+    }
+    if TEARDOWN_LOCK_ORDER_SUSPECT.aggregate() != 0
+        || PROOF_UNDER_QUEUE_LOCK.aggregate() != 0
+        || RECLAIM_CONTEXT_VIOLATIONS.aggregate() != 0
+    {
+        return TestResult::Fail("healthy teardown lock-context counter moved");
+    }
+    if EXIT_SGI_SENT.aggregate() != 0 {
+        return TestResult::Fail("generic reschedule IPI moved EXIT_SGI_SENT");
+    }
+    let _all_counter_readers = snapshot();
+
+    {
+        let mut manager_guard = crate::process::manager();
+        let Some(manager) = manager_guard.as_mut() else {
+            return TestResult::Fail("process manager unavailable for parent cleanup");
+        };
+        if let Some(parent) = manager.get_process_mut(parent_pid) {
+            crate::task::process_task::release_process_resources(parent);
+        }
+        manager.remove_process(parent_pid);
+    }
+
+    TestResult::Pass
+}

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -28,7 +28,6 @@ macro_rules! counter {
 counter!(TEARDOWN_ENTRY_EXIT, "Exit teardown entries");
 counter!(TEARDOWN_ENTRY_FAULT, "Fault teardown entries");
 counter!(TEARDOWN_ENTRY_SIGNAL, "Signal teardown entries");
-counter!(TEARDOWN_ENTRY_GROUP, "Group teardown entries");
 counter!(EXIT_FIRST_REQUESTS, "First exit requests");
 counter!(EXIT_REPEAT_REQUESTS, "Repeated exit requests");
 counter!(TEARDOWN_QUARANTINE, "Scheduler quarantine operations");
@@ -68,6 +67,7 @@ counter!(
 
 // Declaration-only until the phase named in PLAN.md. These intentionally have
 // no trace_count! producer in Phase 0.
+counter!(TEARDOWN_ENTRY_GROUP, "Group teardown entries");
 counter!(EXIT_SGI_SENT, "Teardown-attributed expedite SGIs");
 counter!(EXIT_REQUEST_OBSERVED, "Observed latched exit requests");
 counter!(EXIT_KICK_PUBLISHED, "Published exit-kick buckets");
@@ -279,102 +279,6 @@ pub fn scheduler_scope_active() -> bool {
         != 0
 }
 
-#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-struct TeardownPairingEvidence {
-    seen: alloc::vec::Vec<(u64, u16, u32, u8)>,
-    events: alloc::vec::Vec<crate::tracing::TraceEvent>,
-}
-
-#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-impl TeardownPairingEvidence {
-    fn new() -> Self {
-        let mut evidence = Self {
-            seen: alloc::vec::Vec::new(),
-            events: alloc::vec::Vec::new(),
-        };
-        evidence.sample_into(false);
-        evidence
-    }
-
-    fn sample(&mut self) {
-        self.sample_into(true);
-    }
-
-    fn sample_into(&mut self, retain: bool) {
-        unsafe {
-            let buffers = core::ptr::addr_of!(crate::tracing::TRACE_BUFFERS);
-            for buffer in &*buffers {
-                for event in buffer.iter_events() {
-                    if event.event_type != TEARDOWN_DEFER_EVENT
-                        && event.event_type != TEARDOWN_RECLAIM_EVENT
-                    {
-                        continue;
-                    }
-                    let key = (
-                        event.timestamp,
-                        event.event_type,
-                        event.payload,
-                        event.cpu_id,
-                    );
-                    if self.seen.contains(&key) {
-                        continue;
-                    }
-                    self.seen.push(key);
-                    if retain {
-                        self.events.push(*event);
-                    }
-                }
-            }
-        }
-    }
-}
-
-#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-pub fn defer_reclaim_events_are_paired(
-    pids: &[u64],
-    events: &[crate::tracing::TraceEvent],
-) -> Result<(), &'static str> {
-    let mut defer = alloc::vec![None; pids.len()];
-    let mut reclaim = alloc::vec![None; pids.len()];
-    let mut defer_count = alloc::vec![0u8; pids.len()];
-    let mut reclaim_count = alloc::vec![0u8; pids.len()];
-
-    for event in events {
-        let Some(index) = pids.iter().position(|pid| *pid as u32 == event.payload) else {
-            continue;
-        };
-        if event.event_type == TEARDOWN_DEFER_EVENT {
-            defer_count[index] = defer_count[index].saturating_add(1);
-            defer[index] = Some(event.timestamp);
-        } else if event.event_type == TEARDOWN_RECLAIM_EVENT {
-            reclaim_count[index] = reclaim_count[index].saturating_add(1);
-            reclaim[index] = Some(event.timestamp);
-        }
-    }
-
-    for index in 0..pids.len() {
-        if defer_count[index] == 0 {
-            return Err("per-pid defer event was missing");
-        }
-        if defer_count[index] != 1 {
-            return Err("per-pid defer event was duplicated");
-        }
-        if reclaim_count[index] == 0 {
-            return Err("per-pid reclaim event was missing");
-        }
-        if reclaim_count[index] != 1 {
-            return Err("per-pid reclaim event was duplicated");
-        }
-        if !defer[index]
-            .zip(reclaim[index])
-            .is_some_and(|(deferred, reclaimed)| deferred < reclaimed)
-        {
-            return Err("per-pid reclaim event did not follow its defer event");
-        }
-    }
-    Ok(())
-}
-
 #[cfg(feature = "boot_tests")]
 pub fn deferred_fault_ring_overflow_test() -> crate::test_framework::registry::TestResult {
     use crate::test_framework::registry::TestResult;
@@ -397,29 +301,6 @@ pub fn deferred_fault_ring_overflow_test() -> crate::test_framework::registry::T
 pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry::TestResult {
     use crate::test_framework::registry::TestResult;
 
-    struct RestoreTracingState {
-        globally_enabled: bool,
-        providers: crate::tracing::provider::ProviderEnabledStateSnapshot,
-    }
-    impl Drop for RestoreTracingState {
-        fn drop(&mut self) {
-            self.providers.restore();
-            if self.globally_enabled {
-                crate::tracing::enable();
-            } else {
-                crate::tracing::disable();
-            }
-        }
-    }
-
-    let _restore_tracing_state = RestoreTracingState {
-        globally_enabled: crate::tracing::is_enabled(),
-        providers: crate::tracing::provider::ProviderEnabledStateSnapshot::capture(),
-    };
-    crate::tracing::enable();
-    super::disable_all();
-    TEARDOWN_PROVIDER.enable_all();
-
     let teardown_entry_exit_before = TEARDOWN_ENTRY_EXIT.aggregate();
     let exit_first_requests_before = EXIT_FIRST_REQUESTS.aggregate();
     let exit_repeat_requests_before = EXIT_REPEAT_REQUESTS.aggregate();
@@ -431,8 +312,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     let lock_order_suspect_before = TEARDOWN_LOCK_ORDER_SUSPECT.aggregate();
     let proof_under_queue_lock_before = PROOF_UNDER_QUEUE_LOCK.aggregate();
     let reclaim_context_violations_before = RECLAIM_CONTEXT_VIOLATIONS.aggregate();
-    let exit_sgi_sent_before = EXIT_SGI_SENT.aggregate();
-    let mut pairing_evidence = TeardownPairingEvidence::new();
 
     let parent_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
         Ok(page_table) => alloc::boxed::Box::new(page_table),
@@ -475,7 +354,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         manager.insert_process(parent_pid, parent_process);
     };
 
-    let mut deferred_pids = alloc::vec::Vec::with_capacity(64);
     for _ in 0..64 {
         let child_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
             Ok(page_table) => alloc::boxed::Box::new(page_table),
@@ -516,8 +394,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
                 parent.children.retain(|pid| *pid != child.0);
             }
         }
-        deferred_pids.push(child.0.as_u64());
-        pairing_evidence.sample();
     }
 
     // Exercise today's immediate-release path as part of the same explained
@@ -558,15 +434,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     }
 
     let timer_frequency = crate::arch_impl::aarch64::timer::frequency_hz();
-    for _ in 0..4 {
-        crate::task::scheduler::nudge_retirement_grace_for_test();
-        let boundary_deadline =
-            crate::arch_impl::aarch64::timer::rdtsc().saturating_add(timer_frequency / 1000);
-        while crate::arch_impl::aarch64::timer::rdtsc() < boundary_deadline {
-            core::hint::spin_loop();
-        }
-        pairing_evidence.sample();
-    }
     let quiesce_deadline =
         crate::arch_impl::aarch64::timer::rdtsc().saturating_add(timer_frequency.saturating_mul(5));
     loop {
@@ -577,7 +444,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
             core::hint::spin_loop();
         }
         crate::task::process_task::reclaim_deferred_process_resources();
-        pairing_evidence.sample();
         let deferred_delta = TEARDOWN_DEFER
             .aggregate()
             .saturating_sub(teardown_defer_before);
@@ -614,18 +480,8 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     if exit_first_requests_delta < 64 || exit_repeat_requests_delta < 64 {
         return TestResult::Fail("first/repeat exit request workload deltas did not reach 64");
     }
-    if deferred_delta < 64 {
-        return TestResult::Fail("TEARDOWN_DEFER workload delta did not reach 64");
-    }
-    if deferred_delta != reclaimed_delta {
-        return TestResult::Fail("TEARDOWN_DEFER workload delta did not equal TEARDOWN_RECLAIM");
-    }
-    crate::tracing::disable();
-    pairing_evidence.sample();
-    TEARDOWN_PROVIDER.disable_all();
-    if let Err(message) = defer_reclaim_events_are_paired(&deferred_pids, &pairing_evidence.events)
-    {
-        return TestResult::Fail(message);
+    if deferred_delta != reclaimed_delta || reclaimed_delta < 64 {
+        return TestResult::Fail("defer/reclaim workload deltas did not pair at 64 or more");
     }
     if TEARDOWN_MASKED_FRAMES_WALKED
         .aggregate()
@@ -656,13 +512,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
             != 0
     {
         return TestResult::Fail("healthy teardown lock-context counter moved");
-    }
-    if EXIT_SGI_SENT
-        .aggregate()
-        .saturating_sub(exit_sgi_sent_before)
-        != 0
-    {
-        return TestResult::Fail("generic reschedule IPI moved EXIT_SGI_SENT");
     }
     let _all_counter_readers = snapshot();
 

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -175,17 +175,17 @@ pub fn snapshot() -> [u64; COUNTER_COUNT] {
     core::array::from_fn(|index| COUNTERS[index].aggregate())
 }
 
-#[cfg(feature = "boot_tests")]
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 const BOOT_TEST_PID_COUNT_SLOTS: usize = 128;
 
-#[cfg(feature = "boot_tests")]
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 struct BootTestPidCountSlot {
     pid: AtomicU64,
     defer_count: AtomicU64,
     reclaim_count: AtomicU64,
 }
 
-#[cfg(feature = "boot_tests")]
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 impl BootTestPidCountSlot {
     const fn new() -> Self {
         Self {
@@ -196,20 +196,30 @@ impl BootTestPidCountSlot {
     }
 }
 
-#[cfg(feature = "boot_tests")]
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 static BOOT_TEST_PID_COUNTS: [BootTestPidCountSlot; BOOT_TEST_PID_COUNT_SLOTS] =
     [const { BootTestPidCountSlot::new() }; BOOT_TEST_PID_COUNT_SLOTS];
 
-#[cfg(feature = "boot_tests")]
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 static BOOT_TEST_PID_COUNTS_ACTIVE: AtomicU64 = AtomicU64::new(0);
 
-#[cfg(feature = "boot_tests")]
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+struct BootTestPidCountsGuard;
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl Drop for BootTestPidCountsGuard {
+    fn drop(&mut self) {
+        BOOT_TEST_PID_COUNTS_ACTIVE.store(0, Ordering::Release);
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 enum BootTestPidCountKind {
     Defer,
     Reclaim,
 }
 
-#[cfg(feature = "boot_tests")]
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 #[inline(always)]
 fn record_boot_test_pid_count(pid: u64, kind: BootTestPidCountKind) {
     if BOOT_TEST_PID_COUNTS_ACTIVE.load(Ordering::Acquire) == 0 || pid == 0 {
@@ -238,7 +248,7 @@ fn record_boot_test_pid_count(pid: u64, kind: BootTestPidCountKind) {
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-fn reset_boot_test_pid_counts() {
+fn reset_boot_test_pid_counts() -> BootTestPidCountsGuard {
     BOOT_TEST_PID_COUNTS_ACTIVE.store(0, Ordering::Release);
     for slot in &BOOT_TEST_PID_COUNTS {
         slot.pid.store(0, Ordering::Relaxed);
@@ -246,6 +256,7 @@ fn reset_boot_test_pid_counts() {
         slot.reclaim_count.store(0, Ordering::Relaxed);
     }
     BOOT_TEST_PID_COUNTS_ACTIVE.store(1, Ordering::Release);
+    BootTestPidCountsGuard
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
@@ -300,7 +311,7 @@ fn boot_test_pid_counts_complete(pids: &[u64]) -> bool {
 pub fn record_defer(pid: u64) {
     crate::trace_count!(TEARDOWN_DEFER);
     crate::trace_event!(TEARDOWN_PROVIDER, TEARDOWN_DEFER_EVENT, pid as u32);
-    #[cfg(feature = "boot_tests")]
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
     record_boot_test_pid_count(pid, BootTestPidCountKind::Defer);
 }
 
@@ -308,7 +319,7 @@ pub fn record_defer(pid: u64) {
 pub fn record_reclaim(pid: u64) {
     crate::trace_count!(TEARDOWN_RECLAIM);
     crate::trace_event!(TEARDOWN_PROVIDER, TEARDOWN_RECLAIM_EVENT, pid as u32);
-    #[cfg(feature = "boot_tests")]
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
     record_boot_test_pid_count(pid, BootTestPidCountKind::Reclaim);
 }
 
@@ -479,7 +490,7 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
 
     let mut pairing_child_pids = [0u64; 64];
     let mut pairing_child_count = 0;
-    reset_boot_test_pid_counts();
+    let pid_counts_guard = reset_boot_test_pid_counts();
     for _ in 0..64 {
         let child_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
             Ok(page_table) => alloc::boxed::Box::new(page_table),
@@ -608,7 +619,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
             );
         }
     }
-    BOOT_TEST_PID_COUNTS_ACTIVE.store(0, Ordering::Release);
     if TEARDOWN_MASKED_FRAMES_WALKED
         .aggregate()
         .saturating_sub(masked_frames_walked_before)
@@ -652,5 +662,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         manager.remove_process(parent_pid);
     }
 
+    core::mem::drop(pid_counts_guard);
     TestResult::Pass
 }

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -46,7 +46,7 @@ counter!(TEARDOWN_VICTIM_DIVERGENCE, "TID and CR3 victim divergence");
 counter!(TEARDOWN_CR3_MISS, "Fault-victim CR3 misses");
 counter!(
     EXIT_ATTRIBUTION_UNCERTAIN,
-    "Uncertain fault-victim attribution"
+    "Neither CR3 nor dispatched TID resolved a fault victim"
 );
 counter!(DEFERRED_FAULT_RING_DROPPED, "Dropped deferred fault exits");
 counter!(
@@ -163,7 +163,10 @@ pub static COUNTERS: [&TraceCounter; COUNTER_COUNT] = [
 pub fn init() {
     register_provider(&TEARDOWN_PROVIDER);
     for counter in COUNTERS {
-        register_counter(counter);
+        assert!(
+            register_counter(counter).is_some(),
+            "trace counter registry overflow while registering teardown counters"
+        );
     }
 }
 
@@ -242,9 +245,6 @@ impl SchedulerScope {
     #[inline(always)]
     pub fn enter() -> Self {
         let cpu = current_cpu().min(crate::tracing::MAX_CPUS - 1);
-        if RECLAIM_PROOF_DEPTH[cpu].load(Ordering::Relaxed) != 0 {
-            crate::trace_count!(PROOF_UNDER_QUEUE_LOCK);
-        }
         SCHEDULER_SCOPE_DEPTH[cpu].fetch_add(1, Ordering::Relaxed);
         Self { cpu }
     }
@@ -259,6 +259,14 @@ impl Drop for SchedulerScope {
 
 #[inline(always)]
 pub fn note_process_manager_acquire() {
+    let cpu = current_cpu().min(crate::tracing::MAX_CPUS - 1);
+    if RECLAIM_PROOF_DEPTH[cpu].load(Ordering::Relaxed) != 0 {
+        crate::trace_count!(PROOF_UNDER_QUEUE_LOCK);
+    }
+}
+
+#[inline(always)]
+pub fn note_scheduler_acquire() {
     let cpu = current_cpu().min(crate::tracing::MAX_CPUS - 1);
     if RECLAIM_PROOF_DEPTH[cpu].load(Ordering::Relaxed) != 0 {
         crate::trace_count!(PROOF_UNDER_QUEUE_LOCK);
@@ -371,9 +379,14 @@ pub fn defer_reclaim_events_are_paired(
 pub fn deferred_fault_ring_overflow_test() -> crate::test_framework::registry::TestResult {
     use crate::test_framework::registry::TestResult;
 
-    if crate::task::process_task::deferred_fault_ring_overflow_injection()
-        && DEFERRED_FAULT_RING_DROPPED.aggregate() != 0
-    {
+    let dropped_before = DEFERRED_FAULT_RING_DROPPED.aggregate();
+    let ring_behaved_as_expected =
+        crate::task::process_task::deferred_fault_ring_overflow_injection();
+    let dropped_delta = DEFERRED_FAULT_RING_DROPPED
+        .aggregate()
+        .saturating_sub(dropped_before);
+
+    if ring_behaved_as_expected && dropped_delta >= 1 {
         TestResult::Pass
     } else {
         TestResult::Fail("deferred fault ring overflow was not counted and drained")
@@ -384,18 +397,41 @@ pub fn deferred_fault_ring_overflow_test() -> crate::test_framework::registry::T
 pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry::TestResult {
     use crate::test_framework::registry::TestResult;
 
-    struct RestoreProviders;
-    impl Drop for RestoreProviders {
+    struct RestoreTracingState {
+        globally_enabled: bool,
+        providers: crate::tracing::provider::ProviderEnabledStateSnapshot,
+    }
+    impl Drop for RestoreTracingState {
         fn drop(&mut self) {
-            crate::tracing::enable();
-            super::enable_all();
+            self.providers.restore();
+            if self.globally_enabled {
+                crate::tracing::enable();
+            } else {
+                crate::tracing::disable();
+            }
         }
     }
 
+    let _restore_tracing_state = RestoreTracingState {
+        globally_enabled: crate::tracing::is_enabled(),
+        providers: crate::tracing::provider::ProviderEnabledStateSnapshot::capture(),
+    };
     crate::tracing::enable();
     super::disable_all();
     TEARDOWN_PROVIDER.enable_all();
-    let _restore_providers = RestoreProviders;
+
+    let teardown_entry_exit_before = TEARDOWN_ENTRY_EXIT.aggregate();
+    let exit_first_requests_before = EXIT_FIRST_REQUESTS.aggregate();
+    let exit_repeat_requests_before = EXIT_REPEAT_REQUESTS.aggregate();
+    let teardown_defer_before = TEARDOWN_DEFER.aggregate();
+    let teardown_reclaim_before = TEARDOWN_RECLAIM.aggregate();
+    let masked_frames_walked_before = TEARDOWN_MASKED_FRAMES_WALKED.aggregate();
+    let fd_closes_under_pm_before = FD_CLOSES_UNDER_PM.aggregate();
+    let reclaim_enqueue_under_pm_before = RECLAIM_ENQUEUE_UNDER_PM.aggregate();
+    let lock_order_suspect_before = TEARDOWN_LOCK_ORDER_SUSPECT.aggregate();
+    let proof_under_queue_lock_before = PROOF_UNDER_QUEUE_LOCK.aggregate();
+    let reclaim_context_violations_before = RECLAIM_CONTEXT_VIOLATIONS.aggregate();
+    let exit_sgi_sent_before = EXIT_SGI_SENT.aggregate();
     let mut pairing_evidence = TeardownPairingEvidence::new();
 
     let parent_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
@@ -542,9 +578,13 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         }
         crate::task::process_task::reclaim_deferred_process_resources();
         pairing_evidence.sample();
-        if TEARDOWN_DEFER.aggregate() == TEARDOWN_RECLAIM.aggregate()
-            && TEARDOWN_RECLAIM.aggregate() >= 64
-        {
+        let deferred_delta = TEARDOWN_DEFER
+            .aggregate()
+            .saturating_sub(teardown_defer_before);
+        let reclaimed_delta = TEARDOWN_RECLAIM
+            .aggregate()
+            .saturating_sub(teardown_reclaim_before);
+        if deferred_delta == reclaimed_delta && reclaimed_delta >= 64 {
             break;
         }
         if crate::arch_impl::aarch64::timer::rdtsc() >= quiesce_deadline {
@@ -553,19 +593,32 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         core::hint::spin_loop();
     }
 
-    let deferred = TEARDOWN_DEFER.aggregate();
-    let reclaimed = TEARDOWN_RECLAIM.aggregate();
-    if TEARDOWN_ENTRY_EXIT.aggregate() < 64 {
-        return TestResult::Fail("TEARDOWN_ENTRY_EXIT did not reach 64");
+    let teardown_entry_exit_delta = TEARDOWN_ENTRY_EXIT
+        .aggregate()
+        .saturating_sub(teardown_entry_exit_before);
+    let exit_first_requests_delta = EXIT_FIRST_REQUESTS
+        .aggregate()
+        .saturating_sub(exit_first_requests_before);
+    let exit_repeat_requests_delta = EXIT_REPEAT_REQUESTS
+        .aggregate()
+        .saturating_sub(exit_repeat_requests_before);
+    let deferred_delta = TEARDOWN_DEFER
+        .aggregate()
+        .saturating_sub(teardown_defer_before);
+    let reclaimed_delta = TEARDOWN_RECLAIM
+        .aggregate()
+        .saturating_sub(teardown_reclaim_before);
+    if teardown_entry_exit_delta < 64 {
+        return TestResult::Fail("TEARDOWN_ENTRY_EXIT workload delta did not reach 64");
     }
-    if EXIT_FIRST_REQUESTS.aggregate() < 64 || EXIT_REPEAT_REQUESTS.aggregate() < 64 {
-        return TestResult::Fail("first/repeat exit request counters did not reach 64");
+    if exit_first_requests_delta < 64 || exit_repeat_requests_delta < 64 {
+        return TestResult::Fail("first/repeat exit request workload deltas did not reach 64");
     }
-    if deferred < 64 {
-        return TestResult::Fail("TEARDOWN_DEFER did not reach 64");
+    if deferred_delta < 64 {
+        return TestResult::Fail("TEARDOWN_DEFER workload delta did not reach 64");
     }
-    if deferred != reclaimed {
-        return TestResult::Fail("TEARDOWN_DEFER did not equal TEARDOWN_RECLAIM");
+    if deferred_delta != reclaimed_delta {
+        return TestResult::Fail("TEARDOWN_DEFER workload delta did not equal TEARDOWN_RECLAIM");
     }
     crate::tracing::disable();
     pairing_evidence.sample();
@@ -574,19 +627,41 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     {
         return TestResult::Fail(message);
     }
-    if TEARDOWN_MASKED_FRAMES_WALKED.aggregate() == 0
-        || FD_CLOSES_UNDER_PM.aggregate() == 0
-        || RECLAIM_ENQUEUE_UNDER_PM.aggregate() == 0
+    if TEARDOWN_MASKED_FRAMES_WALKED
+        .aggregate()
+        .saturating_sub(masked_frames_walked_before)
+        == 0
+        || FD_CLOSES_UNDER_PM
+            .aggregate()
+            .saturating_sub(fd_closes_under_pm_before)
+            == 0
+        || RECLAIM_ENQUEUE_UNDER_PM
+            .aggregate()
+            .saturating_sub(reclaim_enqueue_under_pm_before)
+            == 0
     {
         return TestResult::Fail("expected Phase-0 under-PM baseline remained zero");
     }
-    if TEARDOWN_LOCK_ORDER_SUSPECT.aggregate() != 0
-        || PROOF_UNDER_QUEUE_LOCK.aggregate() != 0
-        || RECLAIM_CONTEXT_VIOLATIONS.aggregate() != 0
+    if TEARDOWN_LOCK_ORDER_SUSPECT
+        .aggregate()
+        .saturating_sub(lock_order_suspect_before)
+        != 0
+        || PROOF_UNDER_QUEUE_LOCK
+            .aggregate()
+            .saturating_sub(proof_under_queue_lock_before)
+            != 0
+        || RECLAIM_CONTEXT_VIOLATIONS
+            .aggregate()
+            .saturating_sub(reclaim_context_violations_before)
+            != 0
     {
         return TestResult::Fail("healthy teardown lock-context counter moved");
     }
-    if EXIT_SGI_SENT.aggregate() != 0 {
+    if EXIT_SGI_SENT
+        .aggregate()
+        .saturating_sub(exit_sgi_sent_before)
+        != 0
+    {
         return TestResult::Fail("generic reschedule IPI moved EXIT_SGI_SENT");
     }
     let _all_counter_readers = snapshot();

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -175,16 +175,141 @@ pub fn snapshot() -> [u64; COUNTER_COUNT] {
     core::array::from_fn(|index| COUNTERS[index].aggregate())
 }
 
+#[cfg(feature = "boot_tests")]
+const BOOT_TEST_PID_COUNT_SLOTS: usize = 128;
+
+#[cfg(feature = "boot_tests")]
+struct BootTestPidCountSlot {
+    pid: AtomicU64,
+    defer_count: AtomicU64,
+    reclaim_count: AtomicU64,
+}
+
+#[cfg(feature = "boot_tests")]
+impl BootTestPidCountSlot {
+    const fn new() -> Self {
+        Self {
+            pid: AtomicU64::new(0),
+            defer_count: AtomicU64::new(0),
+            reclaim_count: AtomicU64::new(0),
+        }
+    }
+}
+
+#[cfg(feature = "boot_tests")]
+static BOOT_TEST_PID_COUNTS: [BootTestPidCountSlot; BOOT_TEST_PID_COUNT_SLOTS] =
+    [const { BootTestPidCountSlot::new() }; BOOT_TEST_PID_COUNT_SLOTS];
+
+#[cfg(feature = "boot_tests")]
+static BOOT_TEST_PID_COUNTS_ACTIVE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(feature = "boot_tests")]
+enum BootTestPidCountKind {
+    Defer,
+    Reclaim,
+}
+
+#[cfg(feature = "boot_tests")]
+#[inline(always)]
+fn record_boot_test_pid_count(pid: u64, kind: BootTestPidCountKind) {
+    if BOOT_TEST_PID_COUNTS_ACTIVE.load(Ordering::Acquire) == 0 || pid == 0 {
+        return;
+    }
+
+    let start = pid as usize & (BOOT_TEST_PID_COUNT_SLOTS - 1);
+    for offset in 0..BOOT_TEST_PID_COUNT_SLOTS {
+        let slot = &BOOT_TEST_PID_COUNTS[(start + offset) & (BOOT_TEST_PID_COUNT_SLOTS - 1)];
+        let slot_pid = slot.pid.load(Ordering::Acquire);
+        if slot_pid == pid {
+            match kind {
+                BootTestPidCountKind::Defer => {
+                    slot.defer_count.fetch_add(1, Ordering::Relaxed);
+                }
+                BootTestPidCountKind::Reclaim => {
+                    slot.reclaim_count.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+            return;
+        }
+        if slot_pid == 0 {
+            return;
+        }
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn reset_boot_test_pid_counts() {
+    BOOT_TEST_PID_COUNTS_ACTIVE.store(0, Ordering::Release);
+    for slot in &BOOT_TEST_PID_COUNTS {
+        slot.pid.store(0, Ordering::Relaxed);
+        slot.defer_count.store(0, Ordering::Relaxed);
+        slot.reclaim_count.store(0, Ordering::Relaxed);
+    }
+    BOOT_TEST_PID_COUNTS_ACTIVE.store(1, Ordering::Release);
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn track_boot_test_pid(pid: u64) -> bool {
+    if pid == 0 {
+        return false;
+    }
+
+    let start = pid as usize & (BOOT_TEST_PID_COUNT_SLOTS - 1);
+    for offset in 0..BOOT_TEST_PID_COUNT_SLOTS {
+        let slot = &BOOT_TEST_PID_COUNTS[(start + offset) & (BOOT_TEST_PID_COUNT_SLOTS - 1)];
+        match slot
+            .pid
+            .compare_exchange(0, pid, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => return true,
+            Err(slot_pid) if slot_pid == pid => return true,
+            Err(_) => {}
+        }
+    }
+    false
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_test_pid_counts(pid: u64) -> (u64, u64) {
+    let start = pid as usize & (BOOT_TEST_PID_COUNT_SLOTS - 1);
+    for offset in 0..BOOT_TEST_PID_COUNT_SLOTS {
+        let slot = &BOOT_TEST_PID_COUNTS[(start + offset) & (BOOT_TEST_PID_COUNT_SLOTS - 1)];
+        let slot_pid = slot.pid.load(Ordering::Acquire);
+        if slot_pid == pid {
+            return (
+                slot.defer_count.load(Ordering::Relaxed),
+                slot.reclaim_count.load(Ordering::Relaxed),
+            );
+        }
+        if slot_pid == 0 {
+            break;
+        }
+    }
+    (0, 0)
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_test_pid_counts_complete(pids: &[u64]) -> bool {
+    pids.iter().all(|pid| {
+        let (defer_count, reclaim_count) = boot_test_pid_counts(*pid);
+        defer_count >= 1 && defer_count == reclaim_count
+    })
+}
+
 #[inline(always)]
 pub fn record_defer(pid: u64) {
     crate::trace_count!(TEARDOWN_DEFER);
     crate::trace_event!(TEARDOWN_PROVIDER, TEARDOWN_DEFER_EVENT, pid as u32);
+    #[cfg(feature = "boot_tests")]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::Defer);
 }
 
 #[inline(always)]
 pub fn record_reclaim(pid: u64) {
     crate::trace_count!(TEARDOWN_RECLAIM);
     crate::trace_event!(TEARDOWN_PROVIDER, TEARDOWN_RECLAIM_EVENT, pid as u32);
+    #[cfg(feature = "boot_tests")]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::Reclaim);
 }
 
 #[inline(always)]
@@ -304,8 +429,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     let teardown_entry_exit_before = TEARDOWN_ENTRY_EXIT.aggregate();
     let exit_first_requests_before = EXIT_FIRST_REQUESTS.aggregate();
     let exit_repeat_requests_before = EXIT_REPEAT_REQUESTS.aggregate();
-    let teardown_defer_before = TEARDOWN_DEFER.aggregate();
-    let teardown_reclaim_before = TEARDOWN_RECLAIM.aggregate();
     let masked_frames_walked_before = TEARDOWN_MASKED_FRAMES_WALKED.aggregate();
     let fd_closes_under_pm_before = FD_CLOSES_UNDER_PM.aggregate();
     let reclaim_enqueue_under_pm_before = RECLAIM_ENQUEUE_UNDER_PM.aggregate();
@@ -354,6 +477,9 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         manager.insert_process(parent_pid, parent_process);
     };
 
+    let mut pairing_child_pids = [0u64; 64];
+    let mut pairing_child_count = 0;
+    reset_boot_test_pid_counts();
     for _ in 0..64 {
         let child_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
             Ok(page_table) => alloc::boxed::Box::new(page_table),
@@ -381,6 +507,12 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
             };
             (child_pid, child_tid)
         };
+
+        pairing_child_pids[pairing_child_count] = child.0.as_u64();
+        if !track_boot_test_pid(pairing_child_pids[pairing_child_count]) {
+            return TestResult::Fail("per-PID pairing tally table capacity exhausted");
+        }
+        pairing_child_count += 1;
 
         crate::process::exit_process_for_teardown_test(child.0, 0);
         crate::task::process_task::ProcessScheduler::handle_thread_exit(child.1, 0);
@@ -444,13 +576,7 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
             core::hint::spin_loop();
         }
         crate::task::process_task::reclaim_deferred_process_resources();
-        let deferred_delta = TEARDOWN_DEFER
-            .aggregate()
-            .saturating_sub(teardown_defer_before);
-        let reclaimed_delta = TEARDOWN_RECLAIM
-            .aggregate()
-            .saturating_sub(teardown_reclaim_before);
-        if deferred_delta == reclaimed_delta && reclaimed_delta >= 64 {
+        if boot_test_pid_counts_complete(&pairing_child_pids) {
             break;
         }
         if crate::arch_impl::aarch64::timer::rdtsc() >= quiesce_deadline {
@@ -468,21 +594,21 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     let exit_repeat_requests_delta = EXIT_REPEAT_REQUESTS
         .aggregate()
         .saturating_sub(exit_repeat_requests_before);
-    let deferred_delta = TEARDOWN_DEFER
-        .aggregate()
-        .saturating_sub(teardown_defer_before);
-    let reclaimed_delta = TEARDOWN_RECLAIM
-        .aggregate()
-        .saturating_sub(teardown_reclaim_before);
     if teardown_entry_exit_delta < 64 {
         return TestResult::Fail("TEARDOWN_ENTRY_EXIT workload delta did not reach 64");
     }
     if exit_first_requests_delta < 64 || exit_repeat_requests_delta < 64 {
         return TestResult::Fail("first/repeat exit request workload deltas did not reach 64");
     }
-    if deferred_delta != reclaimed_delta || reclaimed_delta < 64 {
-        return TestResult::Fail("defer/reclaim workload deltas did not pair at 64 or more");
+    for pid in pairing_child_pids {
+        let (defer_count, reclaim_count) = boot_test_pid_counts(pid);
+        if defer_count == 0 || defer_count != reclaim_count {
+            return TestResult::Fail(
+                "per-PID defer/reclaim count pairing failed for a pairing-test child",
+            );
+        }
     }
+    BOOT_TEST_PID_COUNTS_ACTIVE.store(0, Ordering::Release);
     if TEARDOWN_MASKED_FRAMES_WALKED
         .aggregate()
         .saturating_sub(masked_frames_walked_before)

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -182,7 +182,7 @@ const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 333),
 ];
 const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
-    &[("kernel/src/tracing/providers/teardown.rs", 385)];
+    &[("kernel/src/tracing/providers/teardown.rs", 517)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
     ("kernel/src/task/scheduler.rs", 1740),
     ("kernel/src/task/scheduler.rs", 1911),
@@ -396,7 +396,10 @@ fn all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates() {
     );
     assert!(provider.contains("core::array::from_fn(|index| COUNTERS[index].aggregate())"));
     assert!(provider.contains("for _ in 0..64"));
-    assert!(provider.contains("deferred_delta != reclaimed_delta || reclaimed_delta < 64"));
+    assert!(provider.contains("reset_boot_test_pid_counts();"));
+    assert!(provider.contains("for pid in pairing_child_pids"));
+    assert!(provider.contains("defer_count == 0 || defer_count != reclaim_count"));
+    assert!(!provider.contains("deferred_delta != reclaimed_delta || reclaimed_delta < 64"));
     assert!(!provider.contains("TeardownPairingEvidence"));
     assert!(!provider.contains("defer_reclaim_events_are_paired("));
     assert!(!provider.contains("deferred_pids"));

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -1,0 +1,355 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+type Site = (String, usize);
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn rust_sources_below(relative: &str) -> Vec<(String, String)> {
+    fn visit(root: &Path, dir: &Path, out: &mut Vec<(String, String)>) {
+        for entry in fs::read_dir(dir).expect("read source directory") {
+            let path = entry.expect("read directory entry").path();
+            if path.is_dir() {
+                visit(root, &path, out);
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                let relative = path
+                    .strip_prefix(root)
+                    .expect("source below repository root")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                out.push((
+                    relative,
+                    fs::read_to_string(path).expect("read Rust source"),
+                ));
+            }
+        }
+    }
+
+    let root = repo_root();
+    let mut sources = Vec::new();
+    visit(&root, &root.join(relative), &mut sources);
+    sources.sort_by(|left, right| left.0.cmp(&right.0));
+    sources
+}
+
+fn is_code(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    !trimmed.starts_with("//") && !trimmed.starts_with("/*") && !trimmed.starts_with('*')
+}
+
+fn sites_matching<F>(sources: &[(String, String)], mut predicate: F) -> BTreeSet<Site>
+where
+    F: FnMut(&str) -> bool,
+{
+    let mut sites = BTreeSet::new();
+    for (path, source) in sources {
+        for (index, line) in source.lines().enumerate() {
+            if is_code(line) && predicate(line) {
+                sites.insert((path.clone(), index + 1));
+            }
+        }
+    }
+    sites
+}
+
+fn expected(sites: &[(&str, usize)]) -> BTreeSet<Site> {
+    sites
+        .iter()
+        .map(|(path, line)| ((*path).to_owned(), *line))
+        .collect()
+}
+
+fn assert_exact(actual: BTreeSet<Site>, expected_sites: &[(&str, usize)], label: &str) {
+    assert_eq!(actual, expected(expected_sites), "{label} changed");
+}
+
+fn validate_exact(actual: &BTreeSet<Site>, expected_sites: &[(&str, usize)]) -> Result<(), ()> {
+    (*actual == expected(expected_sites))
+        .then_some(())
+        .ok_or(())
+}
+
+fn source<'a>(sources: &'a [(String, String)], path: &str) -> &'a str {
+    &sources
+        .iter()
+        .find(|(candidate, _)| candidate == path)
+        .unwrap_or_else(|| panic!("missing source {path}"))
+        .1
+}
+
+fn function_body<'a>(source: &'a str, name: &str) -> &'a str {
+    let marker = format!("fn {name}");
+    let start = source
+        .find(&marker)
+        .unwrap_or_else(|| panic!("missing function {name}"));
+    let open = start + source[start..].find('{').expect("function open brace");
+    let mut depth = 0usize;
+    for (offset, byte) in source.as_bytes()[open..].iter().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &source[start..open + offset + 1];
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("unterminated function {name}")
+}
+
+const TERMINATE_CALLS: &[(&str, usize)] = &[
+    ("kernel/src/interrupts/context_switch.rs", 1017),
+    ("kernel/src/process/manager.rs", 1162),
+    ("kernel/src/signal/delivery.rs", 225),
+    ("kernel/src/signal/delivery.rs", 260),
+    ("kernel/src/syscall/signal.rs", 163),
+];
+const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 274)];
+const PRODUCTION_INIT_PID_SITES: &[(&str, usize)] = &[
+    ("kernel/src/process/manager.rs", 1179),
+    ("kernel/src/task/process_task.rs", 244),
+    ("kernel/src/task/process_task.rs", 303),
+];
+const TEST_INIT_PID_SITES: &[(&str, usize)] = &[
+    ("kernel/src/test_userspace.rs", 84),
+    ("kernel/src/test_userspace.rs", 203),
+    ("kernel/src/test_userspace.rs", 292),
+];
+const QUARANTINE_CALLS: &[(&str, usize)] = &[
+    ("kernel/src/arch_impl/aarch64/exception.rs", 775),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1149),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1251),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1361),
+];
+const KERNEL_STACK_MUTATIONS: &[(&str, usize)] = &[
+    ("kernel/src/arch_impl/aarch64/syscall_entry.rs", 961),
+    ("kernel/src/process/manager.rs", 1839),
+    ("kernel/src/syscall/clone.rs", 252),
+];
+const RECLAIM_ENQUEUE_CALLS: &[(&str, usize)] = &[
+    ("kernel/src/process/manager.rs", 1153),
+    ("kernel/src/task/process_task.rs", 262),
+];
+const EXIT_PROCESS_CALLS: &[(&str, usize)] = &[
+    ("kernel/src/arch_impl/aarch64/exception.rs", 785),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1160),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1254),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1364),
+    ("kernel/src/interrupts.rs", 1429),
+    ("kernel/src/interrupts.rs", 1735),
+    ("kernel/src/process/mod.rs", 320),
+];
+const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
+    ("kernel/src/task/scheduler.rs", 1726),
+    ("kernel/src/task/scheduler.rs", 1897),
+    ("kernel/src/task/scheduler.rs", 1916),
+    ("kernel/src/task/scheduler.rs", 2065),
+    ("kernel/src/task/scheduler.rs", 2153),
+    ("kernel/src/task/scheduler.rs", 2218),
+    ("kernel/src/task/scheduler.rs", 2227),
+    ("kernel/src/task/scheduler.rs", 2386),
+    ("kernel/src/task/waitqueue.rs", 52),
+];
+
+#[test]
+fn current_teardown_bypass_surface_is_exact() {
+    let sources = rust_sources_below("kernel/src");
+
+    assert_exact(
+        sites_matching(&sources, |line| line.contains(".terminate(")),
+        TERMINATE_CALLS,
+        "Process::terminate callers",
+    );
+    assert_exact(
+        sites_matching(&sources, |line| line.contains(".terminate_minimal(")),
+        TERMINATE_MINIMAL_CALLS,
+        "Process::terminate_minimal callers",
+    );
+
+    let init_sites = sites_matching(&sources, |line| line.contains("ProcessId::new(1)"));
+    let test_sites: BTreeSet<_> = init_sites
+        .iter()
+        .filter(|(path, _)| path == "kernel/src/test_userspace.rs")
+        .cloned()
+        .collect();
+    let production_sites: BTreeSet<_> = init_sites.difference(&test_sites).cloned().collect();
+    assert_exact(
+        production_sites,
+        PRODUCTION_INIT_PID_SITES,
+        "production PID-1 literals",
+    );
+    assert_exact(
+        test_sites,
+        TEST_INIT_PID_SITES,
+        "test_minimal_userspace PID-1 allowlist",
+    );
+    let test_userspace = source(&sources, "kernel/src/test_userspace.rs");
+    assert_eq!(
+        test_userspace
+            .matches("pub fn test_minimal_userspace()")
+            .count(),
+        1,
+        "test_minimal_userspace must remain uniquely nameable"
+    );
+    assert_eq!(
+        function_body(test_userspace, "test_minimal_userspace")
+            .matches("ProcessId::new(1)")
+            .count(),
+        3,
+        "the three test PID-1 sites must remain in test_minimal_userspace"
+    );
+
+    assert_exact(
+        sites_matching(&sources, |line| {
+            line.contains(".terminate_process_threads(")
+        }),
+        QUARANTINE_CALLS,
+        "terminate_process_threads callers",
+    );
+    assert_exact(
+        sites_matching(&sources, |line| line.contains(".kernel_stack_allocation =")),
+        KERNEL_STACK_MUTATIONS,
+        "kernel_stack_allocation ownership mutations",
+    );
+    assert_exact(
+        sites_matching(&sources, |line| {
+            line.contains("enqueue_process_reclaim(")
+                && !line.contains("fn enqueue_process_reclaim")
+        }),
+        RECLAIM_ENQUEUE_CALLS,
+        "enqueue_process_reclaim callers",
+    );
+}
+
+#[test]
+fn v3_structural_closures_are_exact() {
+    let sources = rust_sources_below("kernel/src");
+    assert_exact(
+        sites_matching(&sources, |line| line.contains(".exit_process(")),
+        EXIT_PROCESS_CALLS,
+        "the seven exit_process callers",
+    );
+
+    const BLOCKING_NAMES: &[&str] = &[
+        "block_current(",
+        "block_current_for_signal(",
+        "block_current_for_signal_with_context(",
+        "block_current_for_child_exit(",
+        "block_current_for_timer(",
+        "block_current_for_io(",
+        "block_current_for_io_with_timeout(",
+        "block_current_for_compositor(",
+        "prepare_to_wait(",
+    ];
+    assert_exact(
+        sites_matching(&sources, |line| {
+            line.contains("pub fn ") && BLOCKING_NAMES.iter().any(|name| line.contains(name))
+        }),
+        BLOCKING_PRIMITIVES,
+        "the nine P0 blocking primitives",
+    );
+    assert_exact(
+        sites_matching(&sources, |line| line.contains("thread_group_id = Some(")),
+        &[("kernel/src/syscall/clone.rs", 210)],
+        "thread_group_id production writers",
+    );
+    assert_exact(
+        sites_matching(&sources, |line| line.contains("btrt::on_process_exit(")),
+        &[("kernel/src/task/process_task.rs", 285)],
+        "btrt::on_process_exit callers",
+    );
+
+    let provider = source(&sources, "kernel/src/tracing/providers/teardown.rs");
+    let scheduler = source(&sources, "kernel/src/task/scheduler.rs");
+    assert_eq!(provider.matches("counter!(EXIT_SGI_SENT,").count(), 1);
+    assert_eq!(provider.matches("counter!(EXIT_KICK_PUBLISHED,").count(), 1);
+    assert!(!scheduler.contains("EXIT_SGI_SENT"));
+    assert!(!scheduler.contains("EXIT_KICK_PUBLISHED"));
+    assert!(!scheduler.contains("send_exit_expedite_sgi"));
+    assert!(!provider.contains("struct KickSlot"));
+    assert!(!provider.contains("trace_count!(EXIT_SGI_SENT"));
+    assert!(!provider.contains("trace_count!(EXIT_KICK_PUBLISHED"));
+    assert!(!function_body(scheduler, "send_resched_ipi").contains("EXIT_SGI_SENT"));
+    assert!(!function_body(scheduler, "send_resched_ipi_to_cpu").contains("EXIT_SGI_SENT"));
+}
+
+#[test]
+fn all_phase_zero_counters_have_registered_readers_and_runtime_gates() {
+    let sources = rust_sources_below("kernel/src");
+    let provider = source(&sources, "kernel/src/tracing/providers/teardown.rs");
+    let declarations: BTreeSet<_> = provider
+        .split("counter!(")
+        .skip(1)
+        .filter_map(|rest| {
+            rest.trim_start()
+                .split_once(',')
+                .map(|(name, _)| name.trim().to_owned())
+        })
+        .filter(|name| name != "$name")
+        .collect();
+    let inventory = provider
+        .split("pub static COUNTERS")
+        .nth(1)
+        .expect("COUNTERS inventory")
+        .split("];")
+        .next()
+        .expect("COUNTERS terminator");
+    let readers: BTreeSet<_> = inventory
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix('&'))
+        .filter_map(|rest| rest.strip_suffix(','))
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(declarations.len(), 39);
+    assert_eq!(
+        readers, declarations,
+        "every counter must have an inventory reader"
+    );
+    assert!(provider.contains("core::array::from_fn(|index| COUNTERS[index].aggregate())"));
+    assert!(provider.contains("for _ in 0..64"));
+    assert!(provider.contains("defer_reclaim_events_are_paired("));
+    assert!(provider.contains("&deferred_pids"));
+    assert!(source(&sources, "kernel/src/task/process_task.rs").contains("for tid in 1..=17"));
+    assert!(provider.contains("EXIT_SGI_SENT.aggregate() != 0"));
+
+    let registry = source(&sources, "kernel/src/test_framework/registry.rs");
+    assert!(registry.contains("name: \"fork_exit_defer_reclaim_pairing_test\""));
+    assert!(registry.contains("name: \"deferred_fault_ring_overflow_injection\""));
+}
+
+#[test]
+fn deliberately_broken_variants_fail_the_ratchet() {
+    let sources = rust_sources_below("kernel/src");
+
+    let mut exit_calls = sites_matching(&sources, |line| line.contains(".exit_process("));
+    exit_calls.insert(("kernel/src/synthetic.rs".to_owned(), 1));
+    assert!(validate_exact(&exit_calls, EXIT_PROCESS_CALLS).is_err());
+
+    let mut enqueue_calls = sites_matching(&sources, |line| {
+        line.contains("enqueue_process_reclaim(") && !line.contains("fn enqueue_process_reclaim")
+    });
+    enqueue_calls.insert(("kernel/src/synthetic.rs".to_owned(), 2));
+    assert!(validate_exact(&enqueue_calls, RECLAIM_ENQUEUE_CALLS).is_err());
+
+    let mut blocking = expected(BLOCKING_PRIMITIVES);
+    blocking.insert(("kernel/src/task/synthetic.rs".to_owned(), 3));
+    assert!(validate_exact(&blocking, BLOCKING_PRIMITIVES).is_err());
+
+    let mut group_writes =
+        sites_matching(&sources, |line| line.contains("thread_group_id = Some("));
+    group_writes.insert(("kernel/src/synthetic.rs".to_owned(), 4));
+    assert!(validate_exact(&group_writes, &[("kernel/src/syscall/clone.rs", 210)]).is_err());
+
+    let scheduler = source(&sources, "kernel/src/task/scheduler.rs");
+    let broken_scheduler = scheduler.replacen(
+        "fn send_resched_ipi(&self) {",
+        "fn send_resched_ipi(&self) { crate::trace_count!(EXIT_SGI_SENT);",
+        1,
+    );
+    assert!(function_body(&broken_scheduler, "send_resched_ipi").contains("EXIT_SGI_SENT"));
+}

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -8,6 +8,11 @@ fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+fn repo_text(relative: &str) -> String {
+    fs::read_to_string(repo_root().join(relative))
+        .unwrap_or_else(|_| panic!("read repository file {relative}"))
+}
+
 fn rust_sources_below(relative: &str) -> Vec<(String, String)> {
     fn visit(root: &Path, dir: &Path, out: &mut Vec<(String, String)>) {
         for entry in fs::read_dir(dir).expect("read source directory") {
@@ -72,6 +77,34 @@ fn validate_exact(actual: &BTreeSet<Site>, expected_sites: &[(&str, usize)]) -> 
         .ok_or(())
 }
 
+fn with_synthetic_source(
+    sources: &[(String, String)],
+    path: &str,
+    synthetic_source: &str,
+) -> Vec<(String, String)> {
+    let mut perturbed = sources.to_vec();
+    perturbed.push((path.to_owned(), synthetic_source.to_owned()));
+    perturbed.sort_by(|left, right| left.0.cmp(&right.0));
+    perturbed
+}
+
+fn with_replaced_source(
+    sources: &[(String, String)],
+    path: &str,
+    replacement: String,
+) -> Vec<(String, String)> {
+    sources
+        .iter()
+        .map(|(candidate, contents)| {
+            if candidate == path {
+                (candidate.clone(), replacement.clone())
+            } else {
+                (candidate.clone(), contents.clone())
+            }
+        })
+        .collect()
+}
+
 fn source<'a>(sources: &'a [(String, String)], path: &str) -> &'a str {
     &sources
         .iter()
@@ -121,10 +154,10 @@ const TEST_INIT_PID_SITES: &[(&str, usize)] = &[
     ("kernel/src/test_userspace.rs", 292),
 ];
 const QUARANTINE_CALLS: &[(&str, usize)] = &[
-    ("kernel/src/arch_impl/aarch64/exception.rs", 775),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1149),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1251),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1361),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 815),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1179),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1275),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1375),
 ];
 const KERNEL_STACK_MUTATIONS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/syscall_entry.rs", 961),
@@ -136,25 +169,102 @@ const RECLAIM_ENQUEUE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/task/process_task.rs", 262),
 ];
 const EXIT_PROCESS_CALLS: &[(&str, usize)] = &[
-    ("kernel/src/arch_impl/aarch64/exception.rs", 785),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1160),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1254),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1364),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 825),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1190),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1278),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1378),
     ("kernel/src/interrupts.rs", 1429),
     ("kernel/src/interrupts.rs", 1735),
-    ("kernel/src/process/mod.rs", 320),
+    ("kernel/src/process/mod.rs", 321),
 ];
+const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
+    ("kernel/src/process/mod.rs", 313),
+    ("kernel/src/process/mod.rs", 329),
+];
+const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
+    &[("kernel/src/tracing/providers/teardown.rs", 507)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
-    ("kernel/src/task/scheduler.rs", 1726),
-    ("kernel/src/task/scheduler.rs", 1897),
-    ("kernel/src/task/scheduler.rs", 1916),
-    ("kernel/src/task/scheduler.rs", 2065),
-    ("kernel/src/task/scheduler.rs", 2153),
-    ("kernel/src/task/scheduler.rs", 2218),
-    ("kernel/src/task/scheduler.rs", 2227),
-    ("kernel/src/task/scheduler.rs", 2386),
+    ("kernel/src/task/scheduler.rs", 1740),
+    ("kernel/src/task/scheduler.rs", 1911),
+    ("kernel/src/task/scheduler.rs", 1930),
+    ("kernel/src/task/scheduler.rs", 2079),
+    ("kernel/src/task/scheduler.rs", 2167),
+    ("kernel/src/task/scheduler.rs", 2232),
+    ("kernel/src/task/scheduler.rs", 2241),
+    ("kernel/src/task/scheduler.rs", 2400),
     ("kernel/src/task/waitqueue.rs", 52),
 ];
+const RAW_SCHEDULER_LOCK_SITES: &[(&str, usize)] = &[
+    ("kernel/src/task/scheduler.rs", 239),
+    ("kernel/src/task/scheduler.rs", 246),
+];
+
+const BLOCKING_NAMES: &[&str] = &[
+    "block_current(",
+    "block_current_for_signal(",
+    "block_current_for_signal_with_context(",
+    "block_current_for_child_exit(",
+    "block_current_for_timer(",
+    "block_current_for_io(",
+    "block_current_for_io_with_timeout(",
+    "block_current_for_compositor(",
+    "prepare_to_wait(",
+];
+
+fn validate_reclaim_enqueue_callers(sources: &[(String, String)]) -> Result<(), ()> {
+    validate_exact(
+        &sites_matching(sources, |line| {
+            line.contains("enqueue_process_reclaim(")
+                && !line.contains("fn enqueue_process_reclaim")
+        }),
+        RECLAIM_ENQUEUE_CALLS,
+    )
+}
+
+fn validate_exit_process_entry_points(sources: &[(String, String)]) -> Result<(), ()> {
+    validate_exact(
+        &sites_matching(sources, |line| line.contains(".exit_process(")),
+        EXIT_PROCESS_CALLS,
+    )?;
+    validate_exact(
+        &sites_matching(sources, |line| {
+            line.contains("exit_process_by_pid(") && !line.contains("fn exit_process_by_pid")
+        }),
+        EXIT_PROCESS_BY_PID_CALLS,
+    )?;
+    validate_exact(
+        &sites_matching(sources, |line| {
+            line.contains("exit_process_for_teardown_test(")
+                && !line.contains("fn exit_process_for_teardown_test")
+        }),
+        EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS,
+    )
+}
+
+fn validate_blocking_primitives(sources: &[(String, String)]) -> Result<(), ()> {
+    validate_exact(
+        &sites_matching(sources, |line| {
+            line.contains("pub fn ") && BLOCKING_NAMES.iter().any(|name| line.contains(name))
+        }),
+        BLOCKING_PRIMITIVES,
+    )
+}
+
+fn validate_group_writes(sources: &[(String, String)]) -> Result<(), ()> {
+    validate_exact(
+        &sites_matching(sources, |line| line.contains("thread_group_id = Some(")),
+        &[("kernel/src/syscall/clone.rs", 210)],
+    )
+}
+
+fn validate_exit_sgi_is_teardown_only(sources: &[(String, String)]) -> Result<(), ()> {
+    let scheduler = source(sources, "kernel/src/task/scheduler.rs");
+    (!scheduler.contains("EXIT_SGI_SENT")
+        && !function_body(scheduler, "send_resched_ipi").contains("EXIT_SGI_SENT")
+        && !function_body(scheduler, "send_resched_ipi_to_cpu").contains("EXIT_SGI_SENT"))
+    .then_some(())
+    .ok_or(())
+}
 
 #[test]
 fn current_teardown_bypass_surface_is_exact() {
@@ -216,47 +326,22 @@ fn current_teardown_bypass_surface_is_exact() {
         KERNEL_STACK_MUTATIONS,
         "kernel_stack_allocation ownership mutations",
     );
-    assert_exact(
-        sites_matching(&sources, |line| {
-            line.contains("enqueue_process_reclaim(")
-                && !line.contains("fn enqueue_process_reclaim")
-        }),
-        RECLAIM_ENQUEUE_CALLS,
-        "enqueue_process_reclaim callers",
-    );
+    validate_reclaim_enqueue_callers(&sources)
+        .expect("enqueue_process_reclaim caller ratchet changed");
 }
 
 #[test]
 fn v3_structural_closures_are_exact() {
     let sources = rust_sources_below("kernel/src");
-    assert_exact(
-        sites_matching(&sources, |line| line.contains(".exit_process(")),
-        EXIT_PROCESS_CALLS,
-        "the seven exit_process callers",
-    );
-
-    const BLOCKING_NAMES: &[&str] = &[
-        "block_current(",
-        "block_current_for_signal(",
-        "block_current_for_signal_with_context(",
-        "block_current_for_child_exit(",
-        "block_current_for_timer(",
-        "block_current_for_io(",
-        "block_current_for_io_with_timeout(",
-        "block_current_for_compositor(",
-        "prepare_to_wait(",
-    ];
+    validate_exit_process_entry_points(&sources).expect("process-exit entry-point ratchet changed");
+    validate_blocking_primitives(&sources).expect("the nine P0 blocking primitives changed");
+    validate_group_writes(&sources).expect("thread_group_id production writers changed");
     assert_exact(
         sites_matching(&sources, |line| {
-            line.contains("pub fn ") && BLOCKING_NAMES.iter().any(|name| line.contains(name))
+            line.contains("SCHEDULER.lock()") || line.contains("SCHEDULER.try_lock()")
         }),
-        BLOCKING_PRIMITIVES,
-        "the nine P0 blocking primitives",
-    );
-    assert_exact(
-        sites_matching(&sources, |line| line.contains("thread_group_id = Some(")),
-        &[("kernel/src/syscall/clone.rs", 210)],
-        "thread_group_id production writers",
+        RAW_SCHEDULER_LOCK_SITES,
+        "raw scheduler-lock acquisitions outside the instrumented wrappers",
     );
     assert_exact(
         sites_matching(&sources, |line| line.contains("btrt::on_process_exit(")),
@@ -268,14 +353,13 @@ fn v3_structural_closures_are_exact() {
     let scheduler = source(&sources, "kernel/src/task/scheduler.rs");
     assert_eq!(provider.matches("counter!(EXIT_SGI_SENT,").count(), 1);
     assert_eq!(provider.matches("counter!(EXIT_KICK_PUBLISHED,").count(), 1);
-    assert!(!scheduler.contains("EXIT_SGI_SENT"));
+    validate_exit_sgi_is_teardown_only(&sources)
+        .expect("EXIT_SGI_SENT escaped the teardown-only producer");
     assert!(!scheduler.contains("EXIT_KICK_PUBLISHED"));
     assert!(!scheduler.contains("send_exit_expedite_sgi"));
     assert!(!provider.contains("struct KickSlot"));
     assert!(!provider.contains("trace_count!(EXIT_SGI_SENT"));
     assert!(!provider.contains("trace_count!(EXIT_KICK_PUBLISHED"));
-    assert!(!function_body(scheduler, "send_resched_ipi").contains("EXIT_SGI_SENT"));
-    assert!(!function_body(scheduler, "send_resched_ipi_to_cpu").contains("EXIT_SGI_SENT"));
 }
 
 #[test]
@@ -315,35 +399,68 @@ fn all_phase_zero_counters_have_registered_readers_and_runtime_gates() {
     assert!(provider.contains("defer_reclaim_events_are_paired("));
     assert!(provider.contains("&deferred_pids"));
     assert!(source(&sources, "kernel/src/task/process_task.rs").contains("for tid in 1..=17"));
-    assert!(provider.contains("EXIT_SGI_SENT.aggregate() != 0"));
+    assert!(provider.contains("let exit_sgi_sent_before = EXIT_SGI_SENT.aggregate()"));
+    assert!(provider.contains("saturating_sub(exit_sgi_sent_before)"));
 
     let registry = source(&sources, "kernel/src/test_framework/registry.rs");
     assert!(registry.contains("name: \"fork_exit_defer_reclaim_pairing_test\""));
     assert!(registry.contains("name: \"deferred_fault_ring_overflow_injection\""));
+
+    let plan = repo_text("docs/planning/teardown-unification/PLAN.md");
+    assert!(plan.contains(
+        "./docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only"
+    ));
+    let aarch64_gate = repo_text("docker/qemu/run-aarch64-full-test.sh");
+    assert!(aarch64_gate.contains("cargo build --release --features boot_tests"));
+    assert!(aarch64_gate.contains("--boot-tests-only"));
+    assert!(aarch64_gate.contains("grep -q \"\\[BOOT_TESTS:PASS\\]\""));
 }
 
 #[test]
 fn deliberately_broken_variants_fail_the_ratchet() {
     let sources = rust_sources_below("kernel/src");
 
-    let mut exit_calls = sites_matching(&sources, |line| line.contains(".exit_process("));
-    exit_calls.insert(("kernel/src/synthetic.rs".to_owned(), 1));
-    assert!(validate_exact(&exit_calls, EXIT_PROCESS_CALLS).is_err());
+    let broken_exit = with_synthetic_source(
+        &sources,
+        "kernel/src/synthetic_exit.rs",
+        "fn rogue_exit(pm: &mut ProcessManager, pid: ProcessId) { pm.exit_process(pid, 0); }",
+    );
+    assert!(validate_exit_process_entry_points(&broken_exit).is_err());
 
-    let mut enqueue_calls = sites_matching(&sources, |line| {
-        line.contains("enqueue_process_reclaim(") && !line.contains("fn enqueue_process_reclaim")
-    });
-    enqueue_calls.insert(("kernel/src/synthetic.rs".to_owned(), 2));
-    assert!(validate_exact(&enqueue_calls, RECLAIM_ENQUEUE_CALLS).is_err());
+    let broken_by_pid = with_synthetic_source(
+        &sources,
+        "kernel/src/synthetic_by_pid.rs",
+        "fn rogue_exit(pid: ProcessId) { exit_process_by_pid(pid, 0); }",
+    );
+    assert!(validate_exit_process_entry_points(&broken_by_pid).is_err());
 
-    let mut blocking = expected(BLOCKING_PRIMITIVES);
-    blocking.insert(("kernel/src/task/synthetic.rs".to_owned(), 3));
-    assert!(validate_exact(&blocking, BLOCKING_PRIMITIVES).is_err());
+    let broken_test_helper = with_synthetic_source(
+        &sources,
+        "kernel/src/synthetic_test_helper.rs",
+        "fn rogue_test_exit(pid: ProcessId) { exit_process_for_teardown_test(pid, 0); }",
+    );
+    assert!(validate_exit_process_entry_points(&broken_test_helper).is_err());
 
-    let mut group_writes =
-        sites_matching(&sources, |line| line.contains("thread_group_id = Some("));
-    group_writes.insert(("kernel/src/synthetic.rs".to_owned(), 4));
-    assert!(validate_exact(&group_writes, &[("kernel/src/syscall/clone.rs", 210)]).is_err());
+    let broken_enqueue = with_synthetic_source(
+        &sources,
+        "kernel/src/synthetic_enqueue.rs",
+        "fn rogue_enqueue(reclaim: DeferredProcessReclaim) { enqueue_process_reclaim(reclaim); }",
+    );
+    assert!(validate_reclaim_enqueue_callers(&broken_enqueue).is_err());
+
+    let broken_blocking = with_synthetic_source(
+        &sources,
+        "kernel/src/task/synthetic_blocking.rs",
+        "pub fn block_current() {}",
+    );
+    assert!(validate_blocking_primitives(&broken_blocking).is_err());
+
+    let broken_group_write = with_synthetic_source(
+        &sources,
+        "kernel/src/synthetic_group.rs",
+        "fn rogue_group(thread: &mut Thread) { thread.thread_group_id = Some(1); }",
+    );
+    assert!(validate_group_writes(&broken_group_write).is_err());
 
     let scheduler = source(&sources, "kernel/src/task/scheduler.rs");
     let broken_scheduler = scheduler.replacen(
@@ -351,5 +468,7 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         "fn send_resched_ipi(&self) { crate::trace_count!(EXIT_SGI_SENT);",
         1,
     );
-    assert!(function_body(&broken_scheduler, "send_resched_ipi").contains("EXIT_SGI_SENT"));
+    let broken_sgi =
+        with_replaced_source(&sources, "kernel/src/task/scheduler.rs", broken_scheduler);
+    assert!(validate_exit_sgi_is_teardown_only(&broken_sgi).is_err());
 }

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -175,14 +175,14 @@ const EXIT_PROCESS_CALLS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/exception.rs", 1378),
     ("kernel/src/interrupts.rs", 1429),
     ("kernel/src/interrupts.rs", 1735),
-    ("kernel/src/process/mod.rs", 321),
+    ("kernel/src/process/mod.rs", 325),
 ];
 const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
-    ("kernel/src/process/mod.rs", 313),
-    ("kernel/src/process/mod.rs", 329),
+    ("kernel/src/process/mod.rs", 317),
+    ("kernel/src/process/mod.rs", 333),
 ];
 const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
-    &[("kernel/src/tracing/providers/teardown.rs", 507)];
+    &[("kernel/src/tracing/providers/teardown.rs", 385)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
     ("kernel/src/task/scheduler.rs", 1740),
     ("kernel/src/task/scheduler.rs", 1911),
@@ -363,7 +363,7 @@ fn v3_structural_closures_are_exact() {
 }
 
 #[test]
-fn all_phase_zero_counters_have_registered_readers_and_runtime_gates() {
+fn all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates() {
     let sources = rust_sources_below("kernel/src");
     let provider = source(&sources, "kernel/src/tracing/providers/teardown.rs");
     let declarations: BTreeSet<_> = provider
@@ -396,20 +396,34 @@ fn all_phase_zero_counters_have_registered_readers_and_runtime_gates() {
     );
     assert!(provider.contains("core::array::from_fn(|index| COUNTERS[index].aggregate())"));
     assert!(provider.contains("for _ in 0..64"));
-    assert!(provider.contains("defer_reclaim_events_are_paired("));
-    assert!(provider.contains("&deferred_pids"));
+    assert!(provider.contains("deferred_delta != reclaimed_delta || reclaimed_delta < 64"));
+    assert!(!provider.contains("TeardownPairingEvidence"));
+    assert!(!provider.contains("defer_reclaim_events_are_paired("));
+    assert!(!provider.contains("deferred_pids"));
+    assert!(!provider.contains("iter_events()"));
+    assert!(!provider.contains("TRACE_BUFFERS"));
+    assert!(!provider.contains("super::disable_all()"));
+    assert!(!provider.contains("crate::tracing::enable()"));
+    assert!(!provider.contains("crate::tracing::disable()"));
+    assert!(!provider.contains("TEARDOWN_PROVIDER.enable_all()"));
+    assert!(!provider.contains("TEARDOWN_PROVIDER.disable_all()"));
     assert!(source(&sources, "kernel/src/task/process_task.rs").contains("for tid in 1..=17"));
-    assert!(provider.contains("let exit_sgi_sent_before = EXIT_SGI_SENT.aggregate()"));
-    assert!(provider.contains("saturating_sub(exit_sgi_sent_before)"));
+    assert!(!provider.contains("EXIT_SGI_SENT.aggregate()"));
+    assert!(!provider.contains("TEARDOWN_ENTRY_GROUP.aggregate()"));
+
+    let declaration_only = provider
+        .split("// Declaration-only until the phase named in PLAN.md.")
+        .nth(1)
+        .expect("declaration-only counter boundary");
+    assert!(declaration_only.contains("counter!(TEARDOWN_ENTRY_GROUP,"));
+    assert!(declaration_only.contains("counter!(EXIT_SGI_SENT,"));
 
     let registry = source(&sources, "kernel/src/test_framework/registry.rs");
     assert!(registry.contains("name: \"fork_exit_defer_reclaim_pairing_test\""));
     assert!(registry.contains("name: \"deferred_fault_ring_overflow_injection\""));
 
     let plan = repo_text("docs/planning/teardown-unification/PLAN.md");
-    assert!(plan.contains(
-        "./docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only"
-    ));
+    assert!(plan.contains("./docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only"));
     let aarch64_gate = repo_text("docker/qemu/run-aarch64-full-test.sh");
     assert!(aarch64_gate.contains("cargo build --release --features boot_tests"));
     assert!(aarch64_gate.contains("--boot-tests-only"));

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -182,7 +182,7 @@ const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 333),
 ];
 const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
-    &[("kernel/src/tracing/providers/teardown.rs", 517)];
+    &[("kernel/src/tracing/providers/teardown.rs", 528)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
     ("kernel/src/task/scheduler.rs", 1740),
     ("kernel/src/task/scheduler.rs", 1911),


### PR DESCRIPTION
## Summary

Tranche 1 / Phase 1 of the ratified [teardown-unification plan](docs/planning/teardown-unification/PLAN.md#phase-0--teardown-observability--call-site-ratchet-no-behaviour-change) (`## Phase 0 — Teardown observability + call-site ratchet *(no behaviour change)*`). Tranche 1 (P0+P1+P2) was formally ratified by an independent read-only Codex review (`ENDORSE: YES`, PR #502, v3.2) after three prior refusal rounds closed every mechanism-level defect raised against the design. This PR implements P0 only — P1/P2 are separate, later PRs.

**Zero behavior change.** P0 adds lock-free counters at *named, already-existing* write sites plus a source-structure ratchet test — it does not alter any control flow, locking, or teardown semantics. Frozen gold-master regions (`arch_impl/aarch64/context_switch.rs`, `gic.rs`, `timer_interrupt.rs`) and Tier-1 prohibited files (`syscall/handler.rs`, `syscall/time.rs`, `syscall/entry.asm`, `interrupts/timer.rs`, `interrupts/timer_entry.asm`) are byte-identical to `main`.

## What ships

- `kernel/src/tracing/providers/teardown.rs` (new provider): ~30 lock-free `TraceCounter`s wired to existing teardown write sites — process-exit entry attribution (exit/fault/signal), first-vs-repeat exit requests, quarantine, defer/reclaim, FD closes under the process-manager lock, victim-resolution divergence, deferred-fault-ring drops, reclaim-enqueue-under-PM, lock-order-suspect, etc. A subset is *declared with zero write sites on purpose* (`EXIT_SGI_SENT`, `EXIT_KICK_*`, `RECEIPT_DROPPED_UNRETIRED`, the `RECLAIM_PARK*` family, `LEDGER_EFFECT_AMBIGUOUS{report}`, `TOMBSTONE_JOIN{*}`, `EXIT_BLOCK_REFUSED{family}`, `EXIT_WAIT_CANCELLED{family}`, `INIT_FATAL_SIGNAL_DROPPED{,_group}`) — those producers land in later phases (P1/P2/P6a/P6b/P9/P10/P12); PLAN.md's own rule is that equality-at-zero is never used as evidence.
- `tests/teardown_structure.rs` (new): a structural ratchet pinning today's exact bypass surface by file:line/count — `.terminate(`/`.terminate_minimal(` call sites, production `ProcessId::new(1)` sites, `terminate_process_threads` call sites, `kernel_stack_allocation` mutation sites, `enqueue_process_reclaim` call sites (2), the exact **seven** `exit_process` call sites, the exact **nine** blocking primitives (pending DEBT-3's inventory-completeness fix, owned by P9), the single `thread_group_id = Some(` write site, and `EXIT_SGI_SENT`'s single (currently absent) producer location. Five deliberately-broken variants prove each rule actually fails CI on regression (a tenth blocking primitive, a second `thread_group_id` writer, an eighth `exit_process` caller, a third `enqueue_process_reclaim` site, an `EXIT_SGI_SENT` reference inside a generic reschedule helper).
- Two runtime gate extras registered in the aarch64 boot-test suite: `fork_exit_defer_reclaim_pairing_test` (forks+exits 64 children, asserts a nonzero, workload-explained `TEARDOWN_DEFER == TEARDOWN_RECLAIM` equality scoped to the test's own 64 PIDs — not the raw process-lifetime aggregate, to avoid cross-stage contamination) and a 17-deep ring-overflow injection that drives `DEFERRED_FAULT_RING_DROPPED` nonzero, proving #492's silent-drop counter is real.
- `MAX_COUNTERS` raised 64→160 with a loud overflow assert, to fit the ~30 new counters alongside the ~76 pre-existing ones without silently dropping any.

**Design-debt register.** Per-PID *causal* pairing (proving PID X's defer strictly precedes PID X's reclaim, not just that the counts match) is out of scope for P0's per-CPU scalar `TraceCounter` substrate — registered as **DEBT-7**, owned by P8, in `PLAN.md`'s design-debt register.

## Gate results (all run fresh, HEAD `e0cda3d1`, 6 commits over `main@24fe1d3a`)

**Build (zero warnings, all three configs):**
- `cargo build --release --features testing,external_test_bins --bin qemu-uefi` — 0 warnings/errors
- `cargo build --release --target aarch64-breenix.json ... --bin kernel-aarch64` (plain) — 0 warnings/errors
- Same aarch64 build + `--features ec0_fault_inject` — 0 warnings/errors
- `cargo test --test teardown_structure` — 4/4 passed

**aarch64 boots (native, Apple Silicon, `docker/qemu/run-aarch64-full-test.sh --boot-tests-only`):**
- 2/2 consecutive clean runs, `[BOOT_TESTS:PASS]` **86/86** both times, `fork_exit_defer_reclaim_pairing_test` and the ring-overflow injection test passing in both.

**beast x86 kthread gate (`/root/run-x86-gate.sh feat/teardown-p0-observability 3 kthread` on `breenix-x86`, native KVM):**
- `GATE: PASS (3/3 boot tests passed; mode=kthread build=14s boot=33s total=48s)` — build clean (0 warnings) in 14s, 3/3 `KTHREAD_TEST_ONLY_COMPLETE` boots in 33s (~11s/boot).
- **Depth caveat:** this gate only exercises `--features kthread_test_only`, not the canonical `testing,external_test_bins` full boot (the config `docker/qemu/run-boot-parallel.sh` and CLAUDE.md's Standard Workflow use). That full x86 boot deterministically hangs forever at `RING3_SMOKE` — a pre-existing bug on `main`, independent of this PR, root-caused and filed as **#498** (`kernel/src/task/completion.rs::wait_timeout_inner`'s x86_64 boot-thread-spin branch has no timeout, unlike the aarch64 sibling). Confirmed via `git diff --stat` that P0's changed files carry zero overlap with `completion.rs` or the RING3_SMOKE path.

## P0 criteria (from PLAN.md)

- Every counter's write site is named against the live tree — no counter ships without one, per PLAN.md's own "a counter with no site named here is not in P0" rule.
- No vacuous zero-baseline gate: every runtime-gate counter is proven nonzero under a real workload (the 64-child fork/exit loop, the ring-overflow injection) rather than asserted "==0" with no producer.
- The structural ratchet passes on `main`-derived source unchanged today and is proven load-bearing by five negative (deliberately-broken) test variants.
- Baseline snapshots recorded for the three pre-existing defects later phases drive to zero (`TEARDOWN_MASKED_FRAMES_WALKED`, `FD_CLOSES_UNDER_PM`, `RECLAIM_ENQUEUE_UNDER_PM`), so those later gates have something real to measure against.

## Related

Part of the teardown-unification effort tracked in #491, #464, #471.
