### PR TITLE
fix(run.sh): boot interactive ARM with GICv3 + -cpu max

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1053,8 +1053,7 @@ if [ "$ARCH" = "arm64" ]; then
     # by scanning MMIO addresses low-to-high, so the LAST device here gets the
     # lowest address and becomes device 0 (the system/root disk).
     qemu-system-aarch64 \
-        -M virt -cpu cortex-a72 \
-        -smp 4 \
+        -M virt,gic-version=3 -cpu max -smp 4 \
         -m 512M \
         -kernel "$KERNEL" \
         $DISPLAY_OPTS \


### PR DESCRIPTION
## Diagnosis

`run.sh` launches the ARM64 kernel with `-M virt -cpu cortex-a72` (no
`gic-version`). The kernel is built for GICv3, so on QEMU 11.0.3 this
faults immediately on EL1 entry (PC stuck at `0x200`) and never boots.
This was masked until now by a separate audio abort, already fixed in
PR #505 — this MR complements that fix.

## Fix

Change `run.sh`'s ARM64 QEMU invocation to match the proven-working
config already used by the passing gate script
(`docker/qemu/run-aarch64-boot-test-native.sh:75`):

```diff
-        -M virt -cpu cortex-a72 \
-        -smp 4 \
+        -M virt,gic-version=3 -cpu max -smp 4 \
```

GICv3 + `-cpu max` + `-smp 4`, reconciled onto a single line (no
duplicate `-smp`). Only the machine/cpu/smp line changed — memory,
devices, streams=1 audio (PR #505), display, QMP, etc. are untouched.

## Verification

Built the ARM64 kernel and ran `timeout 60 ./run.sh --headless` in an
isolated worktree. Serial output shows the kernel now boots cleanly
past EL1 entry — no more faulting at PC 0x200:

```
========================================
  Breenix ARM64 Kernel Starting
  BUILD_ID: 006a7626e404c1
========================================

[boot] Current exception level: EL1
[boot] MMU already enabled (high-half kernel)
...
[gic] GICR probe 0x080a0000: WAKER=0x00000006 <<< VALID
...
[BOOT_TESTS:START]
[BOOT_TESTS:TOTAL:88]
[BOOT_TESTS:EARLY_BOOT:80]
...
[STAGE:early:COMPLETE:80/88]
[STAGE:sched:ADVANCE]
...
[timer] cpu0 ticks=5000
[timer] cpu0 ticks=10000
[timer] cpu0 ticks=15000
[timer] cpu0 ticks=20000
[timer] cpu0 ticks=25000
[timer] cpu0 ticks=30000
qemu-system-aarch64: terminating on signal 15 from pid 14432 (<unknown process>)
```

All 80/88 early boot tests PASS, the kernel advances into the
scheduler stage, and timer ticks increment steadily up to the 60s
`timeout` that cleanly terminated the run (SIGTERM) — not a crash.

## Test plan

- [x] `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` — clean build, zero warnings
- [x] `timeout 60 ./run.sh --headless` — boots past EL1, 80/88 early boot tests pass, reaches scheduler stage with steady timer ticks (previously faulted at PC 0x200 before any output)