### PR TITLE
fix: x86 #498 follow-up — post-merge review + userspace-marker gate

### DIFF
--- a/docker/qemu/run-boot-parallel.sh
+++ b/docker/qemu/run-boot-parallel.sh
@@ -51,10 +51,16 @@ for i in $(seq 1 $COUNT); do
     echo "  Started test $i"
 done
 
-# Wait for all to complete - look for kthread markers (they run early in boot)
+# Wait for all to complete - look for kthread markers (they run early in boot),
+# then require proof that userspace actually executed (RING3_SMOKE), not just
+# the early kthread markers. See #498 post-merge review: this gate historically
+# declared PASS before userspace ever ran.
 echo "Waiting for kthread tests to complete (120s timeout)..."
 PASSED=0
 FAILED=0
+# Emitted via raw_serial_str() on COM1 (kernel/src/interrupts/context_switch.rs)
+# on the FIRST entry to userspace, so it lands in serial_user.txt.
+USERSPACE_MARKER="RING3_SMOKE: userspace executed + syscall path verified"
 
 for i in $(seq 1 $COUNT); do
     OUTPUT_DIR="/tmp/breenix_boot_$i"
@@ -72,8 +78,25 @@ for i in $(seq 1 $COUNT); do
     if $FOUND; then
         # Check if kthread tests actually passed
         if grep -q "KTHREAD_EXIT: kthread exited cleanly" "$OUTPUT_DIR/serial_kernel.txt" 2>/dev/null; then
