### PR TITLE
fix: x86 full boot no longer hangs at RING3_SMOKE (#498)

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -999,10 +999,23 @@ fn kernel_main_continue() -> ! {
     // refactored to iterate the shared list. See boot/test_list.rs for details.
     #[cfg(all(feature = "testing", not(feature = "interactive")))]
     {
+        // Disk-backed test binaries require VirtIO block IRQ completions.
+        x86_64::instructions::interrupts::enable();
+        let elf = userspace_test::get_test_binary("hello_time");
+        let register_test_buf = kernel::userspace_test::get_test_binary("register_init_test");
+        let clock_test_buf = kernel::userspace_test::get_test_binary("clock_gettime_test");
+        let brk_test_buf = kernel::userspace_test::get_test_binary("brk_test");
+        let test_mmap_buf = kernel::userspace_test::get_test_binary("test_mmap");
+        let diagnostic_test_buf =
+            kernel::userspace_test::get_test_binary("syscall_diagnostic_test");
+        let udp_test_buf = kernel::userspace_test::get_test_binary("udp_socket_test");
+        let tcp_test_buf = kernel::userspace_test::get_test_binary("tcp_socket_test");
+        let dns_test_buf = kernel::userspace_test::get_test_binary("dns_test");
+        let http_test_buf = kernel::userspace_test::get_test_binary("http_test");
+
         x86_64::instructions::interrupts::without_interrupts(|| {
             use alloc::string::String;
             log::info!("RING3_SMOKE: creating hello_time userspace process (early)");
-            let elf = userspace_test::get_test_binary("hello_time");
             match process::creation::create_user_process(String::from("smoke_hello_time"), &elf) {
                 Ok(pid) => {
                     log::info!(
@@ -1018,8 +1031,6 @@ fn kernel_main_continue() -> ! {
             // Launch register_init_test to verify registers are properly initialized
             {
                 serial_println!("RING3_SMOKE: creating register_init_test userspace process");
-                let register_test_buf =
-                    kernel::userspace_test::get_test_binary("register_init_test");
                 match process::creation::create_user_process(
                     String::from("register_init_test"),
                     &register_test_buf,
@@ -1039,7 +1050,6 @@ fn kernel_main_continue() -> ! {
             // Launch clock_gettime_test after hello_time
             {
                 serial_println!("RING3_SMOKE: creating clock_gettime_test userspace process");
-                let clock_test_buf = kernel::userspace_test::get_test_binary("clock_gettime_test");
                 match process::creation::create_user_process(
                     String::from("clock_gettime_test"),
                     &clock_test_buf,
@@ -1059,7 +1069,6 @@ fn kernel_main_continue() -> ! {
             // Launch brk_test to validate heap management syscall
             {
                 serial_println!("RING3_SMOKE: creating brk_test userspace process");
-                let brk_test_buf = kernel::userspace_test::get_test_binary("brk_test");
                 match process::creation::create_user_process(
                     String::from("brk_test"),
                     &brk_test_buf,
@@ -1076,7 +1085,6 @@ fn kernel_main_continue() -> ! {
             // Launch test_mmap to validate mmap/munmap syscalls
             {
                 serial_println!("RING3_SMOKE: creating test_mmap userspace process");
-                let test_mmap_buf = kernel::userspace_test::get_test_binary("test_mmap");
                 match process::creation::create_user_process(
                     String::from("test_mmap"),
                     &test_mmap_buf,
@@ -1093,8 +1101,6 @@ fn kernel_main_continue() -> ! {
             // Launch syscall_diagnostic_test to isolate register corruption bug
             {
                 serial_println!("RING3_SMOKE: creating syscall_diagnostic_test userspace process");
-                let diagnostic_test_buf =
-                    kernel::userspace_test::get_test_binary("syscall_diagnostic_test");
                 match process::creation::create_user_process(
                     String::from("syscall_diagnostic_test"),
                     &diagnostic_test_buf,
@@ -1114,7 +1120,6 @@ fn kernel_main_continue() -> ! {
             // Launch UDP socket test to verify network syscalls from userspace
             {
                 serial_println!("RING3_SMOKE: creating udp_socket_test userspace process");
-                let udp_test_buf = kernel::userspace_test::get_test_binary("udp_socket_test");
                 match process::creation::create_user_process(
                     String::from("udp_socket_test"),
                     &udp_test_buf,
@@ -1131,7 +1136,6 @@ fn kernel_main_continue() -> ! {
             // Launch TCP socket test to verify TCP syscalls from userspace
             {
                 serial_println!("RING3_SMOKE: creating tcp_socket_test userspace process");
-                let tcp_test_buf = kernel::userspace_test::get_test_binary("tcp_socket_test");
                 match process::creation::create_user_process(
                     String::from("tcp_socket_test"),
                     &tcp_test_buf,
@@ -1148,7 +1152,6 @@ fn kernel_main_continue() -> ! {
             // Launch DNS test to verify DNS resolution using UDP sockets
             {
                 serial_println!("RING3_SMOKE: creating dns_test userspace process");
-                let dns_test_buf = kernel::userspace_test::get_test_binary("dns_test");
                 match process::creation::create_user_process(
                     String::from("dns_test"),
                     &dns_test_buf,
@@ -1165,7 +1168,6 @@ fn kernel_main_continue() -> ! {
             // Launch HTTP test to verify HTTP client over TCP+DNS
             {
                 serial_println!("RING3_SMOKE: creating http_test userspace process");
-                let http_test_buf = kernel::userspace_test::get_test_binary("http_test");
                 match process::creation::create_user_process(
                     String::from("http_test"),
                     &http_test_buf,
@@ -1659,10 +1661,10 @@ fn kernel_main_continue() -> ! {
     // Must be done after interrupts are enabled but before other tests
     #[cfg(all(feature = "testing", not(feature = "interactive")))]
     {
+        let elf = userspace_test::get_test_binary("hello_time");
         x86_64::instructions::interrupts::without_interrupts(|| {
             use alloc::string::String;
             serial_println!("RING3_SMOKE: creating hello_time userspace process (early)");
-            let elf = userspace_test::get_test_binary("hello_time");
             match process::create_user_process(String::from("smoke_hello_time"), &elf) {
                 Ok(pid) => {
                     serial_println!(

--- a/kernel/src/task/completion.rs
+++ b/kernel/src/task/completion.rs
@@ -227,26 +227,18 @@ impl Completion {
             fence(Ordering::SeqCst);
 
             // Compute deadline using the ARM64 free-running counter.
+            #[cfg(target_arch = "aarch64")]
             let deadline_cntpct = {
-                #[cfg(target_arch = "aarch64")]
-                {
-                    let cnt: u64;
-                    let freq: u64;
-                    unsafe {
-                        core::arch::asm!("mrs {}, cntpct_el0", out(reg) cnt, options(nomem, nostack));
-                        core::arch::asm!("mrs {}, cntfrq_el0", out(reg) freq, options(nomem, nostack));
-                    }
-                    // Convert ns timeout to counter ticks.
-                    // freq is in Hz; timeout_ns / 1e9 * freq = timeout_ns * freq / 1e9.
-                    let ticks = (timeout_ns as u128 * freq as u128 / 1_000_000_000) as u64;
-                    cnt.wrapping_add(ticks)
+                let cnt: u64;
+                let freq: u64;
+                unsafe {
+                    core::arch::asm!("mrs {}, cntpct_el0", out(reg) cnt, options(nomem, nostack));
+                    core::arch::asm!("mrs {}, cntfrq_el0", out(reg) freq, options(nomem, nostack));
                 }
-                #[cfg(not(target_arch = "aarch64"))]
-                {
-                    // On x86_64 AHCI is not the primary driver; use a large
-                    // sentinel so the loop below is effectively unbounded.
-                    u64::MAX
-                }
+                // Convert ns timeout to counter ticks.
+                // freq is in Hz; timeout_ns / 1e9 * freq = timeout_ns * freq / 1e9.
+                let ticks = (timeout_ns as u128 * freq as u128 / 1_000_000_000) as u64;
+                cnt.wrapping_add(ticks)
             };
             let deadline_ns = {
                 #[cfg(target_arch = "aarch64")]
@@ -257,7 +249,8 @@ impl Completion {
                 }
                 #[cfg(not(target_arch = "aarch64"))]
                 {
-                    u64::MAX
+                    let (secs, nanos) = crate::time::get_monotonic_time_ns();
+                    (secs * 1_000_000_000 + nanos).saturating_add(timeout_ns)
                 }
             };
 
@@ -396,7 +389,13 @@ impl Completion {
                     }
                     #[cfg(not(target_arch = "aarch64"))]
                     {
-                        let _ = deadline_cntpct;
+                        let (secs, nanos) = crate::time::get_monotonic_time_ns();
+                        let now_ns = secs * 1_000_000_000 + nanos;
+                        if now_ns >= deadline_ns {
+                            self.waiter.store(0, Ordering::Release);
+                            restore_syscall_preempt_state();
+                            return Ok(false);
+                        }
                     }
                 }
             } else {
@@ -436,7 +435,12 @@ impl Completion {
                     }
                     #[cfg(not(target_arch = "aarch64"))]
                     {
-                        let _ = deadline_cntpct;
+                        let (secs, nanos) = crate::time::get_monotonic_time_ns();
+                        let now_ns = secs * 1_000_000_000 + nanos;
+                        if now_ns >= deadline_ns {
+                            self.waiter.store(0, Ordering::Release);
+                            return Ok(false);
+                        }
                         core::hint::spin_loop();
                     }
                 }


### PR DESCRIPTION
Closes #498

## What

Two-part fix for the deterministic, 100%-reproducible x86_64 full-boot hang at `RING3_SMOKE` (`--features testing,external_test_bins`), which spun forever (CPU-pegged, zero progress observed for 400s+ under TCG and 240s+ under KVM) instead of ever reaching userspace:

1. **Deadline-honoring backstop in the x86 completion boot-thread-spin arm** (`kernel/src/task/completion.rs`) — `Completion::wait_timeout_inner()`'s "boot-thread spin path" (taken whenever a scheduler thread exists but the caller is outside syscall context, exactly `RING3_SMOKE`'s situation) computed a TSC-free-running-counter-equivalent deadline on x86_64 but then discarded it (`let _ = deadline_cntpct;`) and spun on `core::hint::spin_loop()` unconditionally, with **no timeout at all**. The aarch64 sibling arm, two lines up, already enforced its `cntpct_el0` deadline correctly. Fixed by computing a real TSC/monotonic-clock-backed `deadline_ns` on x86_64 (mirroring the aarch64 pattern) and enforcing it in both wait arms (syscall-sleep path and boot-thread-spin path), returning `Ok(false)` on expiry instead of spinning forever.
2. **The virtio-blk completion-observation fix** (`kernel/src/main.rs`) — the actual reason the completion was never signalled in the first place: every `RING3_SMOKE` test binary load (`userspace_test::get_test_binary(...)`, which issues a virtio-blk disk read and waits on its IRQ-signalled completion) was called *inside* the `x86_64::instructions::interrupts::without_interrupts(...)` closure used to make process registration atomic. With interrupts masked for the entire closure, the virtio-blk completion IRQ could never be delivered, so the read's completion was never observed — the wait was structurally unwinnable, not just slow. Fixed by hoisting every `get_test_binary()` call out of the `without_interrupts()` closures (both the early-boot and post-interrupts-enabled `RING3_SMOKE` blocks) and enabling interrupts before the disk loads, while keeping process *registration* itself inside the atomic section.

## Root cause (dual RCA)

Issue #498 pinned half 1 (the missing x86 timeout) but left half 2 unpinned ("the underlying virtio-blk read completion never arrives at this call site... investigation was time-boxed before fully pinning why"). This round's dual RCA (independent beast-host reproduction + GDB/serial investigation, reconciled) pinned half 2: the completion was unsignalable by construction because the IRQ that signals it was masked for the full duration of the wait. Half 1 alone (a timeout) would only have converted the silent infinite hang into an observable `Err("Block request timed out")` panic — every disk-backed boot would still fail. Both halves were required to actually reach userspace.

## Gate evidence

**x86_64 (beast host, `breenix-x86` VM, KVM):** fresh `cargo build --release --features testing,external_test_bins --bin qemu-uefi` (0 warnings, 14s) + boot of `fix/x86-boot-hang-498`@`62af9d13` reaches and passes well beyond `RING3_SMOKE`:
- `[ OK ] RING3_SMOKE: userspace executed + syscall path verified` (previously: never reached — infinite spin at the line just before this)
- Progresses through `register_init_test`, `clock_gettime_test`, `brk_test` (`USERSPACE BRK: ALL TESTS PASSED`), `test_mmap` (`USERSPACE MMAP: ALL TESTS PASSED`), `syscall_diagnostic_test`, `udp_socket_test`, `tcp_socket_test`, `dns_test`, and into `http_test`
- Reproduced under both KVM and TCG acceleration in the earlier dual-RCA pass, confirming the fix is real and not an accel-backend artifact

Previously (pre-fix, main@985881a6 and this branch's base): the identical boot deterministically hung forever at `RING3_SMOKE: creating hello_time userspace process (early)` — 100% CPU spin, zero further log output, for 400s+ (TCG) / 240s+ (KVM), on every single run.

**aarch64: unaffected.** `kernel/src/main.rs` is the x86_64 UEFI entry point only (`bootloader_api::BootInfo`, gated by the crate's `#![cfg_attr(not(target_arch = "x86_64"), allow(unused_imports))]`); aarch64 boots through a separate entry path entirely. `kernel/src/task/completion.rs`'s changes are scoped to the `#[cfg(not(target_arch = "aarch64"))]` arms only — the `#[cfg(target_arch = "aarch64")]` arms (both the `deadline_cntpct` computation and the two wait loops' timeout checks) are structurally untouched.

## New finding, out of scope

`http_test` now reaches a previously-unreachable instruction-fetch page fault (`err=0x15`, `U=1 P=1`) right after `[http] DNS resolved`, at a consistent code offset across runs and both accel backends — a genuine pre-existing bug that was masked until x86 boot could get this far at all. Not touched here; recommend a follow-up issue/RCA.

## Testing-integrity note

`docker/qemu/run-boot-parallel.sh` kills QEMU after early kthread/workqueue markers, before `RING3_SMOKE` (or any userspace process) ever runs — so its "PASS" has never actually exercised x86 userspace. With this fix, x86 boots can now genuinely reach and run userspace, so a follow-up should tighten `run-boot-parallel.sh`'s gate criteria to require real `RING3_SMOKE`/userspace markers instead of early kthread-only signals.