### PR TITLE
fix(run.sh): keep coreaudio output, drop failing capture stream; add --no-audio

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,7 @@
 #   ./run.sh --ahci --headless # ARM64 AHCI with serial output only
 #   ./run.sh --btrt            # ARM64 BTRT structured boot test
 #   ./run.sh --btrt --x86      # x86_64 BTRT structured boot test
+#   ./run.sh --no-audio        # Disable audio entirely (default: coreaudio output on)
 #
 # Display:
 #   ARM64:  Native window (cocoa) - no VNC needed
@@ -47,6 +48,7 @@ DEBUG=false
 REBUILD_HOME=false
 RESOLUTION=""
 USE_AHCI=false
+NO_AUDIO=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -102,6 +104,10 @@ while [[ $# -gt 0 ]]; do
             USE_AHCI=true
             shift
             ;;
+        --no-audio)
+            NO_AUDIO=true
+            shift
+            ;;
         --rebuild-home)
             REBUILD_HOME=true
             shift
@@ -135,6 +141,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --graphics, --vnc          Run with VNC display (default)"
             echo "  --btrt                     Run BTRT structured boot test"
             echo "  --ahci                     Use AHCI (SATA) disk instead of virtio-blk (ARM64)"
+            echo "  --no-audio                 Disable audio entirely (default: coreaudio output on)"
             echo "  --debug                    Enable GDB stub (port 1234) for debugging"
             echo "  --resolution WxH           Set display resolution (e.g. 1920x1080)"
             echo "                             Default: auto-detect from screen"
@@ -1004,11 +1011,21 @@ else
 fi
 
 # Audio options (VirtIO sound device)
-AUDIO_OPTS="-audiodev coreaudio,id=audio0"
-if [ "$ARCH" = "arm64" ]; then
-    AUDIO_OPTS="$AUDIO_OPTS -device virtio-sound-device,audiodev=audio0"
+# NOTE: virtio-sound normally creates BOTH a playback (out) and a capture (in)
+# PCM stream. macOS coreaudio can open the playback stream fine, but cannot
+# open a capture stream in this environment ("Can not open `virtio-sound.in'
+# (no host audio driver)"), which aborts device realization and QEMU never
+# boots. streams=1 limits the device to just the playback stream, keeping
+# audio OUTPUT working while dropping the failing capture stream.
+if [ "$NO_AUDIO" = true ]; then
+    AUDIO_OPTS="-audiodev none,id=audio0"
 else
-    AUDIO_OPTS="$AUDIO_OPTS -device virtio-sound-pci,audiodev=audio0"
+    AUDIO_OPTS="-audiodev coreaudio,id=audio0"
+    if [ "$ARCH" = "arm64" ]; then
+        AUDIO_OPTS="$AUDIO_OPTS -device virtio-sound-device,audiodev=audio0,streams=1"
+    else
+        AUDIO_OPTS="$AUDIO_OPTS -device virtio-sound-pci,audiodev=audio0,streams=1"
+    fi
 fi
 
 # QMP socket for programmatic VM control (always enabled)


### PR DESCRIPTION
## Diagnosis

`run.sh` set `AUDIO_OPTS="-audiodev coreaudio,id=audio0"` then attached
`-device virtio-sound-device,audiodev=audio0` (ARM64) / `virtio-sound-pci`
(x86_64). virtio-sound realizes **two** PCM streams by default: a playback
("out") stream and a capture ("in") stream. macOS coreaudio can open the
playback stream fine, but cannot open a capture stream in this environment:

```
qemu-system-aarch64: -device virtio-sound-device,audiodev=audio0: audio: Can not open `virtio-sound.in' (no host audio driver)
```

That failure aborts virtio-sound device realization, which prevents the
`virt` machine from ever starting its vCPUs — QEMU never boots the kernel
or opens a window.

## Fix (output-preserving)

- Default audio path now passes `streams=1` to the virtio-sound device
  (both ARM64 `virtio-sound-device` and x86_64 `virtio-sound-pci`). This
  limits the device to just the playback stream, so QEMU never attempts
  to open the failing capture stream. `-audiodev coreaudio,id=audio0`
  output is otherwise unchanged — audio output keeps working.
- Added a `--no-audio` opt-out (`-audiodev none,id=audio0`, no
  virtio-sound device at all) for anyone who wants to disable audio
  entirely. The default path is never `-audiodev none`.

## Verification (native ARM64 QEMU on this Mac, isolated `/tmp` boot tests using the exact built kernel + built ext2 image)

Before fix — capture-stream realize failure blocks boot immediately:
```
qemu-system-aarch64: -device virtio-sound-device,audiodev=audio0: audio: Can not open `virtio-sound.in' (no host audio driver)
```
(confirmed via HMP monitor: vCPU threads never start — `info cpus`/`info
registers` are unreachable in a meaningful state because device realize()
aborts before the machine finishes starting.)

After fix (`streams=1`) — no audio error at all; QMP/HMP confirms the VM
reaches `VM status: running` with all 4 vCPU threads alive, and a full
build+boot with `-cpu max` (see note below) prints hundreds of kernel
boot/test lines with zero audio errors. The launched cmdline retains a
coreaudio **output** audiodev:
```
-audiodev coreaudio,id=audio0 -device virtio-sound-device,audiodev=audio0,streams=1
```

`--no-audio` equivalent (`-audiodev none,id=audio0`, no virtio-sound
device) also boots cleanly with zero audio-related output.

**Note on `./run.sh --headless` literal banner verification:** while
verifying, I found that `run.sh`'s ARM64 invocation (`-cpu cortex-a72`,
no explicit `gic-version=3`) fails to boot *at all* on this machine's
QEMU 11.0.3 — completely independent of audio (reproduced with
`-audiodev none` and no virtio-sound device too; CPU sits at
`PC=0x200`/`EL1h`, i.e. an early synchronous exception, and never
advances). Swapping in `-cpu max` (keeping everything else, including
this PR's `streams=1` audio fix) boots the kernel cleanly to hundreds of
lines of test/boot output. This is a **separate, pre-existing bug**
unrelated to audio — previously masked because the audio capture-stream
abort always failed first, before the CPU model issue could ever
surface. It's out of scope for this minimal audio fix (a `cpu`/`gic`
config change is unrelated to `AUDIO_OPTS`), and there's already an
active branch in this repo (`fix/x86-boot-hang-498`) that suggests
boot-hang issues are being tracked separately. Flagging for visibility
rather than fixing here.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>