### PR TITLE
teardown-unification P1: retirement fence + RootProof taxonomy

### DIFF
--- a/kernel/src/arch_impl/aarch64/ttbr0.rs
+++ b/kernel/src/arch_impl/aarch64/ttbr0.rs
@@ -2,6 +2,22 @@
 
 const TTBR0_ROOT_MASK: u64 = !0xFFFF_0000_0000_0FFF;
 
+#[inline(always)]
+pub(crate) fn roots_match(left: u64, right: u64) -> bool {
+    let left = left & TTBR0_ROOT_MASK;
+    left != 0 && left == right & TTBR0_ROOT_MASK
+}
+
+/// Read the proving CPU's architectural TTBR0 root.
+#[inline(always)]
+pub(crate) fn local_ttbr0_root() -> u64 {
+    let ttbr0: u64;
+    unsafe {
+        core::arch::asm!("mrs {}, ttbr0_el1", out(reg) ttbr0, options(nomem, nostack));
+    }
+    ttbr0 & TTBR0_ROOT_MASK
+}
+
 /// Return the kernel TTBR0 root, falling back to the boot identity table before
 /// per-CPU state has been populated.
 #[inline(always)]
@@ -52,20 +68,30 @@ pub fn quiesce_ttbr0_for_exit() {
 /// TTBR0 values may carry an ASID, so compare only the physical root bits using
 /// the same mask as the exception fault lookup paths.
 pub fn is_ttbr0_root_live(root_phys: u64) -> bool {
+    let mut online_mask = 0;
+    for cpu_id in 0..super::constants::MAX_CPUS {
+        if super::smp::is_cpu_online(cpu_id) {
+            online_mask |= 1 << cpu_id;
+        }
+    }
+    is_ttbr0_root_live_in_mask(root_phys, online_mask)
+}
+
+/// Return whether a CPU captured by `online_mask` retains `root_phys` in a
+/// TTBR0 shadow. Remote hardware TTBR0 is not architecturally readable.
+pub(crate) fn is_ttbr0_root_live_in_mask(root_phys: u64, online_mask: u64) -> bool {
     let root_phys = root_phys & TTBR0_ROOT_MASK;
     if root_phys == 0 {
         return false;
     }
-
     (0..super::constants::MAX_CPUS).any(|cpu_id| {
-        if !super::smp::is_cpu_online(cpu_id) {
+        if online_mask & (1 << cpu_id) == 0 {
             return false;
         }
 
         crate::per_cpu_aarch64::ttbr0_shadow_snapshot(cpu_id)
             .map(|(saved_process_ttbr0, next_ttbr0)| {
-                saved_process_ttbr0 & TTBR0_ROOT_MASK == root_phys
-                    || next_ttbr0 & TTBR0_ROOT_MASK == root_phys
+                roots_match(saved_process_ttbr0, root_phys) || roots_match(next_ttbr0, root_phys)
             })
             .unwrap_or(false)
     })

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -1100,7 +1100,9 @@ impl ProcessManager {
     /// Remove a terminated process from the process table (reap).
     /// Called after waitpid() has collected the exit status.
     pub fn remove_process(&mut self, pid: ProcessId) {
-        self.processes.remove(&pid);
+        if self.processes.remove(&pid).is_some() {
+            crate::task::process_task::note_process_row_removed();
+        }
     }
 
     /// Get a reference to a process
@@ -3911,5 +3913,17 @@ impl ProcessManager {
             self.write_byte_to_stack(page_table, virt_addr + i as u64, *byte)?;
         }
         Ok(())
+    }
+
+    /// Return whether a live or creating process row still names a matching
+    /// userspace translation-table root.
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn any_live_root_matches<F>(&self, mut root_matches: F) -> bool
+    where
+        F: FnMut(u64) -> bool,
+    {
+        self.processes.values().any(|process| {
+            !process.is_terminated() && process.cr3_value().is_some_and(&mut root_matches)
+        })
     }
 }

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -7,6 +7,8 @@ use crate::ipc::fd::FileDescriptor;
 use crate::process::ProcessId;
 use crate::task::scheduler;
 use crate::task::thread::{Thread, ThreadPrivilege};
+#[cfg(target_arch = "aarch64")]
+use core::sync::atomic::AtomicU32;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 const DEFERRED_FAULT_EXIT_SLOTS: usize = 16;
@@ -70,20 +72,108 @@ pub(crate) struct PendingProcessReclaim {
     old_page_tables: alloc::vec::Vec<
         alloc::boxed::Box<crate::memory::process_memory::ProcessPageTable>,
     >,
-    after_epoch: [u64; crate::arch_impl::aarch64::constants::MAX_CPUS],
+    after_epoch: scheduler::RetirementFence,
+    last_pass: u32,
+    proof_failures: u8,
+    parked: Option<ParkRecord>,
+}
+
+#[cfg(target_arch = "aarch64")]
+#[derive(Clone, Copy)]
+struct ParkRecord {
+    fence_at_park: scheduler::RetirementFence,
+    row_epoch_at_park: u64,
+    age_epoch_sum_at_park: u64,
+}
+
+#[cfg(target_arch = "aarch64")]
+#[derive(Clone, Copy, Default)]
+struct RootProof {
+    blocked_epoch: bool,
+    blocked_hw: bool,
+    blocked_shadow: bool,
+    blocked_cached: bool,
+    blocked_live_row: bool,
+}
+
+#[cfg(target_arch = "aarch64")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RootBlocker {
+    Epoch,
+    Hardware,
+    Shadow,
+    Cached,
+    LiveRow,
+}
+
+#[cfg(target_arch = "aarch64")]
+#[derive(Clone, Copy)]
+enum UnparkReason {
+    Epoch,
+    Row,
+    Age,
 }
 
 #[cfg(target_arch = "aarch64")]
 impl PendingProcessReclaim {
-    fn root_is_live(&self) -> bool {
+    fn any_root_matches<F>(&self, mut root_matches: F) -> bool
+    where
+        F: FnMut(u64) -> bool,
+    {
         self.page_table
             .iter()
             .chain(self.old_page_tables.iter())
-            .any(|page_table| {
-                crate::arch_impl::aarch64::is_ttbr0_root_live(
-                    page_table.level_4_frame().start_address().as_u64(),
-                )
+            .any(|page_table| root_matches(page_table.level_4_frame().start_address().as_u64()))
+    }
+
+    fn lock_free_root_proof(
+        &self,
+        snapshot: &scheduler::RetirementSnapshot,
+        allow_boot_injection: bool,
+    ) -> RootProof {
+        if !snapshot.fence_elapsed(&self.after_epoch)
+            || boot_forces_blocker(self.pid, RootBlocker::Epoch, allow_boot_injection)
+        {
+            return RootProof::blocked(RootBlocker::Epoch);
+        }
+        let local_ttbr0 = crate::arch_impl::aarch64::ttbr0::local_ttbr0_root();
+        if self.any_root_matches(|root| {
+            crate::arch_impl::aarch64::ttbr0::roots_match(local_ttbr0, root)
+        }) || boot_forces_blocker(self.pid, RootBlocker::Hardware, allow_boot_injection)
+        {
+            return RootProof::blocked(RootBlocker::Hardware);
+        }
+        if self.any_root_matches(|root| {
+            crate::arch_impl::aarch64::ttbr0::is_ttbr0_root_live_in_mask(
+                root,
+                self.after_epoch.online_mask,
+            )
+        }) || boot_forces_blocker(self.pid, RootBlocker::Shadow, allow_boot_injection)
+        {
+            return RootProof::blocked(RootBlocker::Shadow);
+        }
+        RootProof::default()
+    }
+
+    fn cached_root_is_live(&self) -> bool {
+        scheduler::with_scheduler(|scheduler| {
+            scheduler.any_cached_ttbr0_matches(|cached| {
+                self.any_root_matches(|root| {
+                    crate::arch_impl::aarch64::ttbr0::roots_match(cached, root)
+                })
             })
+        })
+        .unwrap_or(false)
+    }
+
+    fn live_row_names_root(&self) -> bool {
+        crate::process::manager().as_ref().is_some_and(|manager| {
+            manager.any_live_root_matches(|row_root| {
+                self.any_root_matches(|root| {
+                    crate::arch_impl::aarch64::ttbr0::roots_match(row_root, root)
+                })
+            })
+        })
     }
 
     fn reclaim(mut self) {
@@ -100,6 +190,99 @@ impl PendingProcessReclaim {
 #[cfg(target_arch = "aarch64")]
 static PENDING_PROCESS_RECLAIMS: spin::Mutex<alloc::vec::Vec<PendingProcessReclaim>> =
     spin::Mutex::new(alloc::vec::Vec::new());
+#[cfg(target_arch = "aarch64")]
+static PARKED_PROCESS_RECLAIMS: spin::Mutex<alloc::vec::Vec<PendingProcessReclaim>> =
+    spin::Mutex::new(alloc::vec::Vec::new());
+#[cfg(target_arch = "aarch64")]
+static RECLAIM_PASS_ID: AtomicU32 = AtomicU32::new(0);
+#[cfg(target_arch = "aarch64")]
+static ROW_REMOVAL_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_TEST_OWNER: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_ACTIVE_DRAINS: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_FORCED_PID: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_FORCED_BLOCKER: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_ADVANCE_AFTER_STEP_TWO: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_PASS_START: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_PASS_SELECTIONS: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_LAST_PARK_EPOCHS: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS] =
+    [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_LAST_PARK_MASK: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static BOOT_RECLAIM_LAST_PARK_ROW_EPOCH: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(target_arch = "aarch64")]
+const PROOF_FAILURES_BEFORE_PARK: u8 = 3;
+#[cfg(target_arch = "aarch64")]
+const PARK_AGE_BACKSTOP_EPOCHS: u64 = 64;
+
+#[cfg(target_arch = "aarch64")]
+impl RootProof {
+    fn blocked(blocker: RootBlocker) -> Self {
+        let mut proof = Self::default();
+        match blocker {
+            RootBlocker::Epoch => proof.blocked_epoch = true,
+            RootBlocker::Hardware => proof.blocked_hw = true,
+            RootBlocker::Shadow => proof.blocked_shadow = true,
+            RootBlocker::Cached => proof.blocked_cached = true,
+            RootBlocker::LiveRow => proof.blocked_live_row = true,
+        }
+        proof
+    }
+
+    fn blocker(self) -> Option<RootBlocker> {
+        if self.blocked_epoch {
+            Some(RootBlocker::Epoch)
+        } else if self.blocked_hw {
+            Some(RootBlocker::Hardware)
+        } else if self.blocked_shadow {
+            Some(RootBlocker::Shadow)
+        } else if self.blocked_cached {
+            Some(RootBlocker::Cached)
+        } else if self.blocked_live_row {
+            Some(RootBlocker::LiveRow)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+impl ParkRecord {
+    fn unpark_reason(
+        &self,
+        snapshot: &scheduler::RetirementSnapshot,
+        row_epoch: u64,
+    ) -> Option<UnparkReason> {
+        if snapshot.all_advanced_since(&self.fence_at_park) {
+            Some(UnparkReason::Epoch)
+        } else if row_epoch != self.row_epoch_at_park {
+            Some(UnparkReason::Row)
+        } else if snapshot
+            .epoch_sum(self.fence_at_park.online_mask)
+            .wrapping_sub(self.age_epoch_sum_at_park)
+            >= PARK_AGE_BACKSTOP_EPOCHS
+        {
+            Some(UnparkReason::Age)
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) fn note_process_row_removed() {
+    #[cfg(target_arch = "aarch64")]
+    ROW_REMOVAL_EPOCH.fetch_add(1, Ordering::Relaxed);
+}
 
 pub(crate) fn release_process_resources(process: &mut crate::process::Process) {
     if crate::process::process_manager_held_on_current_cpu() {
@@ -118,13 +301,15 @@ pub(crate) fn release_process_resources(process: &mut crate::process::Process) {
 pub(crate) fn defer_live_process_resources(
     process: &mut crate::process::Process,
 ) -> Option<PendingProcessReclaim> {
+    let snapshot = scheduler::RetirementSnapshot::capture();
     let root_is_live = process
         .page_table
         .iter()
         .chain(process.pending_old_page_tables.iter())
         .any(|page_table| {
-            crate::arch_impl::aarch64::is_ttbr0_root_live(
+            crate::arch_impl::aarch64::ttbr0::is_ttbr0_root_live_in_mask(
                 page_table.level_4_frame().start_address().as_u64(),
+                snapshot.online_mask,
             )
         });
     if !root_is_live {
@@ -144,6 +329,9 @@ pub(crate) fn defer_process_resources(
         page_table: process.page_table.take(),
         old_page_tables: core::mem::take(&mut process.pending_old_page_tables),
         after_epoch: scheduler::retirement_grace_target(),
+        last_pass: 0,
+        proof_failures: 0,
+        parked: None,
     }
 }
 
@@ -388,9 +576,196 @@ pub fn drain_deferred_fault_sigsegv_exits() {
     }
 }
 
+#[cfg(target_arch = "aarch64")]
+fn record_root_blocker(blocker: RootBlocker) {
+    match blocker {
+        RootBlocker::Epoch => {
+            crate::trace_count!(crate::tracing::providers::teardown::ROOT_PROOF_BLOCKED_EPOCH);
+        }
+        RootBlocker::Hardware => {
+            crate::trace_count!(crate::tracing::providers::teardown::ROOT_PROOF_BLOCKED_HW);
+        }
+        RootBlocker::Shadow => {
+            crate::trace_count!(crate::tracing::providers::teardown::ROOT_PROOF_BLOCKED_SHADOW);
+        }
+        RootBlocker::Cached => {
+            crate::trace_count!(crate::tracing::providers::teardown::ROOT_PROOF_BLOCKED_CACHED);
+        }
+        RootBlocker::LiveRow => {
+            crate::trace_count!(crate::tracing::providers::teardown::ROOT_PROOF_BLOCKED_LIVE_ROW);
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn record_unpark(reason: UnparkReason) {
+    match reason {
+        UnparkReason::Epoch => {
+            crate::trace_count!(crate::tracing::providers::teardown::RECLAIM_UNPARKED_EPOCH);
+        }
+        UnparkReason::Row => {
+            crate::trace_count!(crate::tracing::providers::teardown::RECLAIM_UNPARKED_ROW);
+        }
+        UnparkReason::Age => {
+            crate::trace_count!(crate::tracing::providers::teardown::RECLAIM_UNPARKED_AGE);
+        }
+    }
+    crate::trace_count_add!(
+        crate::tracing::providers::teardown::RECLAIM_PARK_RESIDENT,
+        u64::MAX
+    );
+}
+
+#[cfg(target_arch = "aarch64")]
+fn park_reclaim(mut reclaim: PendingProcessReclaim) {
+    let snapshot_at_park = scheduler::RetirementSnapshot::capture();
+    let fence_at_park = snapshot_at_park.as_fence();
+    let row_epoch_at_park = ROW_REMOVAL_EPOCH.load(Ordering::Relaxed);
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    if BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
+        for (slot, epoch) in BOOT_RECLAIM_LAST_PARK_EPOCHS
+            .iter()
+            .zip(snapshot_at_park.epochs)
+        {
+            slot.store(epoch, Ordering::Relaxed);
+        }
+        BOOT_RECLAIM_LAST_PARK_MASK.store(snapshot_at_park.online_mask, Ordering::Relaxed);
+        BOOT_RECLAIM_LAST_PARK_ROW_EPOCH.store(row_epoch_at_park, Ordering::Relaxed);
+    }
+    let park_record = ParkRecord {
+        fence_at_park,
+        row_epoch_at_park,
+        age_epoch_sum_at_park: snapshot_at_park.epoch_sum(fence_at_park.online_mask),
+    };
+    if park_record
+        .unpark_reason(&snapshot_at_park, row_epoch_at_park)
+        .is_some()
+    {
+        crate::trace_count!(crate::tracing::providers::teardown::RECLAIM_PARK_IMMEDIATE_UNPARK);
+    }
+    reclaim.parked = Some(park_record);
+    crate::trace_count!(crate::tracing::providers::teardown::RECLAIM_PARKED);
+    crate::trace_count!(crate::tracing::providers::teardown::RECLAIM_PARK_RESIDENT);
+    crate::arch_without_interrupts(|| PARKED_PROCESS_RECLAIMS.lock().push(reclaim));
+}
+
+#[cfg(target_arch = "aarch64")]
+fn unpark_sweep_with_snapshot(snapshot: scheduler::RetirementSnapshot, row_epoch: u64) {
+    let mut ready = alloc::vec::Vec::new();
+    crate::arch_without_interrupts(|| {
+        let mut parked = PARKED_PROCESS_RECLAIMS.lock();
+        let mut index = 0;
+        while index < parked.len() {
+            let reason = parked[index]
+                .parked
+                .as_ref()
+                .and_then(|record| record.unpark_reason(&snapshot, row_epoch));
+            if let Some(reason) = reason {
+                let mut reclaim = parked.swap_remove(index);
+                reclaim.parked = None;
+                reclaim.proof_failures = 0;
+                record_unpark(reason);
+                ready.push(reclaim);
+            } else {
+                index += 1;
+            }
+        }
+    });
+    if !ready.is_empty() {
+        crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().extend(ready));
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn unpark_sweep() {
+    let snapshot = scheduler::RetirementSnapshot::capture();
+    let row_epoch = ROW_REMOVAL_EPOCH.load(Ordering::Relaxed);
+    unpark_sweep_with_snapshot(snapshot, row_epoch);
+}
+
+#[cfg(target_arch = "aarch64")]
+fn boot_forces_blocker(pid: u64, blocker: RootBlocker, allow_boot_injection: bool) -> bool {
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    {
+        allow_boot_injection
+            && BOOT_RECLAIM_FORCED_PID.load(Ordering::Acquire) == pid
+            && BOOT_RECLAIM_FORCED_BLOCKER.load(Ordering::Acquire) == blocker as u64 + 1
+    }
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    {
+        let _ = (pid, blocker, allow_boot_injection);
+        false
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+struct BootReclaimInvocationGuard;
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl BootReclaimInvocationGuard {
+    fn enter() -> (Self, bool) {
+        BOOT_RECLAIM_ACTIVE_DRAINS.fetch_add(1, Ordering::AcqRel);
+        let allowed = BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) == 0;
+        (Self, allowed)
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl Drop for BootReclaimInvocationGuard {
+    fn drop(&mut self) {
+        BOOT_RECLAIM_ACTIVE_DRAINS.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn boot_after_step_two(fence: &scheduler::RetirementFence) {
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    if BOOT_RECLAIM_ADVANCE_AFTER_STEP_TWO.swap(0, Ordering::AcqRel) != 0 {
+        for cpu_id in 0..crate::arch_impl::aarch64::constants::MAX_CPUS {
+            if fence.online_mask & (1 << cpu_id) != 0 {
+                scheduler::note_scheduling_epoch(cpu_id);
+            }
+        }
+    }
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = fence;
+}
+
+#[cfg(target_arch = "aarch64")]
+fn boot_begin_reclaim_pass() {
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    if BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
+        let queue_len = crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().len());
+        BOOT_RECLAIM_PASS_START.store(queue_len as u64, Ordering::Relaxed);
+        BOOT_RECLAIM_PASS_SELECTIONS.store(0, Ordering::Relaxed);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn boot_note_reclaim_selection() {
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    if BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
+        BOOT_RECLAIM_PASS_SELECTIONS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn boot_finish_reclaim_pass() {
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    if BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
+        debug_assert!(
+            BOOT_RECLAIM_PASS_SELECTIONS.load(Ordering::Relaxed)
+                <= BOOT_RECLAIM_PASS_START.load(Ordering::Relaxed)
+        );
+    }
+}
+
 /// Reclaim process frames whose cross-CPU TTBR0 retention has quiesced.
 #[cfg(target_arch = "aarch64")]
 pub fn reclaim_deferred_process_resources() {
+    let my_pass = RECLAIM_PASS_ID
+        .fetch_add(1, Ordering::Relaxed)
+        .wrapping_add(1);
     if crate::process::process_manager_held_on_current_cpu()
         || crate::tracing::providers::teardown::scheduler_scope_active()
     {
@@ -398,27 +773,492 @@ pub fn reclaim_deferred_process_resources() {
             crate::tracing::providers::teardown::RECLAIM_CONTEXT_VIOLATIONS
         );
     }
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    let (_boot_invocation_guard, boot_reclaim_allowed) = BootReclaimInvocationGuard::enter();
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    if !boot_reclaim_allowed {
+        return;
+    }
+
+    reclaim_deferred_process_resources_for_pass(my_pass);
+}
+
+#[cfg(target_arch = "aarch64")]
+fn reclaim_deferred_process_resources_for_pass(my_pass: u32) {
+    unpark_sweep();
+    boot_begin_reclaim_pass();
 
     loop {
         let reclaim = crate::arch_without_interrupts(|| {
             let mut pending = PENDING_PROCESS_RECLAIMS.lock();
             let _proof_scope =
                 crate::tracing::providers::teardown::ReclaimProofScope::enter();
-            let ready = pending.iter().position(|reclaim| {
-                scheduler::retirement_grace_elapsed(&reclaim.after_epoch)
-                    && !reclaim.root_is_live()
+            let snapshot = scheduler::RetirementSnapshot::capture();
+            let ready = pending.iter_mut().position(|reclaim| {
+                if reclaim.last_pass == my_pass {
+                    crate::trace_count!(crate::tracing::providers::teardown::RECLAIM_PASS_SKIPPED);
+                    return false;
+                }
+                let proof = reclaim.lock_free_root_proof(&snapshot, false);
+                if let Some(blocker) = proof.blocker() {
+                    record_root_blocker(blocker);
+                    return false;
+                }
+                reclaim.last_pass = my_pass;
+                true
             });
             ready.map(|index| pending.swap_remove(index))
         });
 
         match reclaim {
-            Some(reclaim) => {
-                crate::tracing::providers::teardown::record_reclaim(reclaim.pid);
-                reclaim.reclaim();
+            Some(mut reclaim) => {
+                boot_note_reclaim_selection();
+                let snapshot = scheduler::RetirementSnapshot::capture();
+                let mut proof = reclaim.lock_free_root_proof(&snapshot, true);
+                boot_after_step_two(&reclaim.after_epoch);
+                if proof.blocker().is_none()
+                    && (reclaim.cached_root_is_live()
+                        || boot_forces_blocker(reclaim.pid, RootBlocker::Cached, true))
+                {
+                    proof = RootProof::blocked(RootBlocker::Cached);
+                }
+                if proof.blocker().is_none()
+                    && (reclaim.live_row_names_root()
+                        || boot_forces_blocker(reclaim.pid, RootBlocker::LiveRow, true))
+                {
+                    proof = RootProof::blocked(RootBlocker::LiveRow);
+                }
+
+                if let Some(blocker) = proof.blocker() {
+                    record_root_blocker(blocker);
+                    if matches!(blocker, RootBlocker::Cached | RootBlocker::LiveRow) {
+                        reclaim.proof_failures = reclaim.proof_failures.saturating_add(1);
+                    }
+                    if reclaim.proof_failures == PROOF_FAILURES_BEFORE_PARK {
+                        park_reclaim(reclaim);
+                    } else {
+                        crate::arch_without_interrupts(|| {
+                            PENDING_PROCESS_RECLAIMS.lock().push(reclaim)
+                        });
+                    }
+                } else {
+                    crate::tracing::providers::teardown::record_reclaim(reclaim.pid);
+                    reclaim.reclaim();
+                }
             }
             None => break,
         }
     }
+    boot_finish_reclaim_pass();
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_reclaim_deferred_process_resources() {
+    let my_pass = RECLAIM_PASS_ID
+        .fetch_add(1, Ordering::Relaxed)
+        .wrapping_add(1);
+    reclaim_deferred_process_resources_for_pass(my_pass);
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+const BOOT_RECLAIM_PID_BASE: u64 = u64::MAX - 0x1000;
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+struct BootReclaimTestGuard;
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl BootReclaimTestGuard {
+    fn enter() -> Result<Self, &'static str> {
+        let owner = crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id().wrapping_add(1);
+        BOOT_RECLAIM_TEST_OWNER
+            .compare_exchange(0, owner, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| "another reclaim injection is active")?;
+        while BOOT_RECLAIM_ACTIVE_DRAINS.load(Ordering::Acquire) != 0 {
+            core::hint::spin_loop();
+        }
+        let live_empty =
+            crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().is_empty());
+        let parked_empty =
+            crate::arch_without_interrupts(|| PARKED_PROCESS_RECLAIMS.lock().is_empty());
+        let queues_empty = live_empty && parked_empty;
+        if !queues_empty {
+            BOOT_RECLAIM_TEST_OWNER.store(0, Ordering::Release);
+            return Err("reclaim queues were not quiescent before P1 gate");
+        }
+        BOOT_RECLAIM_FORCED_PID.store(0, Ordering::Relaxed);
+        BOOT_RECLAIM_FORCED_BLOCKER.store(0, Ordering::Relaxed);
+        BOOT_RECLAIM_ADVANCE_AFTER_STEP_TWO.store(0, Ordering::Relaxed);
+        Ok(Self)
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl Drop for BootReclaimTestGuard {
+    fn drop(&mut self) {
+        BOOT_RECLAIM_FORCED_PID.store(0, Ordering::Release);
+        BOOT_RECLAIM_FORCED_BLOCKER.store(0, Ordering::Release);
+        BOOT_RECLAIM_ADVANCE_AFTER_STEP_TWO.store(0, Ordering::Release);
+        crate::arch_without_interrupts(|| {
+            PENDING_PROCESS_RECLAIMS
+                .lock()
+                .retain(|reclaim| reclaim.pid < BOOT_RECLAIM_PID_BASE);
+            let mut parked = PARKED_PROCESS_RECLAIMS.lock();
+            let before = parked.len();
+            parked.retain(|reclaim| reclaim.pid < BOOT_RECLAIM_PID_BASE);
+            for _ in parked.len()..before {
+                crate::trace_count_add!(
+                    crate::tracing::providers::teardown::RECLAIM_PARK_RESIDENT,
+                    u64::MAX
+                );
+            }
+        });
+        BOOT_RECLAIM_TEST_OWNER.store(0, Ordering::Release);
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_test_reclaim(pid: u64) -> PendingProcessReclaim {
+    PendingProcessReclaim {
+        pid,
+        page_table: None,
+        old_page_tables: alloc::vec::Vec::new(),
+        after_epoch: scheduler::RetirementSnapshot::capture().as_fence(),
+        last_pass: 0,
+        proof_failures: 0,
+        parked: None,
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_push_live(pid: u64) {
+    crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().push(boot_test_reclaim(pid)));
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_push_parked(pid: u64, record: ParkRecord) {
+    let mut reclaim = boot_test_reclaim(pid);
+    reclaim.proof_failures = PROOF_FAILURES_BEFORE_PARK;
+    reclaim.parked = Some(record);
+    crate::trace_count!(crate::tracing::providers::teardown::RECLAIM_PARKED);
+    crate::trace_count!(crate::tracing::providers::teardown::RECLAIM_PARK_RESIDENT);
+    crate::arch_without_interrupts(|| PARKED_PROCESS_RECLAIMS.lock().push(reclaim));
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_reclaim_locations(pid: u64) -> (bool, bool) {
+    let live = crate::arch_without_interrupts(|| {
+        PENDING_PROCESS_RECLAIMS
+            .lock()
+            .iter()
+            .any(|reclaim| reclaim.pid == pid)
+    });
+    let parked = crate::arch_without_interrupts(|| {
+        PARKED_PROCESS_RECLAIMS
+            .lock()
+            .iter()
+            .any(|reclaim| reclaim.pid == pid)
+    });
+    (live, parked)
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_force_blocker(pid: u64, blocker: Option<RootBlocker>) {
+    BOOT_RECLAIM_FORCED_PID.store(pid, Ordering::Release);
+    BOOT_RECLAIM_FORCED_BLOCKER.store(
+        blocker.map_or(0, |blocker| blocker as u64 + 1),
+        Ordering::Release,
+    );
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_last_park_snapshot() -> (scheduler::RetirementSnapshot, u64) {
+    let mut epochs = [0; crate::arch_impl::aarch64::constants::MAX_CPUS];
+    for (epoch, slot) in epochs.iter_mut().zip(&BOOT_RECLAIM_LAST_PARK_EPOCHS) {
+        *epoch = slot.load(Ordering::Relaxed);
+    }
+    (
+        scheduler::RetirementSnapshot {
+            epochs,
+            online_mask: BOOT_RECLAIM_LAST_PARK_MASK.load(Ordering::Relaxed),
+        },
+        BOOT_RECLAIM_LAST_PARK_ROW_EPOCH.load(Ordering::Relaxed),
+    )
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_synthetic_park(mask: u64, first_epoch: u64) -> (ParkRecord, scheduler::RetirementSnapshot) {
+    let mut epochs = [0; crate::arch_impl::aarch64::constants::MAX_CPUS];
+    for (cpu_id, epoch) in epochs.iter_mut().enumerate() {
+        if mask & (1 << cpu_id) != 0 {
+            *epoch = first_epoch;
+        }
+    }
+    let snapshot = scheduler::RetirementSnapshot {
+        epochs,
+        online_mask: mask,
+    };
+    let fence_at_park = snapshot.as_fence();
+    (
+        ParkRecord {
+            fence_at_park,
+            row_epoch_at_park: ROW_REMOVAL_EPOCH.load(Ordering::Relaxed),
+            age_epoch_sum_at_park: snapshot.epoch_sum(mask),
+        },
+        snapshot,
+    )
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub fn retirement_fence_gate_test() -> crate::test_framework::registry::TestResult {
+    use crate::test_framework::registry::TestResult;
+
+    let empty_before = crate::tracing::providers::teardown::RETIRE_EMPTY_ONLINE_MASK.aggregate();
+    let empty = scheduler::RetirementFence {
+        epochs: [0; crate::arch_impl::aarch64::constants::MAX_CPUS],
+        online_mask: 0,
+    };
+    let zero = scheduler::RetirementSnapshot {
+        epochs: [0; crate::arch_impl::aarch64::constants::MAX_CPUS],
+        online_mask: 0,
+    };
+    if zero.fence_elapsed(&empty)
+        || crate::tracing::providers::teardown::RETIRE_EMPTY_ONLINE_MASK.aggregate() <= empty_before
+    {
+        return TestResult::Fail("empty retirement mask elapsed or was not counted");
+    }
+
+    let mut target_epochs = [0; crate::arch_impl::aarch64::constants::MAX_CPUS];
+    target_epochs[0] = u64::MAX;
+    let wrapped_target = scheduler::RetirementFence {
+        epochs: target_epochs,
+        online_mask: 1,
+    };
+    let mut now_epochs = target_epochs;
+    now_epochs[0] = 1;
+    let wrapped_now = scheduler::RetirementSnapshot {
+        epochs: now_epochs,
+        online_mask: 1,
+    };
+    if !wrapped_now.fence_elapsed(&wrapped_target) {
+        return TestResult::Fail("wrap-safe retirement comparison rejected elapsed fence");
+    }
+    target_epochs[0] = 1;
+    now_epochs[0] = u64::MAX;
+    if (scheduler::RetirementSnapshot {
+        epochs: now_epochs,
+        online_mask: 1,
+    })
+    .fence_elapsed(&scheduler::RetirementFence {
+        epochs: target_epochs,
+        online_mask: 1,
+    }) {
+        return TestResult::Fail("wrap-safe retirement comparison accepted future fence");
+    }
+    TestResult::Pass
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub fn reclaim_progress_gate_test() -> crate::test_framework::registry::TestResult {
+    use crate::test_framework::registry::TestResult;
+    use crate::tracing::providers::teardown as trace;
+
+    let _guard = match BootReclaimTestGuard::enter() {
+        Ok(guard) => guard,
+        Err(message) => return TestResult::Fail(message),
+    };
+    let proof_lock_before = trace::PROOF_UNDER_QUEUE_LOCK.aggregate();
+    let resident_before = trace::RECLAIM_PARK_RESIDENT.aggregate();
+    let parked_before = trace::RECLAIM_PARKED.aggregate();
+    let skipped_before = trace::RECLAIM_PASS_SKIPPED.aggregate();
+    let immediate_before = trace::RECLAIM_PARK_IMMEDIATE_UNPARK.aggregate();
+    let reclaim_before = trace::TEARDOWN_RECLAIM.aggregate();
+
+    let blocked_pid = BOOT_RECLAIM_PID_BASE;
+    let ready_pid = BOOT_RECLAIM_PID_BASE + 1;
+    boot_force_blocker(blocked_pid, Some(RootBlocker::LiveRow));
+    boot_push_live(blocked_pid);
+    boot_push_live(ready_pid);
+    boot_reclaim_deferred_process_resources();
+    let selections = BOOT_RECLAIM_PASS_SELECTIONS.load(Ordering::Relaxed);
+    let pass_start = BOOT_RECLAIM_PASS_START.load(Ordering::Relaxed);
+    if selections != 2 || selections > pass_start || pass_start != 2 {
+        return TestResult::Fail("bounded reclaim pass selected a candidate twice");
+    }
+    if boot_reclaim_locations(blocked_pid) != (true, false)
+        || boot_reclaim_locations(ready_pid) != (false, false)
+        || trace::TEARDOWN_RECLAIM
+            .aggregate()
+            .saturating_sub(reclaim_before)
+            != 1
+        || trace::RECLAIM_PASS_SKIPPED.aggregate() <= skipped_before
+    {
+        return TestResult::Fail("live-row refusal spun or starved a ready receipt");
+    }
+    boot_reclaim_deferred_process_resources();
+    BOOT_RECLAIM_ADVANCE_AFTER_STEP_TWO.store(1, Ordering::Release);
+    boot_reclaim_deferred_process_resources();
+    if trace::RECLAIM_PARKED
+        .aggregate()
+        .saturating_sub(parked_before)
+        != 1
+        || boot_reclaim_locations(blocked_pid) != (false, true)
+        || trace::RECLAIM_PARK_RESIDENT.aggregate() != resident_before.wrapping_add(1)
+    {
+        return TestResult::Fail("persistent live-row refusal did not park exactly at K=3");
+    }
+
+    let unpark_before = trace::RECLAIM_UNPARKED_EPOCH
+        .aggregate()
+        .wrapping_add(trace::RECLAIM_UNPARKED_ROW.aggregate())
+        .wrapping_add(trace::RECLAIM_UNPARKED_AGE.aggregate());
+    let (park_snapshot, park_row_epoch) = boot_last_park_snapshot();
+    unpark_sweep_with_snapshot(park_snapshot, park_row_epoch);
+    let unpark_after = trace::RECLAIM_UNPARKED_EPOCH
+        .aggregate()
+        .wrapping_add(trace::RECLAIM_UNPARKED_ROW.aggregate())
+        .wrapping_add(trace::RECLAIM_UNPARKED_AGE.aggregate());
+    if boot_reclaim_locations(blocked_pid) != (false, true) {
+        return TestResult::Fail("fresh park entry moved without an unpark trigger");
+    }
+    if unpark_after != unpark_before {
+        return TestResult::Fail("fresh park snapshot selected an unpark arm");
+    }
+    if trace::RECLAIM_PARK_IMMEDIATE_UNPARK.aggregate() != immediate_before {
+        return TestResult::Fail("fresh park was immediately eligible when recorded");
+    }
+    boot_force_blocker(blocked_pid, None);
+    let row_marker = {
+        let mut manager = crate::process::manager();
+        let Some(manager) = manager.as_mut() else {
+            return TestResult::Fail("process manager unavailable for row-arm gate");
+        };
+        let pid = manager.allocate_pid();
+        let process = crate::process::Process::new(
+            pid,
+            alloc::string::String::from("p1_row_epoch_gate"),
+            crate::memory::arch_stub::VirtAddr::new(0x400000),
+        );
+        manager.insert_process(pid, process);
+        manager.remove_process(pid);
+        ROW_REMOVAL_EPOCH.load(Ordering::Relaxed)
+    };
+    let row_before = trace::RECLAIM_UNPARKED_ROW.aggregate();
+    unpark_sweep_with_snapshot(park_snapshot, row_marker);
+    if trace::RECLAIM_UNPARKED_ROW
+        .aggregate()
+        .saturating_sub(row_before)
+        != 1
+        || boot_reclaim_locations(blocked_pid) != (true, false)
+    {
+        return TestResult::Fail("row-removal unpark arm did not fire");
+    }
+    boot_reclaim_deferred_process_resources();
+
+    let cached_pid = BOOT_RECLAIM_PID_BASE + 2;
+    boot_force_blocker(cached_pid, Some(RootBlocker::Cached));
+    boot_push_live(cached_pid);
+    for _ in 0..PROOF_FAILURES_BEFORE_PARK {
+        boot_reclaim_deferred_process_resources();
+    }
+    if boot_reclaim_locations(cached_pid) != (false, true)
+        || trace::RECLAIM_PARK_RESIDENT.aggregate() != resident_before.wrapping_add(1)
+    {
+        return TestResult::Fail("cached-root refusal did not become epoch-parked");
+    }
+    boot_force_blocker(cached_pid, None);
+    let (cached_snapshot, cached_row_epoch) = boot_last_park_snapshot();
+    let mut epoch_advanced = cached_snapshot;
+    for (cpu_id, epoch) in epoch_advanced.epochs.iter_mut().enumerate() {
+        if epoch_advanced.online_mask & (1 << cpu_id) != 0 {
+            *epoch = epoch.wrapping_add(1);
+        }
+    }
+    let epoch_before = trace::RECLAIM_UNPARKED_EPOCH.aggregate();
+    unpark_sweep_with_snapshot(epoch_advanced, cached_row_epoch);
+    if trace::RECLAIM_UNPARKED_EPOCH
+        .aggregate()
+        .saturating_sub(epoch_before)
+        != 1
+        || boot_reclaim_locations(cached_pid) != (true, false)
+    {
+        return TestResult::Fail("epoch unpark arm did not return the cached-root receipt");
+    }
+    boot_reclaim_deferred_process_resources();
+
+    let age_pid = BOOT_RECLAIM_PID_BASE + 3;
+    let age_mask = (1 << 6) | (1 << 7);
+    let (age_record, age_snapshot) = boot_synthetic_park(age_mask, 200);
+    boot_push_parked(age_pid, age_record);
+    if trace::RECLAIM_PARK_RESIDENT.aggregate() != resident_before.wrapping_add(1) {
+        return TestResult::Fail("age-arm receipt was not observably resident");
+    }
+    let mut age_63 = age_snapshot;
+    age_63.epochs[6] = age_63.epochs[6].wrapping_add(63);
+    unpark_sweep_with_snapshot(age_63, age_record.row_epoch_at_park);
+    if boot_reclaim_locations(age_pid) != (false, true) {
+        return TestResult::Fail("age unpark arm fired before 64 scheduling epochs");
+    }
+    boot_force_blocker(age_pid, Some(RootBlocker::LiveRow));
+    let mut age_64 = age_63;
+    age_64.epochs[6] = age_64.epochs[6].wrapping_add(1);
+    let age_before = trace::RECLAIM_UNPARKED_AGE.aggregate();
+    unpark_sweep_with_snapshot(age_64, age_record.row_epoch_at_park);
+    boot_reclaim_deferred_process_resources();
+    if trace::RECLAIM_UNPARKED_AGE
+        .aggregate()
+        .saturating_sub(age_before)
+        != 1
+        || boot_reclaim_locations(age_pid) != (true, false)
+    {
+        return TestResult::Fail("age arm did not re-prove the receipt at epoch sum 64");
+    }
+    boot_force_blocker(age_pid, None);
+    boot_reclaim_deferred_process_resources();
+
+    let blocker_cases = [
+        (RootBlocker::Hardware, &trace::ROOT_PROOF_BLOCKED_HW),
+        (RootBlocker::Shadow, &trace::ROOT_PROOF_BLOCKED_SHADOW),
+        (RootBlocker::Cached, &trace::ROOT_PROOF_BLOCKED_CACHED),
+        (RootBlocker::LiveRow, &trace::ROOT_PROOF_BLOCKED_LIVE_ROW),
+    ];
+    for (offset, (blocker, counter)) in blocker_cases.into_iter().enumerate() {
+        let pid = BOOT_RECLAIM_PID_BASE + 10 + offset as u64;
+        let before = counter.aggregate();
+        boot_force_blocker(pid, Some(blocker));
+        boot_push_live(pid);
+        boot_reclaim_deferred_process_resources();
+        if counter.aggregate().saturating_sub(before) != 1
+            || boot_reclaim_locations(pid) != (true, false)
+        {
+            return TestResult::Fail("forced RootProof refusal lost its detached receipt");
+        }
+        boot_force_blocker(pid, None);
+        boot_reclaim_deferred_process_resources();
+        if boot_reclaim_locations(pid) != (false, false) {
+            return TestResult::Fail("reinserted RootProof receipt did not eventually retire");
+        }
+    }
+
+    let full_before = trace::TEARDOWN_RECLAIM.aggregate();
+    for offset in 0..8 {
+        boot_push_live(BOOT_RECLAIM_PID_BASE + 32 + offset);
+    }
+    boot_reclaim_deferred_process_resources();
+    if BOOT_RECLAIM_PASS_START.load(Ordering::Relaxed) != 8
+        || BOOT_RECLAIM_PASS_SELECTIONS.load(Ordering::Relaxed) != 8
+        || trace::TEARDOWN_RECLAIM
+            .aggregate()
+            .saturating_sub(full_before)
+            != 8
+    {
+        return TestResult::Fail("pass cursor acted as a reclaim cap");
+    }
+    if trace::RECLAIM_PARK_RESIDENT.aggregate() != resident_before
+        || trace::PROOF_UNDER_QUEUE_LOCK.aggregate() != proof_lock_before
+    {
+        return TestResult::Fail("P1 reclaim gate left residents or nested proof locks");
+    }
+    TestResult::Pass
 }
 
 #[cfg(feature = "boot_tests")]

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -554,6 +554,16 @@ impl ProcessScheduler {
     }
 }
 
+#[cfg(target_arch = "aarch64")]
+fn next_reclaim_pass_id(mut pass: u32) -> u32 {
+    while pass == 0 {
+        pass = RECLAIM_PASS_ID
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1);
+    }
+    pass
+}
+
 /// Defer a SIGSEGV-style process exit for a user thread that faulted in kernel mode.
 pub fn defer_fault_sigsegv_exit(thread_id: u64) -> bool {
     #[cfg(target_arch = "aarch64")]
@@ -763,15 +773,18 @@ fn boot_finish_reclaim_pass() {
 /// Reclaim process frames whose cross-CPU TTBR0 retention has quiesced.
 #[cfg(target_arch = "aarch64")]
 pub fn reclaim_deferred_process_resources() {
-    let my_pass = RECLAIM_PASS_ID
-        .fetch_add(1, Ordering::Relaxed)
-        .wrapping_add(1);
+    let my_pass = next_reclaim_pass_id(
+        RECLAIM_PASS_ID
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1),
+    );
     if crate::process::process_manager_held_on_current_cpu()
         || crate::tracing::providers::teardown::scheduler_scope_active()
     {
         crate::trace_count!(
             crate::tracing::providers::teardown::RECLAIM_CONTEXT_VIOLATIONS
         );
+        return;
     }
     #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
     let (_boot_invocation_guard, boot_reclaim_allowed) = BootReclaimInvocationGuard::enter();
@@ -854,9 +867,11 @@ fn reclaim_deferred_process_resources_for_pass(my_pass: u32) {
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 fn boot_reclaim_deferred_process_resources() {
-    let my_pass = RECLAIM_PASS_ID
-        .fetch_add(1, Ordering::Relaxed)
-        .wrapping_add(1);
+    let my_pass = next_reclaim_pass_id(
+        RECLAIM_PASS_ID
+            .fetch_add(1, Ordering::Relaxed)
+            .wrapping_add(1),
+    );
     reclaim_deferred_process_resources_for_pass(my_pass);
 }
 

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -2805,7 +2805,11 @@ impl Scheduler {
     {
         self.threads
             .iter()
-            .any(|thread| thread.cached_ttbr0 != 0 && root_matches(thread.cached_ttbr0))
+            .any(|thread| {
+                thread.state != ThreadState::Terminated
+                    && thread.cached_ttbr0 != 0
+                    && root_matches(thread.cached_ttbr0)
+            })
     }
 
     /// Check if a thread is in the deferred requeue state on any CPU.

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -557,28 +557,108 @@ static SCHEDULING_EPOCHS: [AtomicU64; MAX_CPUS] =
 #[derive(Clone, Copy)]
 struct RetirementGrace {
     thread_id: u64,
-    after_epoch: [u64; MAX_CPUS],
+    after_epoch: RetirementFence,
 }
 
 #[cfg(target_arch = "aarch64")]
-pub(crate) fn retirement_grace_target() -> [u64; MAX_CPUS] {
-    let mut target = [0; MAX_CPUS];
-    for cpu_id in 0..MAX_CPUS {
-        if crate::arch_impl::aarch64::smp::is_cpu_online(cpu_id) {
-            target[cpu_id] = SCHEDULING_EPOCHS[cpu_id]
-                .load(Ordering::Acquire)
-                .saturating_add(2);
+#[derive(Clone, Copy)]
+pub(crate) struct RetirementFence {
+    pub(crate) epochs: [u64; MAX_CPUS],
+    pub(crate) online_mask: u64,
+}
+
+#[cfg(target_arch = "aarch64")]
+#[derive(Clone, Copy)]
+pub(crate) struct RetirementSnapshot {
+    pub(crate) epochs: [u64; MAX_CPUS],
+    pub(crate) online_mask: u64,
+}
+
+#[cfg(target_arch = "aarch64")]
+impl RetirementSnapshot {
+    pub(crate) fn capture() -> Self {
+        let mut epochs = [0; MAX_CPUS];
+        let mut online_mask = 0;
+        for cpu_id in 0..MAX_CPUS {
+            epochs[cpu_id] = SCHEDULING_EPOCHS[cpu_id].load(Ordering::Acquire);
+            if crate::arch_impl::aarch64::smp::is_cpu_online(cpu_id) {
+                online_mask |= 1 << cpu_id;
+            }
+        }
+        core::sync::atomic::fence(Ordering::Acquire);
+        Self {
+            epochs,
+            online_mask,
         }
     }
-    target
+
+    pub(crate) fn as_fence(self) -> RetirementFence {
+        RetirementFence {
+            epochs: self.epochs,
+            online_mask: self.online_mask,
+        }
+    }
+
+    fn target_after(self, advances: u64) -> RetirementFence {
+        let mut epochs = self.epochs;
+        for (cpu_id, epoch) in epochs.iter_mut().enumerate() {
+            if self.online_mask & (1 << cpu_id) != 0 {
+                *epoch = epoch.wrapping_add(advances);
+            }
+        }
+        RetirementFence {
+            epochs,
+            online_mask: self.online_mask,
+        }
+    }
+
+    pub(crate) fn fence_elapsed(&self, fence: &RetirementFence) -> bool {
+        if fence.online_mask == 0 {
+            crate::trace_count!(crate::tracing::providers::teardown::RETIRE_EMPTY_ONLINE_MASK);
+            return false;
+        }
+        (0..MAX_CPUS).all(|cpu_id| {
+            fence.online_mask & (1 << cpu_id) == 0
+                || epoch_reached(self.epochs[cpu_id], fence.epochs[cpu_id])
+        })
+    }
+
+    pub(crate) fn all_advanced_since(&self, fence: &RetirementFence) -> bool {
+        fence.online_mask != 0
+            && (0..MAX_CPUS).all(|cpu_id| {
+                fence.online_mask & (1 << cpu_id) == 0
+                    || epoch_advanced(self.epochs[cpu_id], fence.epochs[cpu_id])
+            })
+    }
+
+    pub(crate) fn epoch_sum(&self, online_mask: u64) -> u64 {
+        (0..MAX_CPUS)
+            .filter(|cpu_id| online_mask & (1 << cpu_id) != 0)
+            .fold(0u64, |sum, cpu_id| sum.wrapping_add(self.epochs[cpu_id]))
+    }
 }
 
 #[cfg(target_arch = "aarch64")]
-pub(crate) fn retirement_grace_elapsed(target: &[u64; MAX_CPUS]) -> bool {
-    (0..MAX_CPUS).all(|cpu_id| {
-        target[cpu_id] == 0
-            || SCHEDULING_EPOCHS[cpu_id].load(Ordering::Acquire) >= target[cpu_id]
-    })
+#[inline(always)]
+fn epoch_reached(now: u64, target: u64) -> bool {
+    now.wrapping_sub(target) < (1u64 << 63)
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn epoch_advanced(now: u64, before: u64) -> bool {
+    let delta = now.wrapping_sub(before);
+    delta != 0 && delta < (1u64 << 63)
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn retirement_grace_target() -> RetirementFence {
+    RetirementSnapshot::capture().target_after(2)
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn retirement_grace_elapsed(target: &RetirementFence) -> bool {
+    RetirementSnapshot::capture().fence_elapsed(target)
 }
 
 /// Record a scheduler entry for the current CPU.
@@ -2713,6 +2793,19 @@ impl Scheduler {
     #[cfg(target_arch = "aarch64")]
     pub fn is_idle_thread_inner(&self, thread_id: u64) -> bool {
         (0..MAX_CPUS).any(|cpu| self.cpu_state[cpu].idle_thread == thread_id)
+    }
+
+    /// Return whether any scheduler-owned thread still caches a matching
+    /// userspace translation-table root. The caller supplies the root matcher
+    /// so the scheduler lock is acquired exactly once for an entire receipt.
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn any_cached_ttbr0_matches<F>(&self, mut root_matches: F) -> bool
+    where
+        F: FnMut(u64) -> bool,
+    {
+        self.threads
+            .iter()
+            .any(|thread| thread.cached_ttbr0 != 0 && root_matches(thread.cached_ttbr0))
     }
 
     /// Check if a thread is in the deferred requeue state on any CPU.

--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -5036,6 +5036,22 @@ static PROCESS_TESTS: &[TestDef] = &[
         timeout_ms: 30000,
         stage: TestStage::PostScheduler,
     },
+    #[cfg(target_arch = "aarch64")]
+    TestDef {
+        name: "retirement_fence_gate",
+        func: crate::task::process_task::retirement_fence_gate_test,
+        arch: Arch::Aarch64,
+        timeout_ms: 5000,
+        stage: TestStage::PostScheduler,
+    },
+    #[cfg(target_arch = "aarch64")]
+    TestDef {
+        name: "reclaim_progress_gate",
+        func: crate::task::process_task::reclaim_progress_gate_test,
+        arch: Arch::Aarch64,
+        timeout_ms: 10000,
+        stage: TestStage::PostScheduler,
+    },
     // Note: Userspace stage tests cannot run from syscall context (would block).
     // The Userspace stage is marked when EL0/Ring3 syscall is confirmed, but
     // tests at this stage are skipped. The confirmation itself is the test.

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -1,8 +1,8 @@
 //! Lock-free teardown observability.
 //!
-//! Phase 0 records existing teardown behavior only. Counters whose producer is
-//! introduced by a later phase are deliberately registered and readable here,
-//! but have no increment site yet.
+//! Phase 0 established the provider and Phase 1 adds retirement-proof
+//! producers. Counters owned by later phases remain registered and readable
+//! here without an increment site yet.
 
 use crate::tracing::counter::{register_counter, TraceCounter};
 use crate::tracing::provider::{register_provider, TraceProvider};
@@ -64,16 +64,24 @@ counter!(
     TEARDOWN_LOCK_ORDER_SUSPECT,
     "Suspect teardown lock ordering"
 );
-
-// Declaration-only until the phase named in PLAN.md. These intentionally have
-// no trace_count! producer in Phase 0.
-counter!(TEARDOWN_ENTRY_GROUP, "Group teardown entries");
-counter!(EXIT_SGI_SENT, "Teardown-attributed expedite SGIs");
-counter!(EXIT_REQUEST_OBSERVED, "Observed latched exit requests");
-counter!(EXIT_KICK_PUBLISHED, "Published exit-kick buckets");
-counter!(EXIT_KICK_OBSERVED, "Observed exit-kick victims");
-counter!(EXIT_KICK_BUCKET_COLLISION, "Exit-kick bucket collisions");
-counter!(RECEIPT_DROPPED_UNRETIRED, "Receipts recovered by Drop");
+counter!(ROOT_PROOF_BLOCKED_EPOCH, "Retirements blocked by epoch");
+counter!(ROOT_PROOF_BLOCKED_HW, "Retirements blocked by local TTBR0");
+counter!(
+    ROOT_PROOF_BLOCKED_SHADOW,
+    "Retirements blocked by TTBR0 shadows"
+);
+counter!(
+    ROOT_PROOF_BLOCKED_CACHED,
+    "Retirements blocked by scheduler roots"
+);
+counter!(
+    ROOT_PROOF_BLOCKED_LIVE_ROW,
+    "Retirements blocked by live process rows"
+);
+counter!(
+    RETIRE_EMPTY_ONLINE_MASK,
+    "Retirement fences refused for empty online masks"
+);
 counter!(
     RECLAIM_PASS_SKIPPED,
     "Reclaim candidates skipped in one pass"
@@ -90,6 +98,16 @@ counter!(
     "Immediately unparked reclaims"
 );
 counter!(RECLAIM_PARK_RESIDENT, "Resident parked reclaims");
+
+// Declaration-only until the phase named in PLAN.md. These intentionally have
+// no trace_count! producer yet.
+counter!(TEARDOWN_ENTRY_GROUP, "Group teardown entries");
+counter!(EXIT_SGI_SENT, "Teardown-attributed expedite SGIs");
+counter!(EXIT_REQUEST_OBSERVED, "Observed latched exit requests");
+counter!(EXIT_KICK_PUBLISHED, "Published exit-kick buckets");
+counter!(EXIT_KICK_OBSERVED, "Observed exit-kick victims");
+counter!(EXIT_KICK_BUCKET_COLLISION, "Exit-kick bucket collisions");
+counter!(RECEIPT_DROPPED_UNRETIRED, "Receipts recovered by Drop");
 counter!(LEDGER_EFFECT_AMBIGUOUS_REPORT, "Ambiguous report effects");
 counter!(
     TOMBSTONE_JOIN_REAP_SECOND,
@@ -113,7 +131,7 @@ counter!(
     "Fatal group signals dropped for init"
 );
 
-pub const COUNTER_COUNT: usize = 39;
+pub const COUNTER_COUNT: usize = 45;
 
 /// The registration and normal-context reader inventory. Keeping one inventory
 /// makes a write-only counter structurally impossible without changing the P0
@@ -138,6 +156,12 @@ pub static COUNTERS: [&TraceCounter; COUNTER_COUNT] = [
     &PROOF_UNDER_QUEUE_LOCK,
     &RECLAIM_CONTEXT_VIOLATIONS,
     &TEARDOWN_LOCK_ORDER_SUSPECT,
+    &ROOT_PROOF_BLOCKED_EPOCH,
+    &ROOT_PROOF_BLOCKED_HW,
+    &ROOT_PROOF_BLOCKED_SHADOW,
+    &ROOT_PROOF_BLOCKED_CACHED,
+    &ROOT_PROOF_BLOCKED_LIVE_ROW,
+    &RETIRE_EMPTY_ONLINE_MASK,
     &EXIT_SGI_SENT,
     &EXIT_REQUEST_OBSERVED,
     &EXIT_KICK_PUBLISHED,

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -137,16 +137,16 @@ fn function_body<'a>(source: &'a str, name: &str) -> &'a str {
 
 const TERMINATE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/interrupts/context_switch.rs", 1017),
-    ("kernel/src/process/manager.rs", 1162),
+    ("kernel/src/process/manager.rs", 1164),
     ("kernel/src/signal/delivery.rs", 225),
     ("kernel/src/signal/delivery.rs", 260),
     ("kernel/src/syscall/signal.rs", 163),
 ];
-const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 274)];
+const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 462)];
 const PRODUCTION_INIT_PID_SITES: &[(&str, usize)] = &[
-    ("kernel/src/process/manager.rs", 1179),
-    ("kernel/src/task/process_task.rs", 244),
-    ("kernel/src/task/process_task.rs", 303),
+    ("kernel/src/process/manager.rs", 1181),
+    ("kernel/src/task/process_task.rs", 432),
+    ("kernel/src/task/process_task.rs", 491),
 ];
 const TEST_INIT_PID_SITES: &[(&str, usize)] = &[
     ("kernel/src/test_userspace.rs", 84),
@@ -161,12 +161,12 @@ const QUARANTINE_CALLS: &[(&str, usize)] = &[
 ];
 const KERNEL_STACK_MUTATIONS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/syscall_entry.rs", 961),
-    ("kernel/src/process/manager.rs", 1839),
+    ("kernel/src/process/manager.rs", 1841),
     ("kernel/src/syscall/clone.rs", 252),
 ];
 const RECLAIM_ENQUEUE_CALLS: &[(&str, usize)] = &[
-    ("kernel/src/process/manager.rs", 1153),
-    ("kernel/src/task/process_task.rs", 262),
+    ("kernel/src/process/manager.rs", 1155),
+    ("kernel/src/task/process_task.rs", 450),
 ];
 const EXIT_PROCESS_CALLS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/exception.rs", 825),
@@ -182,16 +182,16 @@ const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 333),
 ];
 const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
-    &[("kernel/src/tracing/providers/teardown.rs", 528)];
+    &[("kernel/src/tracing/providers/teardown.rs", 552)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
-    ("kernel/src/task/scheduler.rs", 1740),
-    ("kernel/src/task/scheduler.rs", 1911),
-    ("kernel/src/task/scheduler.rs", 1930),
-    ("kernel/src/task/scheduler.rs", 2079),
-    ("kernel/src/task/scheduler.rs", 2167),
-    ("kernel/src/task/scheduler.rs", 2232),
-    ("kernel/src/task/scheduler.rs", 2241),
-    ("kernel/src/task/scheduler.rs", 2400),
+    ("kernel/src/task/scheduler.rs", 1820),
+    ("kernel/src/task/scheduler.rs", 1991),
+    ("kernel/src/task/scheduler.rs", 2010),
+    ("kernel/src/task/scheduler.rs", 2159),
+    ("kernel/src/task/scheduler.rs", 2247),
+    ("kernel/src/task/scheduler.rs", 2312),
+    ("kernel/src/task/scheduler.rs", 2321),
+    ("kernel/src/task/scheduler.rs", 2480),
     ("kernel/src/task/waitqueue.rs", 52),
 ];
 const RAW_SCHEDULER_LOCK_SITES: &[(&str, usize)] = &[
@@ -345,7 +345,7 @@ fn v3_structural_closures_are_exact() {
     );
     assert_exact(
         sites_matching(&sources, |line| line.contains("btrt::on_process_exit(")),
-        &[("kernel/src/task/process_task.rs", 285)],
+        &[("kernel/src/task/process_task.rs", 473)],
         "btrt::on_process_exit callers",
     );
 
@@ -360,6 +360,111 @@ fn v3_structural_closures_are_exact() {
     assert!(!provider.contains("struct KickSlot"));
     assert!(!provider.contains("trace_count!(EXIT_SGI_SENT"));
     assert!(!provider.contains("trace_count!(EXIT_KICK_PUBLISHED"));
+}
+
+#[test]
+fn phase_one_retirement_fence_and_lock_domains_are_structural() {
+    let sources = rust_sources_below("kernel/src");
+    let process = source(&sources, "kernel/src/task/process_task.rs");
+    let scheduler = source(&sources, "kernel/src/task/scheduler.rs");
+    let manager = source(&sources, "kernel/src/process/manager.rs");
+    let ttbr0 = source(&sources, "kernel/src/arch_impl/aarch64/ttbr0.rs");
+    let provider = source(&sources, "kernel/src/tracing/providers/teardown.rs");
+
+    assert_eq!(
+        process.matches("static PENDING_PROCESS_RECLAIMS:").count(),
+        1
+    );
+    assert_eq!(
+        process.matches("static PARKED_PROCESS_RECLAIMS:").count(),
+        1
+    );
+    assert!(process.contains("last_pass: u32"));
+    assert!(process.contains("proof_failures: u8"));
+    assert!(process.contains("parked: Option<ParkRecord>"));
+    assert!(process.contains("fence_at_park: scheduler::RetirementFence"));
+    assert!(process.contains("row_epoch_at_park: u64"));
+    assert!(process.contains("age_epoch_sum_at_park: u64"));
+    assert!(process.contains("const PARK_AGE_BACKSTOP_EPOCHS: u64 = 64"));
+
+    let drain = function_body(process, "reclaim_deferred_process_resources");
+    assert_eq!(drain.matches("RECLAIM_PASS_ID").count(), 1);
+    assert!(drain.contains(".fetch_add(1, Ordering::Relaxed)"));
+    let cycle = function_body(process, "reclaim_deferred_process_resources_for_pass");
+    assert!(
+        cycle.find("unpark_sweep();").unwrap() < cycle.find("PENDING_PROCESS_RECLAIMS").unwrap()
+    );
+    assert!(cycle.contains("reclaim.last_pass = my_pass"));
+    assert!(cycle.contains("pending.swap_remove(index)"));
+    assert!(cycle.contains("reclaim.cached_root_is_live()"));
+    assert!(cycle.contains("reclaim.live_row_names_root()"));
+
+    let lock_free = function_body(process, "lock_free_root_proof");
+    assert!(lock_free.contains("fence_elapsed(&self.after_epoch)"));
+    assert!(lock_free.contains("local_ttbr0_root()"));
+    assert!(lock_free.contains("is_ttbr0_root_live_in_mask"));
+    assert!(!lock_free.contains("with_scheduler"));
+    assert!(!lock_free.contains("process::manager"));
+
+    let park = function_body(process, "park_reclaim");
+    assert!(park.contains("let snapshot_at_park = scheduler::RetirementSnapshot::capture();"));
+    assert!(park.contains("let fence_at_park = snapshot_at_park.as_fence();"));
+    assert!(!park.contains("reclaim.after_epoch"));
+    let unpark = function_body(process, "unpark_sweep_with_snapshot");
+    assert!(
+        unpark.find("PARKED_PROCESS_RECLAIMS.lock()").unwrap()
+            < unpark.find("PENDING_PROCESS_RECLAIMS.lock()").unwrap()
+    );
+
+    assert!(scheduler.contains("pub(crate) struct RetirementFence"));
+    assert!(scheduler.contains("pub(crate) struct RetirementSnapshot"));
+    let capture = function_body(scheduler, "capture");
+    assert!(capture.contains("core::sync::atomic::fence(Ordering::Acquire)"));
+    let elapsed = function_body(scheduler, "fence_elapsed");
+    assert!(
+        elapsed.find("fence.online_mask == 0").unwrap()
+            < elapsed.find("(0..MAX_CPUS).all").unwrap()
+    );
+    let stack_reclaim = function_body(scheduler, "reclaim_terminated_threads");
+    assert!(
+        stack_reclaim.find("retirement_grace_elapsed").unwrap()
+            < stack_reclaim.find("is_kernel_stack_slot_live").unwrap()
+    );
+
+    assert_exact(
+        sites_matching(&sources, |line| {
+            line.contains("note_process_row_removed()")
+                && !line.contains("fn note_process_row_removed")
+        }),
+        &[("kernel/src/process/manager.rs", 1104)],
+        "ROW_REMOVAL_EPOCH bump sites",
+    );
+    assert!(function_body(manager, "remove_process").contains("self.processes.remove(&pid)"));
+    assert!(ttbr0.contains("core::arch::asm!(\"mrs {}, ttbr0_el1\""));
+
+    for counter in [
+        "ROOT_PROOF_BLOCKED_EPOCH",
+        "ROOT_PROOF_BLOCKED_HW",
+        "ROOT_PROOF_BLOCKED_SHADOW",
+        "ROOT_PROOF_BLOCKED_CACHED",
+        "ROOT_PROOF_BLOCKED_LIVE_ROW",
+        "RETIRE_EMPTY_ONLINE_MASK",
+    ] {
+        assert!(provider.contains(counter));
+    }
+    let declaration_only = provider
+        .split("// Declaration-only until the phase named in PLAN.md.")
+        .nth(1)
+        .expect("declaration-only counter boundary")
+        .split("pub const COUNTER_COUNT")
+        .next()
+        .expect("declaration-only counter terminator");
+    assert!(!declaration_only.contains("RECLAIM_PASS_SKIPPED"));
+    assert!(!declaration_only.contains("RETIRE_EMPTY_ONLINE_MASK"));
+
+    let registry = source(&sources, "kernel/src/test_framework/registry.rs");
+    assert!(registry.contains("name: \"retirement_fence_gate\""));
+    assert!(registry.contains("name: \"reclaim_progress_gate\""));
 }
 
 #[test]
@@ -389,7 +494,7 @@ fn all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates() {
         .filter_map(|rest| rest.strip_suffix(','))
         .map(str::to_owned)
         .collect();
-    assert_eq!(declarations.len(), 39);
+    assert_eq!(declarations.len(), 45);
     assert_eq!(
         readers, declarations,
         "every counter must have an inventory reader"


### PR DESCRIPTION
tranche-1 phase 2 of the ratified plan (docs/planning/teardown-unification/PLAN.md, [Phase 1 — Retirement fence + RootProof blocker taxonomy](docs/planning/teardown-unification/PLAN.md#phase-1--retirement-fence--rootproof-blocker-taxonomy)).

## What

Behaviour-preserving hardening of the deferred-reclaim retirement path:

- Replace the bare grace arrays with `RetirementFence { epochs, online_mask }` + `RetirementSnapshot` — an unconditional Acquire fence before any liveness read, with an empty/all-zero online mask now refused (counted, not silently passed).
- Replace the boolean root-liveness answer with `RootProof`'s blocker taxonomy: local hardware `TTBR0_EL1` on the proving CPU, every captured CPU's `saved_process_cr3`/`next_cr3` shadows, scheduler cached roots, and live/creating rows, each with its own counter.
- Restructure the drain (`reclaim_deferred_process_resources`) so no proof ever runs under the reclaim-queue lock (`PENDING_PROCESS_RECLAIMS`) — `RootProof` now touches SCHEDULER and PM locks the old bare boolean check did not, so lock order was reshaped to keep the queue lock out of that path.
- Four review-round-2 fixes on top of the initial hardening: reentrancy on `reclaim_deferred_process_resources` now returns early instead of only counting (avoids a live self-deadlock now that `live_row_names_root()`/`cached_root_is_live()` acquire the same non-reentrant locks internally); `next_reclaim_pass_id` no longer wraps to the reserved `0` "never scanned" sentinel; `any_cached_ttbr0_matches` now excludes `ThreadState::Terminated` threads so the Cached blocker's non-firing on the normal exit path is a real invariant, not reclaim-order luck.

No observable behaviour change — this is proof scaffolding, counters, and lock-order hardening around the existing reclaim/retirement decision, not a new decision.

## Gate evidence

**aarch64 (primary gate for this tranche):**
- `run-aarch64-full-test.sh --boot-tests-only`: 88/88 PASS, clean.
- 14/14 completed 6x SMP=4 boots via `run-aarch64-boot-test-native.sh` covering the new `retirement_fence_gate` and `reclaim_progress_gate` boot_tests: PASS, zero fault markers. One run hit an unrelated `timer:timer_delay` flake under 4-way host contention (sibling of the documented pre-existing timer-flake family, not a P1 regression).
- 5/5 `teardown_structure` ratchet tests (`tests/teardown_structure.rs`), plus `fork_exit_defer_reclaim_pairing_test` and `deferred_fault_ring_overflow_injection` boot_tests: PASS.
- `run-aarch64-boot-test-strict.sh` reproducibly fails independent of this branch: `-cpu cortex-a72` produces zero bytes of serial output on this host's QEMU 11.0.3 while `-cpu max` (used by the native/gate scripts above) works fine — isolated by swapping only the CPU flag on an otherwise identical invocation, confirmed pre-existing/environmental.
- x86_64 / aarch64-plain / aarch64 `ec0_fault_inject` builds: zero warnings across all three.

**beast x86 (secondary, informational):**
- `kthread_test_only` boot gate PASSES natively via KVM on the beast host (~11s).
- The canonical full boot (`testing,external_test_bins`) still hangs forever at `RING3_SMOKE` on x86_64 on any host/accelerator — this is the pre-existing #498 defect (`Completion::wait_timeout_inner`'s x86 boot-thread spin path discards its computed deadline and never times out), unrelated to this branch's changes and tracked separately. It does not gate this tranche; x86 full-boot trust is being restored before P2 per the operator-approved sequencing.

**P1 acceptance criteria (PLAN.md Phase 1):** grace still checked first; empty/all-zero online mask refuses (`RETIRE_EMPTY_ONLINE_MASK`) instead of passing on zero atomic loads; `RootProof` blocker taxonomy replaces the boolean answer with per-blocker counters; no proof runs under `PENDING_PROCESS_RECLAIMS`. All met per the diff + gates above.

FROZEN gold-master regions and Tier-1/Tier-2 files are byte-identical vs pre-branch `main`.

## Related

Related to #491, #464, #471 (teardown-unification tranche context — not closed by this PR).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