-            echo "  Test $i: PASS"
-            PASSED=$((PASSED + 1))
+            # Kthread markers alone don't prove userspace ever ran - wait for
+            # the RING3_SMOKE marker emitted on first entry to Ring 3.
+            USERSPACE_FOUND=false
+            for j in $(seq 1 90); do
+                if grep -q "$USERSPACE_MARKER" "$OUTPUT_DIR/serial_user.txt" 2>/dev/null; then
+                    USERSPACE_FOUND=true
+                    break
+                fi
+                sleep 1
+            done
+
+            if $USERSPACE_FOUND; then
+                echo "  Test $i: PASS"
+                PASSED=$((PASSED + 1))
+            else
+                echo "  Test $i: FAIL (userspace never executed - RING3_SMOKE marker not found)"
+                tail -10 "$OUTPUT_DIR/serial_user.txt" 2>/dev/null || echo "    (no output)"
+                FAILED=$((FAILED + 1))
+            fi
         else
             echo "  Test $i: FAIL (kthread didn't exit cleanly)"
             FAILED=$((FAILED + 1))

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -999,6 +999,31 @@ fn kernel_main_continue() -> ! {
     // refactored to iterate the shared list. See boot/test_list.rs for details.
     #[cfg(all(feature = "testing", not(feature = "interactive")))]
     {
+        // Disk-backed test binaries require VirtIO block IRQ completions, so
+        // interrupts must be hardware-enabled here and must STAY enabled for
+        // the rest of this boot-time test-registration phase: every
+        // get_test_binary() call in the dozens of test_exec::test_*()
+        // functions invoked later in this function also loads from disk and
+        // needs the same IRQ completion (confirmed: unconditionally
+        // re-disabling interrupts here causes those later calls to panic
+        // with "DISK LOADING FAILED" - the IRQ can never be serviced).
+        //
+        // preempt_disable() is used (not interrupts::disable()) so the boot
+        // thread's scheduling is gated by preempt_count rather than the raw
+        // interrupt flag, keeping IRQs serviceable. This closes the
+        // documented-invariant violation the post-#498-merge review flagged
+        // (PRECONDITION 7 below now checks the real guard, preempt_count,
+        // instead of the interrupt flag) and matches this function's
+        // documented intent that scheduling should not happen until the
+        // deliberate preempt_enable()/interrupts::enable() pair near the end
+        // of this function. NOTE: real boot testing shows the timer
+        // interrupt can still switch away from the boot thread during the
+        // busy-spin disk-completion wait in this window (a pre-existing gap
+        // between preempt_count and this kernel's actual can_schedule()
+        // logic, not something this change introduces or fully closes) -
+        // see the PR that added this comment for full investigation notes
+        // and the recommended follow-up RCA.
+        kernel::per_cpu::preempt_disable();
         // Disk-backed test binaries require VirtIO block IRQ completions.
         x86_64::instructions::interrupts::enable();
         let elf = userspace_test::get_test_binary("hello_time");
@@ -1580,15 +1605,20 @@ fn kernel_main_continue() -> ! {
         false
     };
 
-    // PRECONDITION 7: Interrupts Currently Disabled
-    log::info!("PRECONDITION 7: Verifying interrupts are currently disabled...");
-    let interrupts_enabled = interrupts::are_interrupts_enabled();
-    if !interrupts_enabled {
-        log::info!("PRECONDITION 7: Interrupts disabled ✓ PASS");
-        log::info!("  Ready to enable interrupts safely");
+    // PRECONDITION 7: Preemption Currently Disabled
+    // (Interrupts are intentionally already hardware-enabled by this point -
+    // see the preempt_disable()/interrupts::enable() pair in the first
+    // RING3_SMOKE block above, needed for disk-backed test binary loads.
+    // preempt_count is the real invariant guarding against premature
+    // scheduling during this boot-time test-registration phase.)
+    log::info!("PRECONDITION 7: Verifying preemption is currently disabled...");
+    let preemption_disabled = kernel::per_cpu::preempt_count() > 0;
+    if preemption_disabled {
+        log::info!("PRECONDITION 7: Preemption disabled ✓ PASS");
+        log::info!("  Ready to enable preemption safely");
     } else {
-        log::error!("PRECONDITION 7: Interrupts disabled ✗ FAIL");
-        log::error!("  Interrupts are already enabled! This should not happen.");
+        log::error!("PRECONDITION 7: Preemption disabled ✗ FAIL");
+        log::error!("  Preemption is not disabled! This should not happen.");
     }
 
     log::info!("================================================================");
@@ -1599,7 +1629,7 @@ fn kernel_main_continue() -> ! {
         && irq0_unmasked
         && has_runnable.unwrap_or(false)
         && has_current_thread
-        && !interrupts_enabled;
+        && preemption_disabled;
 
     if all_passed {
         log::info!("✓ ALL PRECONDITIONS PASSED - Safe to enable interrupts");
@@ -1614,9 +1644,11 @@ fn kernel_main_continue() -> ! {
     time_test::test_timer_resolution();
     log::info!("✅ Timer resolution test passed");
 
-    // Test our clock_gettime implementation BEFORE enabling interrupts
-    // This must run before interrupts are enabled because once interrupts are on,
-    // the scheduler will preempt to userspace and this code will never execute.
+    // Test our clock_gettime implementation BEFORE enabling preemption.
+    // Interrupts are already hardware-enabled at this point (see the first
+    // RING3_SMOKE block above); preemption is intended to still be disabled
+    // via preempt_disable() called there (see that comment for a known gap:
+    // the timer can still switch away during a disk-completion busy-wait).
     log::info!("Testing clock_gettime syscall implementation...");
     clock_gettime_test::test_clock_gettime();
     log::info!("✅ clock_gettime tests passed");
@@ -1649,6 +1681,12 @@ fn kernel_main_continue() -> ! {
     // registered test processes have completed.
     #[cfg(all(feature = "btrt", not(feature = "testing")))]
     kernel::test_framework::btrt::finalize();
+
+    // Release the scheduling brake taken in the first RING3_SMOKE block
+    // above (see its preempt_disable() comment) - this is the true,
+    // intended start of preemption for userspace processes registered
+    // since then.
+    kernel::per_cpu::preempt_enable();
 
     // Enable interrupts for preemptive multitasking - userspace processes will now run
     // WARNING: After this call, kernel_main will likely be preempted immediately


### PR DESCRIPTION
## Review verdict: two blockers confirmed real, both closed with a corrected fix (not the literal suggested one)

Closes the #498 post-merge review on PR #506.

**Blocker 1** (`kernel/src/main.rs:1003`) and **Blocker 2** (`kernel/src/main.rs:1621`) are both real: the first RING3_SMOKE block's `interrupts::enable()` is never balanced by a `disable()`, leaving interrupts hardware-enabled for the remaining ~650 lines of `kernel_main_continue()` and silently violating the function's documented "interrupts stay off until the deliberate final enable" invariant. Confirmed independently: `PRECONDITION 7` (a self-check a few hundred lines later) was already false-failing on every boot as a direct result.

**The literal suggested fix (just re-add `interrupts::disable()`) was tried and rejected** — real boot testing showed it causes a regression worse than the current state: the kernel panics almost immediately (`FATAL: DISK LOADING FAILED`), because ~50 `test_exec::test_*()` functions later in the same section *also* call `get_test_binary()` (disk-backed, VirtIO-IRQ-driven), and none of them can complete with interrupts masked.

**Actual fix**: use the kernel's existing `preempt_disable()`/`preempt_enable()` primitive instead of the raw interrupt flag. Interrupts stay hardware-enabled throughout this phase (so every later disk load keeps working), while `preempt_count` gates scheduling so the boot thread isn't switched away early — matching this kernel's own `can_schedule()` logic (`current_preempt == 0` gates the timer-driven switch). `PRECONDITION 7` now checks `preempt_count` (the real invariant) instead of the interrupt flag, so it no longer false-fails.

**Known limitation** (confirmed via direct boot testing, documented inline at the `preempt_disable()` call site, left for a dedicated follow-up RCA): the timer interrupt can still switch away from the boot thread during the busy-spin disk-completion wait inside this window, so the ~450 lines of `test_exec::test_*()` calls do not reliably run to completion today. This is a **pre-existing gap** between `preempt_count` and this kernel's `can_schedule()` logic — reproduced identically on unmodified merged `main` (same "boot thread never regains the CPU once other threads are runnable" behavior, just triggered earlier by this change). This fix does **not** make boot behavior worse than currently-merged main: RING3_SMOKE fires and all 10 first-block userspace test processes still run and exit cleanly on every observed boot, same as before.

Also confirmed via direct testing: an unrelated, pre-existing instruction-fetch page fault (the same class of issue PR #506 flagged as out-of-scope for `http_test`) also reproduces earlier, on the very first userspace process, under concurrent-boot resource contention on this Mac — on **both** this branch and unmodified merged main. Not touched here.

## Gate tightened to require real userspace execution

`docker/qemu/run-boot-parallel.sh` declared PASS on early kthread-join markers alone, before RING3_SMOKE or any userspace process ever ran (called out explicitly in PR #506's own testing-integrity note). It now additionally waits for and requires the RING3_SMOKE userspace-execution marker (`kernel/src/interrupts/context_switch.rs:219`, emitted on COM1 → `serial_user.txt`) on top of the existing kthread markers.

The beast runner's `/root/run-x86-gate.sh` `full` mode was inspected (it's VM-local, not in this repo) and found to already require a genuine, late userspace-completion marker (`USERSPACE TEST COMPLETE`, strictly downstream of RING3_SMOKE — fires only once every registered userspace test process has exited) — no change needed there.

## Verification

- x86 (`--features testing,external_test_bins`) and aarch64 both build with **zero warnings**.
- aarch64 (unaffected — `kernel/src/main.rs` is x86_64-only, per PR #506's own note): **2 clean smp=4 native smoke boots** (`./docker/qemu/run-aarch64-boot-test-native.sh`).
- x86: gate script (`docker/qemu/run-boot-parallel.sh`) confirmed **PASS** against a real boot with the new marker check; RING3_SMOKE fires and all 10 first-block userspace test processes run to completion on every single-instance boot observed.
- Frozen gold-master regions and Tier-1 prohibited files: untouched.

References PR #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>