### PR TITLE
P2: SIGKILL use-after-free spine (exit_kick + reclaim custody)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ test_invalid_opcode = ["kernel/test_invalid_opcode"]
 test_page_fault = ["kernel/test_page_fault"]
 test_all_exceptions = ["kernel/test_all_exceptions"]
 external_test_bins = ["kernel/external_test_bins"]
+receipt_drop_test = ["kernel/receipt_drop_test"]
 vmnet = ["kernel/vmnet"]
 interactive = ["kernel/interactive"]
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(never)", "cfg(feature, values(\"ec0_fault_inject\", \"particle_animation\", \"xhci_linux_harness\"))"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(never)", "cfg(feature, values(\"ec0_fault_inject\", \"particle_animation\", \"receipt_drop_test\", \"xhci_linux_harness\"))"] }
 
 [[bin]]
 name = "kernel"
@@ -41,6 +41,7 @@ test_userspace = []
 test_all_exceptions = []
 external_test_bins = []
 ec0_fault_inject = []  # Inject one EL1 UDF on CPU 0 after about 10 seconds
+receipt_drop_test = ["boot_tests"]  # Deliberately exercise RetirementReceipt::drop
 vmnet = []  # Use vmnet network config (192.168.64.x) instead of SLIRP (10.0.2.x)
 interactive = ["testing"]  # Boot into init_shell instead of running automated tests
 

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -821,9 +821,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                             pid.as_u64() as u16,
                             (-11i16) as u16,
                         );
-                        let _ = crate::process::with_process_manager(|pm| {
-                            pm.exit_process(pid, -11); // SIGSEGV exit code
-                        });
+                        let _ = crate::process::exit_process_and_retire(pid, -11);
                         terminated = true;
                     }
                 }
@@ -1186,9 +1184,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                             pid.as_u64() as u16,
                             (-11i16) as u16,
                         );
-                        let _ = crate::process::with_process_manager(|pm| {
-                            pm.exit_process(pid, -11); // SIGSEGV
-                        });
+                        let _ = crate::process::exit_process_and_retire(pid, -11);
                         terminated = true;
                     }
                 }
@@ -1274,9 +1270,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
                     });
-                    let _ = crate::process::with_process_manager(|pm| {
-                        pm.exit_process(pid, -11);
-                    });
+                    let _ = crate::process::exit_process_and_retire(pid, -11);
                 }
                 terminate_current_scheduler_thread();
             }
@@ -1374,9 +1368,7 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
                     });
-                    let _ = crate::process::with_process_manager(|pm| {
-                        pm.exit_process(pid, -11);
-                    });
+                    let _ = crate::process::exit_process_and_retire(pid, -11);
                 }
                 terminate_current_scheduler_thread();
             }

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -817,10 +817,10 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                     if was_terminated {
                         already_terminated = true;
                     } else {
+                        let batch = crate::task::scheduler::GroupBatchId::for_single_victim(pid.as_u64());
+                        crate::task::scheduler::Scheduler::send_exit_expedite_sgi(pid.as_u64(), batch);
                         crate::tracing::providers::process::trace_process_exit(
-                            pid.as_u64() as u16,
-                            (-11i16) as u16,
-                        );
+                            pid.as_u64() as u16, (-11i16) as u16);
                         let _ = crate::process::exit_process_and_retire(pid, -11);
                         terminated = true;
                     }
@@ -1180,10 +1180,10 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                         already_terminated = true;
                     } else {
                         killed_pid = pid.as_u64();
+                        let batch = crate::task::scheduler::GroupBatchId::for_single_victim(pid.as_u64());
+                        crate::task::scheduler::Scheduler::send_exit_expedite_sgi(pid.as_u64(), batch);
                         crate::tracing::providers::process::trace_process_exit(
-                            pid.as_u64() as u16,
-                            (-11i16) as u16,
-                        );
+                            pid.as_u64() as u16, (-11i16) as u16);
                         let _ = crate::process::exit_process_and_retire(pid, -11);
                         terminated = true;
                     }
@@ -1266,10 +1266,10 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 let page_table_phys = ttbr0 & !0xFFFF_0000_0000_0FFF;
                 super::quiesce_ttbr0_for_exit();
                 let victim = resolve_el0_fault_victim(page_table_phys);
-                if let Some((pid, _)) = victim {
+                if let Some((pid, was_terminated)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
-                    });
+                    }); if !was_terminated { let batch = crate::task::scheduler::GroupBatchId::for_single_victim(pid.as_u64()); crate::task::scheduler::Scheduler::send_exit_expedite_sgi(pid.as_u64(), batch); }
                     let _ = crate::process::exit_process_and_retire(pid, -11);
                 }
                 terminate_current_scheduler_thread();
@@ -1364,10 +1364,10 @@ pub extern "C" fn handle_sync_exception(frame: *mut Aarch64ExceptionFrame, esr: 
                 let page_table_phys = ttbr0 & !0xFFFF_0000_0000_0FFF;
                 super::quiesce_ttbr0_for_exit();
                 let victim = resolve_el0_fault_victim(page_table_phys);
-                if let Some((pid, _)) = victim {
+                if let Some((pid, was_terminated)) = victim {
                     let _ = crate::task::scheduler::with_scheduler(|sched| {
                         sched.terminate_process_threads(pid.as_u64());
-                    });
+                    }); if !was_terminated { let batch = crate::task::scheduler::GroupBatchId::for_single_victim(pid.as_u64()); crate::task::scheduler::Scheduler::send_exit_expedite_sgi(pid.as_u64(), batch); }
                     let _ = crate::process::exit_process_and_retire(pid, -11);
                 }
                 terminate_current_scheduler_thread();

--- a/kernel/src/boot/test_list.rs
+++ b/kernel/src/boot/test_list.rs
@@ -31,6 +31,7 @@ pub const TEST_BINARIES: &[&str] = &[
     "signal_regs_test",
     "sigaltstack_test",
     "sigchld_test",
+    "sigkill_teardown_test",
     "pause_test",
     "sigsuspend_test",
     "signal_exec_test",

--- a/kernel/src/fs/procfs/mod.rs
+++ b/kernel/src/fs/procfs/mod.rs
@@ -68,6 +68,10 @@ pub enum ProcEntryType {
     TraceCounters,
     /// /proc/trace/providers - registered providers
     TraceProviders,
+    /// /proc/trace/teardown - per-PID teardown evidence directory
+    TraceTeardownDir,
+    /// /proc/trace/teardown/[pid] - per-PID teardown evidence
+    TraceTeardownPid(u64),
     /// /proc/slabinfo - slab allocator statistics
     SlabInfo,
     /// /proc/stat - kernel activity counters
@@ -113,6 +117,8 @@ impl ProcEntryType {
             ProcEntryType::TraceBuffer => "buffer",
             ProcEntryType::TraceCounters => "counters",
             ProcEntryType::TraceProviders => "providers",
+            ProcEntryType::TraceTeardownDir => "teardown",
+            ProcEntryType::TraceTeardownPid(_) => "pid",
             ProcEntryType::SlabInfo => "slabinfo",
             ProcEntryType::Stat => "stat",
             ProcEntryType::CowInfo => "cowinfo",
@@ -145,6 +151,8 @@ impl ProcEntryType {
             ProcEntryType::TraceBuffer => "/proc/trace/buffer",
             ProcEntryType::TraceCounters => "/proc/trace/counters",
             ProcEntryType::TraceProviders => "/proc/trace/providers",
+            ProcEntryType::TraceTeardownDir => "/proc/trace/teardown",
+            ProcEntryType::TraceTeardownPid(_) => "/proc/trace/teardown/<pid>",
             ProcEntryType::SlabInfo => "/proc/slabinfo",
             ProcEntryType::Stat => "/proc/stat",
             ProcEntryType::CowInfo => "/proc/cowinfo",
@@ -179,6 +187,8 @@ impl ProcEntryType {
             ProcEntryType::TraceBuffer => 103,
             ProcEntryType::TraceCounters => 104,
             ProcEntryType::TraceProviders => 105,
+            ProcEntryType::TraceTeardownDir => 106,
+            ProcEntryType::TraceTeardownPid(pid) => 30000 + pid,
             ProcEntryType::SlabInfo => 5,
             ProcEntryType::Stat => 6,
             ProcEntryType::CowInfo => 7,
@@ -200,6 +210,7 @@ impl ProcEntryType {
         matches!(
             self,
             ProcEntryType::TraceDir
+                | ProcEntryType::TraceTeardownDir
                 | ProcEntryType::BreenixDir
                 | ProcEntryType::XhciDir
                 | ProcEntryType::PidDir(_)
@@ -295,6 +306,9 @@ pub fn init() {
     procfs
         .entries
         .push(ProcEntry::new(ProcEntryType::TraceProviders));
+    procfs
+        .entries
+        .push(ProcEntry::new(ProcEntryType::TraceTeardownDir));
 
     procfs.initialized = true;
     log::info!("procfs: initialized with {} entries", procfs.entries.len());
@@ -325,6 +339,9 @@ pub fn lookup(name: &str) -> Option<ProcEntry> {
 
     // Try dynamic per-PID paths (e.g., "123/status", "123")
     let normalized = name.trim_start_matches('/');
+    if let Some(entry) = lookup_trace_teardown_path(normalized) {
+        return Some(entry);
+    }
     let full_path = alloc::format!("/proc/{}", normalized);
     lookup_pid_path(&full_path)
 }
@@ -343,7 +360,7 @@ pub fn lookup_by_path(path: &str) -> Option<ProcEntry> {
     // PROCFS lock is released here before we try dynamic PID lookup
 
     // Try dynamic per-PID paths (e.g., /proc/123/status, /proc/123)
-    lookup_pid_path(path)
+    lookup_trace_teardown_path(path.trim_start_matches("/proc/")).or_else(|| lookup_pid_path(path))
 }
 
 /// Look up an entry by inode number
@@ -378,6 +395,7 @@ pub fn list_entries() -> Vec<String> {
                         | ProcEntryType::TraceBuffer
                         | ProcEntryType::TraceCounters
                         | ProcEntryType::TraceProviders
+                        | ProcEntryType::TraceTeardownDir
                         | ProcEntryType::BreenixTesting
                         | ProcEntryType::XhciTrace
                         | ProcEntryType::XhciCounters
@@ -415,6 +433,7 @@ pub fn list_trace_entries() -> Vec<String> {
                     | ProcEntryType::TraceBuffer
                     | ProcEntryType::TraceCounters
                     | ProcEntryType::TraceProviders
+                    | ProcEntryType::TraceTeardownDir
             )
         })
         .map(|e| String::from(e.entry_type.name()))
@@ -476,6 +495,8 @@ pub fn read_entry(entry_type: ProcEntryType) -> Result<String, i32> {
         ProcEntryType::TraceBuffer => Ok(trace::generate_buffer()),
         ProcEntryType::TraceCounters => Ok(trace::generate_counters()),
         ProcEntryType::TraceProviders => Ok(trace::generate_providers()),
+        ProcEntryType::TraceTeardownDir => Ok(String::from("<pid>\n")),
+        ProcEntryType::TraceTeardownPid(pid) => Ok(trace::generate_teardown_pid(pid)),
         ProcEntryType::SlabInfo => Ok(generate_slabinfo()),
         ProcEntryType::Stat => Ok(generate_stat()),
         ProcEntryType::CowInfo => Ok(generate_cowinfo()),
@@ -982,6 +1003,19 @@ fn lookup_pid_path(path: &str) -> Option<ProcEntry> {
         Some("status") => Some(ProcEntry::new(ProcEntryType::PidStatus(pid))),
         Some(_) => None, // Unknown sub-path
     }
+}
+
+fn lookup_trace_teardown_path(path: &str) -> Option<ProcEntry> {
+    let relative = path.trim_start_matches('/');
+    let pid_text = relative.strip_prefix("trace/teardown/")?;
+    if pid_text.is_empty()
+        || pid_text.contains('/')
+        || (pid_text.len() > 1 && pid_text.starts_with('0'))
+    {
+        return None;
+    }
+    let pid = pid_text.parse().ok()?;
+    Some(ProcEntry::new(ProcEntryType::TraceTeardownPid(pid)))
 }
 
 /// Generate directory listing for /proc/[pid]

--- a/kernel/src/fs/procfs/trace.rs
+++ b/kernel/src/fs/procfs/trace.rs
@@ -247,6 +247,41 @@ pub fn generate_counters() -> String {
     output
 }
 
+/// Generate the test-scoped, per-PID teardown evidence used by the P2 gate.
+/// Reading the file before a kill registers that PID in the provider's fixed,
+/// lock-free tally table; a later read returns only that PID's deltas.
+pub fn generate_teardown_pid(pid: u64) -> String {
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    {
+        let Some(evidence) = crate::tracing::providers::teardown::teardown_pid_evidence(pid) else {
+            return String::from("capacity_exhausted: 1\n");
+        };
+        return format!(
+            "pid: {}\ndefer: {}\nreclaim: {}\nquarantine: {}\nsgi_sent: {}\nkick_observed: {}\nkick_interval: {}\ntick_period: {}\nmasked_frames_walked: {}\nreport: {}\nbucket_published: {}\nbucket_observed: {}\nbucket_collision: {}\n",
+            pid,
+            evidence.defer_count,
+            evidence.reclaim_count,
+            evidence.quarantine_count,
+            evidence.sgi_sent_count,
+            evidence.kick_observed_count,
+            evidence.kick_observed_interval,
+            crate::arch_impl::aarch64::timer_interrupt::TICKS_PER_INTERRUPT
+                .load(Ordering::Acquire),
+            evidence.masked_frames_walked,
+            evidence.report_count,
+            evidence.bucket_published_count,
+            evidence.bucket_observed_count,
+            evidence.bucket_collision_count,
+        );
+    }
+
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    {
+        let _ = pid;
+        String::from("unavailable: 1\n")
+    }
+}
+
 #[cfg(target_arch = "aarch64")]
 fn append_gicv2m_diag(output: &mut String) {
     let Some(irq) = crate::drivers::virtio::net_pci::get_irq() else {

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -1414,19 +1414,20 @@ extern "x86-interrupt" fn page_fault_handler(
             // Find the process by CR3 - this is more reliable than using current_thread_id
             // because during context switch the "current" thread may not match the faulting process
             let mut faulting_thread_id: Option<u64> = None;
+            let mut faulting_process_id: Option<crate::process::ProcessId> = None;
 
             crate::process::with_process_manager(|pm| {
                 if let Some((pid, process)) = pm.find_process_by_cr3_mut(cr3) {
                     let name = process.name.clone();
                     // Get the thread ID before we exit the process
                     faulting_thread_id = process.main_thread.as_ref().map(|t| t.id);
+                    faulting_process_id = Some(pid);
                     log::error!(
                         "Killing process {} (PID {}) due to page fault (CR3={:#x})",
                         name,
                         pid.as_u64(),
                         cr3
                     );
-                    pm.exit_process(pid, -11); // SIGSEGV exit code
                 } else {
                     log::error!(
                         "Could not find process with CR3={:#x} - cannot terminate",
@@ -1434,6 +1435,10 @@ extern "x86-interrupt" fn page_fault_handler(
                     );
                 }
             });
+
+            if let Some(pid) = faulting_process_id {
+                let _ = crate::process::exit_process_and_retire(pid, -11);
+            }
 
             // Mark thread as terminated by setting it not runnable
             if let Some(thread_id) = faulting_thread_id {
@@ -1720,19 +1725,20 @@ extern "x86-interrupt" fn general_protection_fault_handler(
 
         // Find the process by CR3
         let mut faulting_thread_id: Option<u64> = None;
+        let mut faulting_process_id: Option<crate::process::ProcessId> = None;
 
         crate::process::with_process_manager(|pm| {
             if let Some((pid, process)) = pm.find_process_by_cr3_mut(cr3) {
                 let name = process.name.clone();
                 // Get the thread ID before we exit the process
                 faulting_thread_id = process.main_thread.as_ref().map(|t| t.id);
+                faulting_process_id = Some(pid);
                 log::error!(
                     "Killing process {} (PID {}) due to GPF (CR3={:#x})",
                     name,
                     pid.as_u64(),
                     cr3
                 );
-                pm.exit_process(pid, -11); // SIGSEGV exit code
             } else {
                 log::error!(
                     "Could not find process with CR3={:#x} - cannot terminate",
@@ -1740,6 +1746,10 @@ extern "x86-interrupt" fn general_protection_fault_handler(
                 );
             }
         });
+
+        if let Some(pid) = faulting_process_id {
+            let _ = crate::process::exit_process_and_retire(pid, -11);
+        }
 
         // Mark thread as terminated by setting it not runnable
         if let Some(thread_id) = faulting_thread_id {

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -1117,25 +1117,31 @@ impl ProcessManager {
         self.processes.get_mut(&pid)
     }
 
-    /// Exit a process with the given exit code
-    #[allow(dead_code)]
-    pub fn exit_process(&mut self, pid: ProcessId, exit_code: i32) {
+    /// Locked half of process exit. The sole caller is
+    /// `process::exit_process_and_retire`, which drops PM before enqueueing the
+    /// returned receipt.
+    pub(crate) fn exit_process_locked(
+        &mut self,
+        pid: ProcessId,
+        exit_code: i32,
+    ) -> Option<super::RetirementReceipt> {
         let already_terminated = match self.processes.get(&pid) {
             Some(process) => process.is_terminated(),
-            None => return,
+            None => return None,
         };
         crate::tracing::providers::teardown::record_exit_request(already_terminated);
 
         // Get parent PID before we borrow the process mutably
         let parent_pid = self.processes.get(&pid).and_then(|p| p.parent);
 
+        #[cfg(target_arch = "aarch64")]
+        let mut receipt = None;
+        #[cfg(not(target_arch = "aarch64"))]
+        let receipt: Option<super::RetirementReceipt> = None;
         if let Some(process) = self.processes.get_mut(&pid) {
-            log::info!(
-                "Process {} (PID {}) exiting with code {}",
-                process.name,
-                pid.as_u64(),
-                exit_code
-            );
+            if !already_terminated {
+                process.exit_notifications.seed();
+            }
 
             if already_terminated {
                 // Preserve the single-CoW-decref invariant: external terminate()
@@ -1152,7 +1158,7 @@ impl ProcessManager {
                     // A peer's own EL1-fault shadow-clear window remains the same
                     // parked structural issue as normal-exit deferral.
                     let reclaim = crate::task::process_task::defer_process_resources(process);
-                    crate::task::process_task::enqueue_process_reclaim(reclaim);
+                    receipt = Some(super::RetirementReceipt::from_reclaim(reclaim));
                     drop(process.stack.take());
                 }
                 #[cfg(not(target_arch = "aarch64"))]
@@ -1201,18 +1207,27 @@ impl ProcessManager {
             }
         }
 
-        // Send SIGCHLD to the parent process (if any)
-        if let Some(parent_pid) = parent_pid {
-            if let Some(parent_process) = self.processes.get_mut(&parent_pid) {
-                use crate::signal::constants::SIGCHLD;
-                parent_process.signals.set_pending(SIGCHLD);
-                log::debug!(
-                    "Sent SIGCHLD to parent process {} for child {} exit",
-                    parent_pid.as_u64(),
-                    pid.as_u64()
-                );
+        // Class-A SIGCHLD obligation: perform the PM-owned effect and mark it
+        // completed in this same acquisition. Repeat exit paths do neither.
+        let sigchld_pending = self.processes.get(&pid).is_some_and(|process| {
+            matches!(
+                process.exit_notifications.sigchld,
+                super::process::ExitObligationState::Pending
+            )
+        });
+        if sigchld_pending {
+            if let Some(parent_pid) = parent_pid {
+                if let Some(parent_process) = self.processes.get_mut(&parent_pid) {
+                    use crate::signal::constants::SIGCHLD;
+                    parent_process.signals.set_pending(SIGCHLD);
+                }
+            }
+            if let Some(process) = self.processes.get_mut(&pid) {
+                process.exit_notifications.complete_sigchld();
             }
         }
+
+        receipt
     }
 
     /// Get the next ready process to run

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -14,6 +14,47 @@ pub mod process;
 pub use manager::ProcessManager;
 pub use process::{Process, ProcessId, ProcessState};
 
+/// Result of entering process teardown through the receipt-custody wrapper.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExitOutcome {
+    Missing,
+    FirstCommit,
+    RepeatCommit,
+}
+
+/// Crate-private custody object for a deferred process root. There is no
+/// public constructor and no public API that can hand one to a caller.
+pub(crate) struct RetirementReceipt {
+    #[cfg(target_arch = "aarch64")]
+    reclaim: Option<crate::task::process_task::PendingProcessReclaim>,
+}
+
+impl RetirementReceipt {
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn from_reclaim(reclaim: crate::task::process_task::PendingProcessReclaim) -> Self {
+        Self {
+            reclaim: Some(reclaim),
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn take_contents(
+        &mut self,
+    ) -> Option<crate::task::process_task::PendingProcessReclaim> {
+        self.reclaim.take()
+    }
+}
+
+impl Drop for RetirementReceipt {
+    fn drop(&mut self) {
+        #[cfg(target_arch = "aarch64")]
+        if let Some(reclaim) = self.take_contents() {
+            crate::trace_count!(crate::tracing::providers::teardown::RECEIPT_DROPPED_UNRETIRED);
+            crate::task::process_task::enqueue_process_reclaim(reclaim);
+        }
+    }
+}
+
 const PM_LOCK_OWNER_NONE: u64 = u64::MAX;
 
 /// Best-effort owner snapshot for PROCESS_MANAGER lock contention analysis.
@@ -207,6 +248,54 @@ where
     })
 }
 
+/// The only public process-exit entry point. The locked half can return a
+/// receipt only into this function; PM is out of scope before the receipt is
+/// enqueued and before notification redemption enters scheduler/SERIAL code.
+pub fn exit_process_and_retire(pid: ProcessId, exit_code: i32) -> ExitOutcome {
+    let locked = with_process_manager(|pm| {
+        let Some(process) = pm.get_process(pid) else {
+            return (ExitOutcome::Missing, None, None, exit_code);
+        };
+        let outcome = if process.is_terminated() {
+            ExitOutcome::RepeatCommit
+        } else {
+            ExitOutcome::FirstCommit
+        };
+        let thread_id = process.main_thread.as_ref().map(|thread| thread.id);
+        let receipt = pm.exit_process_locked(pid, exit_code);
+        let reported_exit_code = pm
+            .get_process(pid)
+            .and_then(|process| process.exit_code)
+            .unwrap_or(exit_code);
+        (outcome, receipt, thread_id, reported_exit_code)
+    });
+
+    let Some((outcome, receipt, thread_id, reported_exit_code)) = locked else {
+        return ExitOutcome::Missing;
+    };
+
+    #[cfg(target_arch = "aarch64")]
+    if let Some(mut receipt) = receipt {
+        if let Some(reclaim) = receipt.take_contents() {
+            crate::task::process_task::enqueue_process_reclaim(reclaim);
+        }
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    let _receipt = receipt;
+
+    // The unchanged btrt effect remains in handle_thread_exit. Calling the
+    // existing two-phase path here lets a remote commit race a natural thread
+    // exit for the row's report claim without ever invoking SERIAL under PM.
+    if let Some(thread_id) = thread_id {
+        crate::task::process_task::ProcessScheduler::handle_thread_exit(
+            thread_id,
+            reported_exit_code,
+        );
+    }
+
+    outcome
+}
+
 /// Execute a function with the process manager while interrupts are disabled (ARM64)
 /// This prevents deadlock when timer interrupts try to access the process manager
 #[cfg(target_arch = "aarch64")]
@@ -321,11 +410,7 @@ pub fn exit_current(exit_code: i32) {
 }
 
 fn exit_process_by_pid(pid: ProcessId, exit_code: i32) {
-    if let Some(ref mut manager) = *manager() {
-        manager.exit_process(pid, exit_code);
-    } else {
-        log::error!("Process manager not available!");
-    }
+    let _ = exit_process_and_retire(pid, exit_code);
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]

--- a/kernel/src/process/process.rs
+++ b/kernel/src/process/process.rs
@@ -62,6 +62,101 @@ pub enum ProcessState {
     Terminated(i32), // exit code
 }
 
+/// Phase-2 exit-obligation state. The PM lock is the sole serializer for
+/// every transition; later teardown phases extend this exact shape rather
+/// than upgrading a boolean in place.
+#[derive(Clone, Copy)]
+pub(crate) enum ExitObligationState {
+    Absent,
+    Pending,
+    Claimed { claimer: u64, fence: ExitClaimFence },
+    Completed,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct ExitClaimFence {
+    #[cfg(target_arch = "aarch64")]
+    retirement: crate::task::scheduler::RetirementFence,
+}
+
+impl ExitClaimFence {
+    fn capture() -> Self {
+        Self {
+            #[cfg(target_arch = "aarch64")]
+            retirement: crate::task::scheduler::retirement_grace_target(),
+        }
+    }
+}
+
+/// P2's durable notification seed: SIGCHLD is a class-A obligation completed
+/// with its PM-owned effect, while Report uses T1/T2/T3 around the unchanged
+/// `btrt::on_process_exit` effect outside PM. T4 intentionally does not exist.
+pub(crate) struct ExitNotificationObligations {
+    pub(crate) sigchld: ExitObligationState,
+    report: ExitObligationState,
+}
+
+impl ExitNotificationObligations {
+    const fn new() -> Self {
+        Self {
+            sigchld: ExitObligationState::Absent,
+            report: ExitObligationState::Absent,
+        }
+    }
+
+    /// T1: create each obligation exactly once, on the first exit commit.
+    pub(crate) fn seed(&mut self) {
+        if matches!(self.sigchld, ExitObligationState::Absent) {
+            self.sigchld = ExitObligationState::Pending;
+        }
+        if matches!(self.report, ExitObligationState::Absent) {
+            self.report = ExitObligationState::Pending;
+        }
+    }
+
+    /// Class-A T2.3: the caller performs the SIGCHLD effect in the same PM
+    /// acquisition before marking the obligation complete.
+    pub(crate) fn complete_sigchld(&mut self) {
+        if matches!(self.sigchld, ExitObligationState::Pending) {
+            self.sigchld = ExitObligationState::Completed;
+        }
+    }
+
+    /// T2: claim the report effect under PM. Exactly one competing exit path
+    /// can observe Pending and become the sole redeemer.
+    pub(crate) fn claim_report(&mut self, claimer: u64) -> bool {
+        if !matches!(self.report, ExitObligationState::Pending) {
+            return false;
+        }
+        self.report = ExitObligationState::Claimed {
+            claimer,
+            fence: ExitClaimFence::capture(),
+        };
+        true
+    }
+
+    /// T3: only the path that claimed the report may complete it, under a
+    /// fresh PM acquisition after the effect ran outside PM.
+    pub(crate) fn complete_report(&mut self, claimer: u64) {
+        match self.report {
+            ExitObligationState::Claimed {
+                claimer: owner,
+                fence,
+            } if owner == claimer => {
+                #[cfg(target_arch = "aarch64")]
+                let _claim_fence = fence.retirement;
+                #[cfg(not(target_arch = "aarch64"))]
+                let _claim_fence = fence;
+                self.report = ExitObligationState::Completed;
+            }
+            ExitObligationState::Claimed { .. } => {
+                crate::trace_count!(crate::tracing::providers::teardown::LEDGER_CLAIM_MISMATCH);
+            }
+            _ => {}
+        }
+    }
+}
+
 /// A process represents a running program with its own address space
 pub struct Process {
     /// Unique process identifier
@@ -115,6 +210,9 @@ pub struct Process {
 
     /// Exit code (if terminated)
     pub exit_code: Option<i32>,
+
+    /// Durable P2 notification state, serialized exclusively by the PM lock.
+    pub(crate) exit_notifications: ExitNotificationObligations,
 
     /// Memory usage statistics
     pub memory_usage: MemoryUsage,
@@ -224,6 +322,7 @@ impl Process {
             parent: None,
             children: Vec::new(),
             exit_code: None,
+            exit_notifications: ExitNotificationObligations::new(),
             memory_usage: MemoryUsage::default(),
             stack: None,
             page_table: None,

--- a/kernel/src/syscall/signal.rs
+++ b/kernel/src/syscall/signal.rs
@@ -155,17 +155,21 @@ fn send_signal_to_process(target_pid: ProcessId, sig: u32) -> SyscallResult {
 
             // SIGKILL and SIGSTOP are special - cannot be caught or blocked
             if sig == SIGKILL {
-                log::info!(
-                    "SIGKILL sent to process {} - terminating immediately",
-                    target_pid.as_u64()
-                );
+                let victim_pid = process.id;
+                drop(manager_guard);
+
                 crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_SIGNAL);
-                process.terminate(-9); // Exit code for SIGKILL
-                                       // Wake up process if blocked so scheduler removes it
-                if matches!(process.state, crate::process::ProcessState::Blocked) {
-                    process.set_ready();
-                }
-                // Trigger reschedule
+                crate::task::scheduler::with_scheduler(|scheduler| {
+                    scheduler.terminate_process_threads(victim_pid.as_u64());
+                });
+
+                let batch =
+                    crate::task::scheduler::GroupBatchId::for_single_victim(victim_pid.as_u64());
+                crate::task::scheduler::Scheduler::send_exit_expedite_sgi(
+                    victim_pid.as_u64(),
+                    batch,
+                );
+                let _ = crate::process::exit_process_and_retire(victim_pid, -9);
                 crate::task::scheduler::set_need_resched();
                 return SyscallResult::Ok(0);
             }

--- a/kernel/src/task/kthread.rs
+++ b/kernel/src/task/kthread.rs
@@ -59,6 +59,28 @@ pub fn kthread_run<F>(func: F, name: &str) -> Result<KthreadHandle, KthreadError
 where
     F: FnOnce() + Send + 'static,
 {
+    kthread_run_with(func, name, scheduler::spawn)
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+pub(crate) fn kthread_run_on_cpu_for_test<F>(
+    func: F,
+    name: &str,
+    cpu: usize,
+) -> Result<KthreadHandle, KthreadError>
+where
+    F: FnOnce() + Send + 'static,
+{
+    kthread_run_with(func, name, move |thread| {
+        scheduler::spawn_on_cpu_for_test(thread, cpu)
+    })
+}
+
+fn kthread_run_with<F, S>(func: F, name: &str, spawn_thread: S) -> Result<KthreadHandle, KthreadError>
+where
+    F: FnOnce() + Send + 'static,
+    S: FnOnce(Box<Thread>),
+{
     let mut thread = Thread::new_kernel(name.to_string(), kthread_entry, 0)
         .map_err(|_| KthreadError::SpawnFailed)?;
 
@@ -92,7 +114,7 @@ where
     // the registry entry to exist.
     without_interrupts(|| {
         KTHREAD_REGISTRY.lock().insert(tid, Arc::clone(&kthread));
-        scheduler::spawn(Box::new(thread));
+        spawn_thread(Box::new(thread));
     });
 
     Ok(KthreadHandle { inner: kthread })
@@ -233,6 +255,9 @@ pub fn kthread_exit(code: i32) -> ! {
     without_interrupts(|| {
         KTHREAD_REGISTRY.lock().remove(&handle.inner.tid);
     });
+
+    #[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+    scheduler::clear_cpu_affinity_for_test(handle.inner.tid);
 
     scheduler::with_scheduler(|sched| {
         if let Some(thread) = sched.current_thread_mut() {

--- a/kernel/src/task/kthread.rs
+++ b/kernel/src/task/kthread.rs
@@ -214,6 +214,19 @@ pub fn kthread_unpark(handle: &KthreadHandle) {
     scheduler::set_need_resched();
 }
 
+/// Test-only, non-blocking probe of whether a kthread has exited.
+///
+/// Boot-test coordinators (which run synchronously on CPU 0) use this to bound
+/// their cross-CPU join waits: they poll this flag with their own capped
+/// spin-loop instead of blocking unboundedly in `kthread_join`, so a lost
+/// wakeup on a secondary CPU surfaces as an actionable test failure rather than
+/// a silent harness hang. This is a pure read; it changes no production
+/// behavior and matches the SeqCst ordering `kthread_join` uses.
+#[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+pub(crate) fn kthread_has_exited_for_test(handle: &KthreadHandle) -> bool {
+    handle.inner.exited.load(Ordering::SeqCst)
+}
+
 /// Wait for kthread to exit and return its exit code
 /// Blocks the calling context until the thread terminates
 pub fn kthread_join(handle: &KthreadHandle) -> Result<i32, KthreadError> {

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -201,8 +201,6 @@ static ROW_REMOVAL_EPOCH: AtomicU64 = AtomicU64::new(0);
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 static BOOT_RECLAIM_TEST_OWNER: AtomicU64 = AtomicU64::new(0);
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-static BOOT_RECLAIM_ACTIVE_DRAINS: AtomicU64 = AtomicU64::new(0);
-#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 static BOOT_RECLAIM_FORCED_PID: AtomicU64 = AtomicU64::new(0);
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 static BOOT_RECLAIM_FORCED_BLOCKER: AtomicU64 = AtomicU64::new(0);
@@ -790,25 +788,6 @@ fn boot_forces_blocker(pid: u64, blocker: RootBlocker, allow_boot_injection: boo
     }
 }
 
-#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-struct BootReclaimInvocationGuard;
-
-#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-impl BootReclaimInvocationGuard {
-    fn enter() -> (Self, bool) {
-        BOOT_RECLAIM_ACTIVE_DRAINS.fetch_add(1, Ordering::AcqRel);
-        let allowed = BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) == 0;
-        (Self, allowed)
-    }
-}
-
-#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-impl Drop for BootReclaimInvocationGuard {
-    fn drop(&mut self) {
-        BOOT_RECLAIM_ACTIVE_DRAINS.fetch_sub(1, Ordering::AcqRel);
-    }
-}
-
 #[cfg(target_arch = "aarch64")]
 fn boot_after_step_two(fence: &scheduler::RetirementFence) {
     #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
@@ -824,32 +803,38 @@ fn boot_after_step_two(fence: &scheduler::RetirementFence) {
 }
 
 #[cfg(target_arch = "aarch64")]
-fn boot_begin_reclaim_pass() {
+fn boot_begin_reclaim_pass(boot_test_owned: bool) {
     #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-    if BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
+    if boot_test_owned {
         let queue_len = crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().len());
         BOOT_RECLAIM_PASS_START.store(queue_len as u64, Ordering::Relaxed);
         BOOT_RECLAIM_PASS_SELECTIONS.store(0, Ordering::Relaxed);
     }
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = boot_test_owned;
 }
 
 #[cfg(target_arch = "aarch64")]
-fn boot_note_reclaim_selection() {
+fn boot_note_reclaim_selection(boot_test_owned: bool) {
     #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-    if BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
+    if boot_test_owned {
         BOOT_RECLAIM_PASS_SELECTIONS.fetch_add(1, Ordering::Relaxed);
     }
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = boot_test_owned;
 }
 
 #[cfg(target_arch = "aarch64")]
-fn boot_finish_reclaim_pass() {
+fn boot_finish_reclaim_pass(boot_test_owned: bool) {
     #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-    if BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
+    if boot_test_owned {
         debug_assert!(
             BOOT_RECLAIM_PASS_SELECTIONS.load(Ordering::Relaxed)
                 <= BOOT_RECLAIM_PASS_START.load(Ordering::Relaxed)
         );
     }
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = boot_test_owned;
 }
 
 /// Reclaim process frames whose cross-CPU TTBR0 retention has quiesced.
@@ -869,21 +854,29 @@ pub fn reclaim_deferred_process_resources() {
         return;
     }
     #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-    let (_boot_invocation_guard, boot_reclaim_allowed) = BootReclaimInvocationGuard::enter();
-    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-    if !boot_reclaim_allowed {
+    if BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
         return;
     }
 
-    reclaim_deferred_process_resources_for_pass(my_pass);
+    reclaim_deferred_process_resources_for_pass(my_pass, false);
 }
 
 #[cfg(target_arch = "aarch64")]
-fn reclaim_deferred_process_resources_for_pass(my_pass: u32) {
+fn reclaim_deferred_process_resources_for_pass(my_pass: u32, boot_test_owned: bool) {
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = boot_test_owned;
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    if !boot_test_owned && BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
+        return;
+    }
     unpark_sweep();
-    boot_begin_reclaim_pass();
+    boot_begin_reclaim_pass(boot_test_owned);
 
     loop {
+        #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+        if !boot_test_owned && BOOT_RECLAIM_TEST_OWNER.load(Ordering::Acquire) != 0 {
+            break;
+        }
         let reclaim = crate::arch_without_interrupts(|| {
             let mut pending = PENDING_PROCESS_RECLAIMS.lock();
             let _proof_scope =
@@ -907,7 +900,7 @@ fn reclaim_deferred_process_resources_for_pass(my_pass: u32) {
 
         match reclaim {
             Some(mut reclaim) => {
-                boot_note_reclaim_selection();
+                boot_note_reclaim_selection(boot_test_owned);
                 let snapshot = scheduler::RetirementSnapshot::capture();
                 let mut proof = reclaim.lock_free_root_proof(&snapshot, true);
                 boot_after_step_two(&reclaim.after_epoch);
@@ -944,7 +937,7 @@ fn reclaim_deferred_process_resources_for_pass(my_pass: u32) {
             None => break,
         }
     }
-    boot_finish_reclaim_pass();
+    boot_finish_reclaim_pass(boot_test_owned);
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
@@ -954,7 +947,7 @@ fn boot_reclaim_deferred_process_resources() {
             .fetch_add(1, Ordering::Relaxed)
             .wrapping_add(1),
     );
-    reclaim_deferred_process_resources_for_pass(my_pass);
+    reclaim_deferred_process_resources_for_pass(my_pass, true);
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
@@ -970,9 +963,6 @@ impl BootReclaimTestGuard {
         BOOT_RECLAIM_TEST_OWNER
             .compare_exchange(0, owner, Ordering::AcqRel, Ordering::Acquire)
             .map_err(|_| "another reclaim injection is active")?;
-        while BOOT_RECLAIM_ACTIVE_DRAINS.load(Ordering::Acquire) != 0 {
-            core::hint::spin_loop();
-        }
         let live_empty =
             crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().is_empty());
         let parked_empty =

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -286,9 +286,7 @@ pub(crate) fn note_process_row_removed() {
 
 pub(crate) fn release_process_resources(process: &mut crate::process::Process) {
     if crate::process::process_manager_held_on_current_cpu() {
-        crate::trace_count!(
-            crate::tracing::providers::teardown::TEARDOWN_MASKED_FRAMES_WALKED
-        );
+        crate::tracing::providers::teardown::record_masked_frames_walked(process.id.as_u64());
     }
     process.cleanup_cow_frames();
     process.drain_old_page_tables();
@@ -312,11 +310,35 @@ pub(crate) fn defer_live_process_resources(
                 snapshot.online_mask,
             )
         });
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    let root_is_live = root_is_live
+        || FORCE_LIVE_RECLAIM_TEST_PID.load(Ordering::Acquire) == process.id.as_u64();
     if !root_is_live {
         return None;
     }
 
     Some(defer_process_resources(process))
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static FORCE_LIVE_RECLAIM_TEST_PID: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub(crate) struct ForceLiveReclaimTestGuard;
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl ForceLiveReclaimTestGuard {
+    pub(crate) fn arm(pid: u64) -> Self {
+        FORCE_LIVE_RECLAIM_TEST_PID.store(pid, Ordering::Release);
+        Self
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl Drop for ForceLiveReclaimTestGuard {
+    fn drop(&mut self) {
+        FORCE_LIVE_RECLAIM_TEST_PID.store(0, Ordering::Release);
+    }
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -421,12 +443,18 @@ impl ProcessScheduler {
     /// SERIAL and framebuffer locks) creates an unbreakable deadlock.
     pub fn handle_thread_exit(thread_id: u64, exit_code: i32) {
         crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_ENTRY_EXIT);
+        // Capture the claimer before taking PM. This is a separate scheduler-only
+        // acquisition; no scheduler state is consulted while PM is live.
+        let report_claimer = scheduler::current_thread_id().unwrap_or(thread_id);
         // Phase 1: Under PM lock — minimal work only
         let phase1_result = {
             if let Some(ref mut manager) = *crate::process::manager() {
                 if let Some((pid, process)) = manager.find_process_by_thread_mut(thread_id) {
                     let already_terminated = process.is_terminated();
                     crate::tracing::providers::teardown::record_exit_request(already_terminated);
+                    if !already_terminated {
+                        process.exit_notifications.seed();
+                    }
                     let parent_pid = process.parent;
                     let process_name = process.name.clone();
                     let children = if pid == ProcessId::new(1) {
@@ -437,47 +465,53 @@ impl ProcessScheduler {
 
                     // Extract FDs without closing them under the PM lock.
                     let fd_entries = process.take_fd_entries();
-                    if already_terminated {
-                        // Preserve the single-CoW-decref invariant: external
-                        // terminate() already walked these mappings, so raw-drop
-                        // them without another reclaim/decref path.
-                        drop(process.page_table.take());
-                        drop(process.stack.take());
-                        process.pending_old_page_tables.clear();
-                    } else {
-                        #[cfg(target_arch = "aarch64")]
-                        if let Some(reclaim) = defer_live_process_resources(process) {
-                            enqueue_process_reclaim(reclaim);
+                    let retirement_receipt: Option<crate::process::RetirementReceipt> =
+                        if already_terminated {
+                            // Preserve the single-CoW-decref invariant: external
+                            // terminate() already walked these mappings, so raw-drop
+                            // them without another reclaim/decref path.
+                            drop(process.page_table.take());
                             drop(process.stack.take());
+                            process.pending_old_page_tables.clear();
+                            None
                         } else {
-                            release_process_resources(process);
-                        }
-                        #[cfg(not(target_arch = "aarch64"))]
-                        release_process_resources(process);
-                    }
+                            #[cfg(target_arch = "aarch64")]
+                            let receipt =
+                                if let Some(reclaim) = defer_live_process_resources(process) {
+                                    drop(process.stack.take());
+                                    Some(crate::process::RetirementReceipt::from_reclaim(reclaim))
+                                } else {
+                                    release_process_resources(process);
+                                    None
+                                };
+                            #[cfg(not(target_arch = "aarch64"))]
+                            let receipt = {
+                                release_process_resources(process);
+                                None
+                            };
+                            receipt
+                        };
 
                     // Keep termination after release/deferral. Once page_table is
                     // None, cleanup_cow_frames() cannot repeat the CoW walk; moving
                     // terminate()/terminate_minimal() earlier breaks that invariant.
                     process.terminate_minimal(exit_code);
-
-                    #[cfg(feature = "btrt")]
-                    {
-                        // terminate_minimal() is a no-op on a repeat teardown pass (process.rs:320
-                        // early-returns without touching exit_code), so process.exit_code already
-                        // holds the first-recorded status here on every pass — report that, never
-                        // this pass's exit_code parameter, so a later pass with a different code
-                        // (e.g. a fault arriving after an earlier SIGKILL) can't overwrite what the
-                        // parent already reaped via waitpid.
-                        let reported_exit_code = process.exit_code.unwrap_or(exit_code);
-                        crate::test_framework::btrt::on_process_exit(pid.as_u64(), reported_exit_code);
-                    }
+                    // terminate_minimal() is a no-op on a repeat teardown pass, so
+                    // preserve and report the first-recorded status.
+                    let reported_exit_code = process.exit_code.unwrap_or(exit_code);
+                    let report_claimed = process.exit_notifications.claim_report(report_claimer);
+                    let sigchld_pending = matches!(
+                        process.exit_notifications.sigchld,
+                        crate::process::process::ExitObligationState::Pending
+                    );
 
                     // Set SIGCHLD on parent and get parent thread ID for wakeup
                     let parent_tid = if let Some(parent_pid) = parent_pid {
                         if let Some(parent_process) = manager.get_process_mut(parent_pid) {
-                            use crate::signal::constants::SIGCHLD;
-                            parent_process.signals.set_pending(SIGCHLD);
+                            if sigchld_pending {
+                                use crate::signal::constants::SIGCHLD;
+                                parent_process.signals.set_pending(SIGCHLD);
+                            }
                             parent_process.main_thread.as_ref().map(|t| t.id)
                         } else {
                             None
@@ -485,6 +519,11 @@ impl ProcessScheduler {
                     } else {
                         None
                     };
+                    if sigchld_pending {
+                        if let Some(process) = manager.get_process_mut(pid) {
+                            process.exit_notifications.complete_sigchld();
+                        }
+                    }
 
                     // Reparent children to init (PID 1)
                     if !children.is_empty() {
@@ -499,7 +538,15 @@ impl ProcessScheduler {
                         }
                     }
 
-                    Some((pid, process_name, fd_entries, parent_tid))
+                    Some((
+                        pid,
+                        process_name,
+                        fd_entries,
+                        parent_tid,
+                        retirement_receipt,
+                        report_claimed,
+                        reported_exit_code,
+                    ))
                 } else {
                     None
                 }
@@ -509,7 +556,25 @@ impl ProcessScheduler {
         }; // PM lock dropped here
 
         // Phase 2: No PM lock — safe to do pipe wakeups, scheduler calls, logging
-        if let Some((pid, process_name, fd_entries, parent_tid)) = phase1_result {
+        if let Some((
+            pid,
+            process_name,
+            fd_entries,
+            parent_tid,
+            retirement_receipt,
+            report_claimed,
+            reported_exit_code,
+        )) = phase1_result
+        {
+            #[cfg(target_arch = "aarch64")]
+            if let Some(mut receipt) = retirement_receipt {
+                if let Some(reclaim) = receipt.take_contents() {
+                    enqueue_process_reclaim(reclaim);
+                }
+            }
+            #[cfg(not(target_arch = "aarch64"))]
+            let _retirement_receipt = retirement_receipt;
+
             // Close FDs outside PM lock (pipe close_write wakes readers, etc.)
             close_extracted_fds(fd_entries);
 
@@ -527,6 +592,23 @@ impl ProcessScheduler {
                     parent_tid as u16,
                     pid.as_u64() as u16,
                 );
+            }
+
+            if report_claimed {
+                #[cfg(feature = "btrt")]
+                crate::test_framework::btrt::on_process_exit(pid.as_u64(), reported_exit_code);
+                #[cfg(not(feature = "btrt"))]
+                let _ = reported_exit_code;
+                crate::tracing::providers::teardown::record_report(pid.as_u64());
+
+                let completing_claimer = scheduler::current_thread_id().unwrap_or(report_claimer);
+                let _ = crate::process::with_process_manager(|manager| {
+                    if let Some(process) = manager.get_process_mut(pid) {
+                        process
+                            .exit_notifications
+                            .complete_report(completing_claimer);
+                    }
+                });
             }
 
             log::debug!(
@@ -942,6 +1024,41 @@ fn boot_test_reclaim(pid: u64) -> PendingProcessReclaim {
         proof_failures: 0,
         parked: None,
     }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub fn retirement_receipt_drop_gate_test() -> crate::test_framework::registry::TestResult {
+    use crate::test_framework::registry::TestResult;
+    use crate::tracing::providers::teardown::{RECEIPT_DROPPED_UNRETIRED, TEARDOWN_RECLAIM};
+
+    let _guard = match BootReclaimTestGuard::enter() {
+        Ok(guard) => guard,
+        Err(message) => return TestResult::Fail(message),
+    };
+    let pid = BOOT_RECLAIM_PID_BASE + 1;
+    let queue_before = crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().len());
+    let dropped_before = RECEIPT_DROPPED_UNRETIRED.aggregate();
+    let reclaimed_before = TEARDOWN_RECLAIM.aggregate();
+
+    let receipt = crate::process::RetirementReceipt::from_reclaim(boot_test_reclaim(pid));
+    core::mem::drop(receipt);
+
+    let queue_after = crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().len());
+    if queue_after != queue_before + 1
+        || RECEIPT_DROPPED_UNRETIRED
+            .aggregate()
+            .saturating_sub(dropped_before)
+            != 1
+        || TEARDOWN_RECLAIM
+            .aggregate()
+            .saturating_sub(reclaimed_before)
+            != 0
+        || !boot_reclaim_locations(pid).0
+    {
+        return TestResult::Fail("dropped retirement receipt did not re-enqueue without reclaim");
+    }
+
+    TestResult::Pass
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]

--- a/kernel/src/task/scheduler.rs
+++ b/kernel/src/task/scheduler.rs
@@ -53,6 +53,44 @@ use core::cmp::Reverse;
 use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use spin::Mutex;
 
+/// Exit-batch identity carried by teardown-attributed expedite evidence.
+/// P2 uses one pid-derived batch per single-victim request; P9 later assigns
+/// one shared id to a group request rather than introducing a parallel type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GroupBatchId(u64);
+
+impl GroupBatchId {
+    pub const fn for_single_victim(pid: u64) -> Self {
+        Self(pid)
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn observe_exit_kick(thread_pid: u64) -> bool {
+    use crate::tracing::providers::teardown::{EXIT_KICK_BUCKETS, EXIT_KICK_SLOTS};
+
+    let slot = &EXIT_KICK_SLOTS[thread_pid as usize % EXIT_KICK_BUCKETS];
+    if let Some(observation) = slot.observe(thread_pid) {
+        let interval = crate::tracing::trace_timestamp().wrapping_sub(observation.at);
+        crate::tracing::providers::teardown::record_exit_kick_observed(thread_pid, interval);
+        true
+    } else {
+        slot.is_observed_for(thread_pid)
+    }
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[inline(always)]
+fn observe_exit_kick(_thread_pid: u64) -> bool {
+    true
+}
+
 // Architecture-generic HAL wrappers for interrupt control.
 #[cfg(not(target_arch = "aarch64"))]
 use crate::arch_interrupts_enabled as are_enabled;
@@ -234,6 +272,10 @@ pub fn emit_wake_attribution_counters() {
 /// Global scheduler instance
 static SCHEDULER: Mutex<Option<Scheduler>> = Mutex::new(None);
 
+#[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+static BOOT_TEST_CPU_AFFINITY: [AtomicU64; MAX_CPUS] =
+    [const { AtomicU64::new(0) }; MAX_CPUS];
+
 #[inline(always)]
 fn lock_scheduler() -> spin::MutexGuard<'static, Option<Scheduler>> {
     let guard = SCHEDULER.lock();
@@ -246,6 +288,29 @@ fn try_lock_scheduler() -> Option<spin::MutexGuard<'static, Option<Scheduler>>> 
     let guard = SCHEDULER.try_lock()?;
     crate::tracing::providers::teardown::note_scheduler_acquire();
     Some(guard)
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+fn retain_cpu_affine_test_thread(
+    queue: &mut VecDeque<u64>,
+    thread_id: u64,
+    current_cpu: usize,
+) -> bool {
+    let target_cpu = BOOT_TEST_CPU_AFFINITY
+        .iter()
+        .position(|slot| slot.load(Ordering::Acquire) == thread_id);
+    if target_cpu.is_none() || target_cpu == Some(current_cpu) {
+        return false;
+    }
+    queue.push_back(thread_id);
+    true
+}
+
+#[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+pub(crate) fn clear_cpu_affinity_for_test(thread_id: u64) {
+    for slot in BOOT_TEST_CPU_AFFINITY.iter() {
+        let _ = slot.compare_exchange(thread_id, 0, Ordering::AcqRel, Ordering::Relaxed);
+    }
 }
 
 /// Global need_resched flag for timer interrupt
@@ -1010,6 +1075,14 @@ impl Scheduler {
         self.add_thread_inner(thread, true);
     }
 
+    #[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+    fn add_thread_on_cpu_for_test(&mut self, thread: Box<Thread>, cpu: usize) {
+        debug_assert!(cpu < MAX_CPUS);
+        let thread_id = thread.id();
+        self.threads.push(thread);
+        self.per_cpu_queues[cpu].push_back(thread_id);
+    }
+
     fn add_thread_inner(&mut self, thread: Box<Thread>, front: bool) {
         let thread_id = thread.id();
         let thread_name = thread.name.clone();
@@ -1045,11 +1118,7 @@ impl Scheduler {
     #[cfg(target_arch = "aarch64")]
     pub fn reclaim_terminated_threads(&mut self) {
         for queue in self.per_cpu_queues.iter_mut() {
-            queue.retain(|&thread_id| {
-                self.threads.iter().any(|thread| {
-                    thread.id() == thread_id && thread.state != ThreadState::Terminated
-                })
-            });
+            queue.retain(|&thread_id| self.threads.iter().any(|thread| thread.id() == thread_id));
         }
 
         let terminated_ids: alloc::vec::Vec<u64> = self
@@ -1108,6 +1177,9 @@ impl Scheduler {
         });
         self.retirement_grace
             .retain(|grace| !reclaimed_ids.contains(&grace.thread_id));
+        for queue in self.per_cpu_queues.iter_mut() {
+            queue.retain(|thread_id| !reclaimed_ids.contains(thread_id));
+        }
     }
 
     /// Add a thread as the current running thread without scheduling.
@@ -1271,11 +1343,20 @@ impl Scheduler {
         let current_cpu = Self::current_cpu_id();
         let mut next_thread_id = 'outer: loop {
             // Try local queue first
-            while let Some(n) = self.per_cpu_queues[current_cpu].pop_front() {
-                if let Some(thread) = self.get_thread(n) {
-                    if thread.state == ThreadState::Terminated {
-                        continue;
+            let local_candidates = self.per_cpu_queues[current_cpu].len();
+            for _ in 0..local_candidates {
+                let Some(n) = self.per_cpu_queues[current_cpu].pop_front() else {
+                    break;
+                };
+                let (terminated, owner_pid) = self
+                    .get_thread(n)
+                    .map(|thread| (thread.state == ThreadState::Terminated, thread.owner_pid))
+                    .unwrap_or((false, None));
+                if terminated {
+                    if owner_pid.is_some_and(|pid| !observe_exit_kick(pid)) {
+                        self.per_cpu_queues[current_cpu].push_back(n);
                     }
+                    continue;
                 }
                 break 'outer n;
             }
@@ -1284,7 +1365,19 @@ impl Scheduler {
                 if steal_cpu == current_cpu {
                     continue;
                 }
-                while let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() {
+                let steal_candidates = self.per_cpu_queues[steal_cpu].len();
+                for _ in 0..steal_candidates {
+                    let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() else {
+                        break;
+                    };
+                    #[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+                    if retain_cpu_affine_test_thread(
+                        &mut self.per_cpu_queues[steal_cpu],
+                        n,
+                        current_cpu,
+                    ) {
+                        continue;
+                    }
                     #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
                     if retain_ec0_fault_inject_on_cpu0(
                         &mut self.per_cpu_queues[steal_cpu],
@@ -1293,10 +1386,15 @@ impl Scheduler {
                     ) {
                         break;
                     }
-                    if let Some(thread) = self.get_thread(n) {
-                        if thread.state == ThreadState::Terminated {
-                            continue;
+                    let (terminated, owner_pid) = self
+                        .get_thread(n)
+                        .map(|thread| (thread.state == ThreadState::Terminated, thread.owner_pid))
+                        .unwrap_or((false, None));
+                    if terminated {
+                        if owner_pid.is_some_and(|pid| !observe_exit_kick(pid)) {
+                            self.per_cpu_queues[steal_cpu].push_back(n);
                         }
+                        continue;
                     }
                     break 'outer n;
                 }
@@ -1331,6 +1429,14 @@ impl Scheduler {
                             continue;
                         }
                         if let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() {
+                            #[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+                            if retain_cpu_affine_test_thread(
+                                &mut self.per_cpu_queues[steal_cpu],
+                                n,
+                                current_cpu,
+                            ) {
+                                continue;
+                            }
                             #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
                             if retain_ec0_fault_inject_on_cpu0(
                                 &mut self.per_cpu_queues[steal_cpu],
@@ -1525,19 +1631,30 @@ impl Scheduler {
         let mut should_requeue_old = false;
         if let Some(current_id) = self.cpu_state[Self::current_cpu_id()].current_thread {
             if current_id != self.cpu_state[Self::current_cpu_id()].idle_thread {
-                let (is_terminated, is_blocked) = if let Some(current) = self.get_thread(current_id)
-                {
-                    let was_terminated = current.state == ThreadState::Terminated;
-                    let was_blocked = current.state == ThreadState::Blocked
-                        || current.state == ThreadState::BlockedOnSignal
-                        || current.state == ThreadState::BlockedOnChildExit
-                        || current.state == ThreadState::BlockedOnTimer
-                        || current.state == ThreadState::BlockedOnIO;
+                let (is_terminated, is_blocked, terminated_owner_pid) =
+                    if let Some(current) = self.get_thread(current_id) {
+                        let was_terminated = current.state == ThreadState::Terminated;
+                        let was_blocked = current.state == ThreadState::Blocked
+                            || current.state == ThreadState::BlockedOnSignal
+                            || current.state == ThreadState::BlockedOnChildExit
+                            || current.state == ThreadState::BlockedOnTimer
+                            || current.state == ThreadState::BlockedOnIO;
 
-                    (was_terminated, was_blocked)
-                } else {
-                    (true, false)
-                };
+                        (
+                            was_terminated,
+                            was_blocked,
+                            was_terminated.then_some(current.owner_pid).flatten(),
+                        )
+                    } else {
+                        (true, false, None)
+                    };
+
+                // This peer scheduling pass is declining to dispatch a thread
+                // already quarantined by terminate_process_threads. Consume the
+                // matching teardown kick without taking any additional lock.
+                if let Some(owner_pid) = terminated_owner_pid {
+                    observe_exit_kick(owner_pid);
+                }
 
                 let published_ready = !is_terminated && !is_blocked;
                 let in_queue = self.per_cpu_queues.iter().any(|q| q.contains(&current_id));
@@ -1582,11 +1699,20 @@ impl Scheduler {
         let current_cpu = Self::current_cpu_id();
         let mut next_thread_id = 'sched_outer: loop {
             // Try local queue
-            while let Some(n) = self.per_cpu_queues[current_cpu].pop_front() {
-                if let Some(thread) = self.get_thread(n) {
-                    if thread.state == ThreadState::Terminated {
-                        continue;
+            let local_candidates = self.per_cpu_queues[current_cpu].len();
+            for _ in 0..local_candidates {
+                let Some(n) = self.per_cpu_queues[current_cpu].pop_front() else {
+                    break;
+                };
+                let (terminated, owner_pid) = self
+                    .get_thread(n)
+                    .map(|thread| (thread.state == ThreadState::Terminated, thread.owner_pid))
+                    .unwrap_or((false, None));
+                if terminated {
+                    if owner_pid.is_some_and(|pid| !observe_exit_kick(pid)) {
+                        self.per_cpu_queues[current_cpu].push_back(n);
                     }
+                    continue;
                 }
                 break 'sched_outer n;
             }
@@ -1595,7 +1721,19 @@ impl Scheduler {
                 if steal_cpu == current_cpu {
                     continue;
                 }
-                while let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() {
+                let steal_candidates = self.per_cpu_queues[steal_cpu].len();
+                for _ in 0..steal_candidates {
+                    let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() else {
+                        break;
+                    };
+                    #[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+                    if retain_cpu_affine_test_thread(
+                        &mut self.per_cpu_queues[steal_cpu],
+                        n,
+                        current_cpu,
+                    ) {
+                        continue;
+                    }
                     #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
                     if retain_ec0_fault_inject_on_cpu0(
                         &mut self.per_cpu_queues[steal_cpu],
@@ -1604,10 +1742,15 @@ impl Scheduler {
                     ) {
                         break;
                     }
-                    if let Some(thread) = self.get_thread(n) {
-                        if thread.state == ThreadState::Terminated {
-                            continue;
+                    let (terminated, owner_pid) = self
+                        .get_thread(n)
+                        .map(|thread| (thread.state == ThreadState::Terminated, thread.owner_pid))
+                        .unwrap_or((false, None));
+                    if terminated {
+                        if owner_pid.is_some_and(|pid| !observe_exit_kick(pid)) {
+                            self.per_cpu_queues[steal_cpu].push_back(n);
                         }
+                        continue;
                     }
                     break 'sched_outer n;
                 }
@@ -1641,6 +1784,14 @@ impl Scheduler {
                             continue;
                         }
                         if let Some(n) = self.per_cpu_queues[steal_cpu].pop_front() {
+                            #[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+                            if retain_cpu_affine_test_thread(
+                                &mut self.per_cpu_queues[steal_cpu],
+                                n,
+                                current_cpu,
+                            ) {
+                                continue;
+                            }
                             #[cfg(all(target_arch = "aarch64", feature = "ec0_fault_inject"))]
                             if retain_ec0_fault_inject_on_cpu0(
                                 &mut self.per_cpu_queues[steal_cpu],
@@ -1980,6 +2131,49 @@ impl Scheduler {
             crate::arch_impl::aarch64::constants::SGI_RESCHEDULE as u8,
             target_cpu as u8,
         );
+    }
+
+    /// Publish teardown-attributed evidence, then broadcast a reschedule SGI
+    /// to every other online CPU. This is intentionally separate from the two
+    /// generic wakeup helpers and must be called with no lock held.
+    pub fn send_exit_expedite_sgi(victim_pid: u64, batch: GroupBatchId) {
+        #[cfg(target_arch = "aarch64")]
+        {
+            use crate::arch_impl::aarch64::{constants::SGI_RESCHEDULE, gic, smp};
+            use crate::tracing::providers::teardown::{
+                KickPublishResult, EXIT_KICK_BUCKETS, EXIT_KICK_PUBLISHED, EXIT_KICK_SLOTS,
+            };
+
+            let bucket = victim_pid as usize % EXIT_KICK_BUCKETS;
+            let slot = &EXIT_KICK_SLOTS[bucket];
+            let at = crate::tracing::trace_timestamp();
+            match slot.publish(victim_pid, at) {
+                KickPublishResult::Published { displaced, .. } => {
+                    if displaced {
+                        crate::tracing::providers::teardown::record_exit_kick_collision(bucket);
+                    }
+                    crate::trace_count!(EXIT_KICK_PUBLISHED);
+                    crate::tracing::providers::teardown::record_exit_kick_published(bucket);
+                }
+                KickPublishResult::ReservationLost => {
+                    crate::tracing::providers::teardown::record_exit_kick_collision(bucket);
+                }
+            }
+
+            crate::trace_count!(crate::tracing::providers::teardown::EXIT_SGI_SENT);
+            crate::tracing::providers::teardown::record_exit_sgi_sent(victim_pid, batch.as_u64());
+
+            let current_cpu = Self::current_cpu_id();
+            let online = smp::cpus_online() as usize;
+            for cpu in 0..online.min(MAX_CPUS) {
+                if cpu != current_cpu {
+                    gic::send_sgi(SGI_RESCHEDULE as u8, cpu as u8);
+                }
+            }
+        }
+
+        #[cfg(not(target_arch = "aarch64"))]
+        let _ = (victim_pid, batch);
     }
 
     /// Block current thread until a signal is delivered
@@ -2689,27 +2883,42 @@ impl Scheduler {
     }
 
     /// Make every scheduler-owned thread for a process non-runnable.
-    #[cfg(target_arch = "aarch64")]
     pub fn terminate_process_threads(&mut self, owner_pid: u64) {
-        crate::trace_count!(crate::tracing::providers::teardown::TEARDOWN_QUARANTINE);
+        crate::tracing::providers::teardown::record_quarantine(owner_pid);
         if crate::process::process_manager_held_on_current_cpu() {
             crate::trace_count!(
                 crate::tracing::providers::teardown::TEARDOWN_LOCK_ORDER_SUSPECT
             );
         }
-        for thread in self.threads.iter_mut() {
-            if thread.owner_pid == Some(owner_pid) {
+        // Preserve one scheduler-visible quarantine token per victim thread. A
+        // peer can take SCHEDULER in the intentional gap before EXIT_KICK is
+        // published; a pre-publication decline requeues this token, and the SGI
+        // pass after publication consumes it. No CPU-residency predicate is
+        // needed, and unobserved collision cases age out with thread retirement.
+        for index in 0..self.threads.len() {
+            let thread_id = {
+                let thread = &mut self.threads[index];
+                if thread.owner_pid != Some(owner_pid) {
+                    continue;
+                }
                 thread.set_terminated();
+                thread.id()
+            };
+            if !self.per_cpu_queues.iter().any(|queue| queue.contains(&thread_id)) {
+                // A quarantine pass may not allocate while SCHEDULER is held.
+                // A running thread was previously popped from a queue, so the
+                // normal path has retained capacity for this token. If every
+                // queue is genuinely full, the outgoing-current observation
+                // hook remains the evidence path for a running victim.
+                if let Some(target) = (0..MAX_CPUS)
+                    .filter(|&cpu| {
+                        self.per_cpu_queues[cpu].len() < self.per_cpu_queues[cpu].capacity()
+                    })
+                    .min_by_key(|&cpu| self.per_cpu_queues[cpu].len())
+                {
+                    self.per_cpu_queues[target].push_back(thread_id);
+                }
             }
-        }
-
-        let threads = &self.threads;
-        for queue in self.per_cpu_queues.iter_mut() {
-            queue.retain(|&thread_id| {
-                !threads.iter().any(|thread| {
-                    thread.id() == thread_id && thread.owner_pid == Some(owner_pid)
-                })
-            });
         }
     }
 
@@ -3000,6 +3209,23 @@ pub fn spawn(thread: Box<Thread>) {
         } else {
             panic!("Scheduler not initialized");
         }
+    });
+}
+
+/// Test-only deterministic placement for concurrent protocol gates.
+#[cfg(all(target_arch = "aarch64", feature = "boot_tests"))]
+pub(crate) fn spawn_on_cpu_for_test(thread: Box<Thread>, cpu: usize) {
+    without_interrupts(|| {
+        let thread_id = thread.id();
+        let mut scheduler_lock = lock_scheduler();
+        let scheduler = scheduler_lock
+            .as_mut()
+            .expect("scheduler not initialized for test placement");
+        BOOT_TEST_CPU_AFFINITY[cpu].store(thread_id, Ordering::Release);
+        scheduler.add_thread_on_cpu_for_test(thread, cpu);
+        NEED_RESCHED.store(true, Ordering::Relaxed);
+        crate::per_cpu_aarch64::set_need_resched(true);
+        scheduler.send_resched_ipi_to_cpu(cpu);
     });
 }
 

--- a/kernel/src/test_framework/catalog.rs
+++ b/kernel/src/test_framework/catalog.rs
@@ -177,6 +177,7 @@ pub const UTEST_UNIX_NAMED_SOCKET: u16 = 372;
 pub const UTEST_PIPE_FORK: u16 = 373;
 pub const UTEST_PIPE_CONCURRENT: u16 = 374;
 pub const UTEST_JOB_CONTROL: u16 = 375;
+pub const UTEST_SIGKILL_TEARDOWN: u16 = 376;
 
 // =============================================================================
 // Full Catalog
@@ -740,6 +741,11 @@ pub static CATALOG: &[BootTestDef] = &[
         name: "utest_job_control",
         category: BootTestCategory::UserspaceResult,
     },
+    BootTestDef {
+        id: UTEST_SIGKILL_TEARDOWN,
+        name: "utest_sigkill_teardown",
+        category: BootTestCategory::UserspaceResult,
+    },
 ];
 
 /// Look up a test name by ID.
@@ -834,6 +840,7 @@ pub fn utest_name_to_id(name: &str) -> Option<u16> {
         "pipe_fork_test" => Some(UTEST_PIPE_FORK),
         "pipe_concurrent_test" => Some(UTEST_PIPE_CONCURRENT),
         "job_control_test" => Some(UTEST_JOB_CONTROL),
+        "sigkill_teardown_test" => Some(UTEST_SIGKILL_TEARDOWN),
         _ => None,
     }
 }

--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -5052,6 +5052,22 @@ static PROCESS_TESTS: &[TestDef] = &[
         timeout_ms: 10000,
         stage: TestStage::PostScheduler,
     },
+    #[cfg(target_arch = "aarch64")]
+    TestDef {
+        name: "exit_kick_protocol_gate",
+        func: crate::tracing::providers::teardown::exit_kick_protocol_gate_test,
+        arch: Arch::Aarch64,
+        timeout_ms: 30000,
+        stage: TestStage::PostScheduler,
+    },
+    #[cfg(all(target_arch = "aarch64", feature = "receipt_drop_test"))]
+    TestDef {
+        name: "retirement_receipt_drop_gate",
+        func: crate::task::process_task::retirement_receipt_drop_gate_test,
+        arch: Arch::Aarch64,
+        timeout_ms: 5000,
+        stage: TestStage::PostScheduler,
+    },
     // Note: Userspace stage tests cannot run from syscall context (would block).
     // The Userspace stage is marked when EL0/Ring3 syscall is confirmed, but
     // tests at this stage are skipped. The confirmation itself is the test.

--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -1278,6 +1278,23 @@ fn test_timer_delay() -> TestResult {
     {
         use crate::arch_impl::aarch64::timer;
 
+        struct TimerDelayPreemptGuard;
+
+        impl TimerDelayPreemptGuard {
+            fn enter() -> Self {
+                crate::per_cpu_aarch64::preempt_disable();
+                Self
+            }
+        }
+
+        impl Drop for TimerDelayPreemptGuard {
+            fn drop(&mut self) {
+                crate::per_cpu_aarch64::preempt_enable();
+            }
+        }
+
+        let _preempt_guard = TimerDelayPreemptGuard::enter();
+
         // Get frequency for nanosecond calculations
         let freq = timer::frequency_hz();
         if freq == 0 {

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -11,6 +11,214 @@ use core::sync::atomic::{AtomicU64, Ordering};
 pub const PROVIDER_ID: u8 = 0x0a;
 pub const TEARDOWN_DEFER_EVENT: u16 = ((PROVIDER_ID as u16) << 8) | 0x00;
 pub const TEARDOWN_RECLAIM_EVENT: u16 = ((PROVIDER_ID as u16) << 8) | 0x01;
+pub const EXIT_SGI_SENT_EVENT: u16 = ((PROVIDER_ID as u16) << 8) | 0x02;
+pub const EXIT_SGI_BATCH_EVENT: u16 = ((PROVIDER_ID as u16) << 8) | 0x03;
+pub const EXIT_KICK_OBSERVED_EVENT: u16 = ((PROVIDER_ID as u16) << 8) | 0x04;
+
+pub(crate) const EXIT_KICK_BUCKETS: usize = 64;
+pub(crate) const EXIT_KICK_LOCK: u64 = 0b10;
+pub(crate) const EXIT_KICK_OBSERVED_BIT: u64 = 0b01;
+pub(crate) const KICK_RESERVE_ATTEMPTS: usize = 4;
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static EXIT_KICK_TEST_HOOK_PID: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static EXIT_KICK_TEST_HOOK_RESERVED: AtomicU64 = AtomicU64::new(0);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static EXIT_KICK_TEST_HOOK_RELEASE: AtomicU64 = AtomicU64::new(1);
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+static EXIT_KICK_TEST_HOOK_CPU: AtomicU64 = AtomicU64::new(u64::MAX);
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+struct ExitKickTestHookGuard;
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl ExitKickTestHookGuard {
+    fn arm(pid: u64) -> Self {
+        EXIT_KICK_TEST_HOOK_CPU.store(u64::MAX, Ordering::Relaxed);
+        EXIT_KICK_TEST_HOOK_RESERVED.store(0, Ordering::Relaxed);
+        EXIT_KICK_TEST_HOOK_RELEASE.store(0, Ordering::Relaxed);
+        EXIT_KICK_TEST_HOOK_PID.store(pid, Ordering::Release);
+        Self
+    }
+
+    fn release(&self) {
+        EXIT_KICK_TEST_HOOK_RELEASE.store(1, Ordering::Release);
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+impl Drop for ExitKickTestHookGuard {
+    fn drop(&mut self) {
+        // A failed assertion or early return must never strand the publisher
+        // in the synthetic reserve-to-commit hold point.
+        EXIT_KICK_TEST_HOOK_RELEASE.store(1, Ordering::Release);
+        EXIT_KICK_TEST_HOOK_PID.store(0, Ordering::Release);
+    }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+#[inline(always)]
+fn hold_exit_kick_test_publisher(pid: u64) {
+    if EXIT_KICK_TEST_HOOK_PID.load(Ordering::Acquire) != pid {
+        return;
+    }
+    EXIT_KICK_TEST_HOOK_CPU.store(
+        crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as u64,
+        Ordering::Relaxed,
+    );
+    EXIT_KICK_TEST_HOOK_RESERVED.store(1, Ordering::Release);
+    while EXIT_KICK_TEST_HOOK_RELEASE.load(Ordering::Acquire) == 0 {
+        core::hint::spin_loop();
+    }
+}
+
+pub(crate) struct KickSlot {
+    pub(crate) pid: AtomicU64,
+    pub(crate) at: AtomicU64,
+    pub(crate) state: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KickPublishResult {
+    Published { generation: u64, displaced: bool },
+    ReservationLost,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct KickObservation {
+    pub(crate) generation: u64,
+    pub(crate) pid: u64,
+    pub(crate) at: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct KickReservation {
+    displaced_state: u64,
+    generation: u64,
+}
+
+impl KickSlot {
+    const fn new() -> Self {
+        Self {
+            pid: AtomicU64::new(0),
+            at: AtomicU64::new(0),
+            state: AtomicU64::new(0),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn reserve(&self) -> Option<KickReservation> {
+        let mut current = self.state.load(Ordering::Relaxed);
+        for _ in 0..KICK_RESERVE_ATTEMPTS {
+            if current & EXIT_KICK_LOCK != 0 {
+                return None;
+            }
+            let generation = (current >> 2).wrapping_add(1);
+            let reserved_state = (generation << 2) | EXIT_KICK_LOCK;
+            match self.state.compare_exchange_weak(
+                current,
+                reserved_state,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return Some(KickReservation {
+                        displaced_state: current,
+                        generation,
+                    });
+                }
+                Err(actual) => current = actual,
+            }
+        }
+        None
+    }
+
+    #[inline(always)]
+    pub(crate) fn commit(
+        &self,
+        reservation: KickReservation,
+        pid: u64,
+        at: u64,
+    ) -> KickPublishResult {
+        let displaced = reservation.displaced_state >> 2 != 0
+            && reservation.displaced_state & EXIT_KICK_OBSERVED_BIT == 0
+            && self.pid.load(Ordering::Relaxed) != pid;
+        self.pid.store(pid, Ordering::Relaxed);
+        self.at.store(at, Ordering::Relaxed);
+        self.state
+            .store(reservation.generation << 2, Ordering::Release);
+        KickPublishResult::Published {
+            generation: reservation.generation,
+            displaced,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn publish(&self, pid: u64, at: u64) -> KickPublishResult {
+        match self.reserve() {
+            Some(reservation) => {
+                #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+                hold_exit_kick_test_publisher(pid);
+                self.commit(reservation, pid, at)
+            }
+            None => KickPublishResult::ReservationLost,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn observe(&self, expected_pid: u64) -> Option<KickObservation> {
+        let first_state = self.state.load(Ordering::Acquire);
+        if first_state >> 2 == 0 || first_state & (EXIT_KICK_LOCK | EXIT_KICK_OBSERVED_BIT) != 0 {
+            return None;
+        }
+
+        let pid = self.pid.load(Ordering::Relaxed);
+        let at = self.at.load(Ordering::Relaxed);
+        let second_state = self.state.load(Ordering::Acquire);
+        if second_state != first_state || pid != expected_pid {
+            return None;
+        }
+
+        self.state
+            .compare_exchange(
+                first_state,
+                first_state | EXIT_KICK_OBSERVED_BIT,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .ok()
+            .map(|_| KickObservation {
+                generation: first_state >> 2,
+                pid,
+                at,
+            })
+    }
+
+    #[inline(always)]
+    pub(crate) fn is_observed_for(&self, expected_pid: u64) -> bool {
+        let first_state = self.state.load(Ordering::Acquire);
+        if first_state >> 2 == 0
+            || first_state & EXIT_KICK_LOCK != 0
+            || first_state & EXIT_KICK_OBSERVED_BIT == 0
+        {
+            return false;
+        }
+        let pid = self.pid.load(Ordering::Relaxed);
+        let second_state = self.state.load(Ordering::Acquire);
+        second_state == first_state && pid == expected_pid
+    }
+}
+
+pub(crate) static EXIT_KICK_SLOTS: [KickSlot; EXIT_KICK_BUCKETS] =
+    [const { KickSlot::new() }; EXIT_KICK_BUCKETS];
+
+static EXIT_KICK_BUCKET_PUBLISH_COUNTS: [AtomicU64; EXIT_KICK_BUCKETS] =
+    [const { AtomicU64::new(0) }; EXIT_KICK_BUCKETS];
+static EXIT_KICK_BUCKET_OBSERVED_COUNTS: [AtomicU64; EXIT_KICK_BUCKETS] =
+    [const { AtomicU64::new(0) }; EXIT_KICK_BUCKETS];
+static EXIT_KICK_BUCKET_COLLISION_COUNTS: [AtomicU64; EXIT_KICK_BUCKETS] =
+    [const { AtomicU64::new(0) }; EXIT_KICK_BUCKETS];
 
 #[no_mangle]
 pub static TEARDOWN_PROVIDER: TraceProvider = TraceProvider {
@@ -98,16 +306,18 @@ counter!(
     "Immediately unparked reclaims"
 );
 counter!(RECLAIM_PARK_RESIDENT, "Resident parked reclaims");
-
-// Declaration-only until the phase named in PLAN.md. These intentionally have
-// no trace_count! producer yet.
-counter!(TEARDOWN_ENTRY_GROUP, "Group teardown entries");
 counter!(EXIT_SGI_SENT, "Teardown-attributed expedite SGIs");
-counter!(EXIT_REQUEST_OBSERVED, "Observed latched exit requests");
 counter!(EXIT_KICK_PUBLISHED, "Published exit-kick buckets");
 counter!(EXIT_KICK_OBSERVED, "Observed exit-kick victims");
 counter!(EXIT_KICK_BUCKET_COLLISION, "Exit-kick bucket collisions");
 counter!(RECEIPT_DROPPED_UNRETIRED, "Receipts recovered by Drop");
+counter!(LEDGER_CLAIM_MISMATCH, "Exit-obligation claimer mismatches");
+counter!(LEDGER_CLAIM_ORPHANED, "Recovered orphaned exit claims");
+
+// Declaration-only until the phase named in PLAN.md. These intentionally have
+// no trace_count! producer yet.
+counter!(TEARDOWN_ENTRY_GROUP, "Group teardown entries");
+counter!(EXIT_REQUEST_OBSERVED, "Observed latched exit requests");
 counter!(LEDGER_EFFECT_AMBIGUOUS_REPORT, "Ambiguous report effects");
 counter!(
     TOMBSTONE_JOIN_REAP_SECOND,
@@ -131,7 +341,7 @@ counter!(
     "Fatal group signals dropped for init"
 );
 
-pub const COUNTER_COUNT: usize = 45;
+pub const COUNTER_COUNT: usize = 47;
 
 /// The registration and normal-context reader inventory. Keeping one inventory
 /// makes a write-only counter structurally impossible without changing the P0
@@ -168,6 +378,8 @@ pub static COUNTERS: [&TraceCounter; COUNTER_COUNT] = [
     &EXIT_KICK_OBSERVED,
     &EXIT_KICK_BUCKET_COLLISION,
     &RECEIPT_DROPPED_UNRETIRED,
+    &LEDGER_CLAIM_MISMATCH,
+    &LEDGER_CLAIM_ORPHANED,
     &RECLAIM_PASS_SKIPPED,
     &RECLAIM_PARKED,
     &RECLAIM_UNPARKED_EPOCH,
@@ -200,13 +412,19 @@ pub fn snapshot() -> [u64; COUNTER_COUNT] {
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-const BOOT_TEST_PID_COUNT_SLOTS: usize = 128;
+const BOOT_TEST_PID_COUNT_SLOTS: usize = 256;
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 struct BootTestPidCountSlot {
     pid: AtomicU64,
     defer_count: AtomicU64,
     reclaim_count: AtomicU64,
+    quarantine_count: AtomicU64,
+    sgi_sent_count: AtomicU64,
+    kick_observed_count: AtomicU64,
+    kick_observed_interval: AtomicU64,
+    masked_frames_walked: AtomicU64,
+    report_count: AtomicU64,
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
@@ -216,6 +434,12 @@ impl BootTestPidCountSlot {
             pid: AtomicU64::new(0),
             defer_count: AtomicU64::new(0),
             reclaim_count: AtomicU64::new(0),
+            quarantine_count: AtomicU64::new(0),
+            sgi_sent_count: AtomicU64::new(0),
+            kick_observed_count: AtomicU64::new(0),
+            kick_observed_interval: AtomicU64::new(0),
+            masked_frames_walked: AtomicU64::new(0),
+            report_count: AtomicU64::new(0),
         }
     }
 }
@@ -241,6 +465,11 @@ impl Drop for BootTestPidCountsGuard {
 enum BootTestPidCountKind {
     Defer,
     Reclaim,
+    Quarantine,
+    SgiSent,
+    KickObserved(u64),
+    MaskedFramesWalked,
+    Report,
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
@@ -262,6 +491,23 @@ fn record_boot_test_pid_count(pid: u64, kind: BootTestPidCountKind) {
                 BootTestPidCountKind::Reclaim => {
                     slot.reclaim_count.fetch_add(1, Ordering::Relaxed);
                 }
+                BootTestPidCountKind::Quarantine => {
+                    slot.quarantine_count.fetch_add(1, Ordering::Relaxed);
+                }
+                BootTestPidCountKind::SgiSent => {
+                    slot.sgi_sent_count.fetch_add(1, Ordering::Relaxed);
+                }
+                BootTestPidCountKind::KickObserved(interval) => {
+                    slot.kick_observed_interval
+                        .store(interval, Ordering::Relaxed);
+                    slot.kick_observed_count.fetch_add(1, Ordering::Release);
+                }
+                BootTestPidCountKind::MaskedFramesWalked => {
+                    slot.masked_frames_walked.fetch_add(1, Ordering::Relaxed);
+                }
+                BootTestPidCountKind::Report => {
+                    slot.report_count.fetch_add(1, Ordering::Relaxed);
+                }
             }
             return;
         }
@@ -278,6 +524,12 @@ fn reset_boot_test_pid_counts() -> BootTestPidCountsGuard {
         slot.pid.store(0, Ordering::Relaxed);
         slot.defer_count.store(0, Ordering::Relaxed);
         slot.reclaim_count.store(0, Ordering::Relaxed);
+        slot.quarantine_count.store(0, Ordering::Relaxed);
+        slot.sgi_sent_count.store(0, Ordering::Relaxed);
+        slot.kick_observed_count.store(0, Ordering::Relaxed);
+        slot.kick_observed_interval.store(0, Ordering::Relaxed);
+        slot.masked_frames_walked.store(0, Ordering::Relaxed);
+        slot.report_count.store(0, Ordering::Relaxed);
     }
     BOOT_TEST_PID_COUNTS_ACTIVE.store(1, Ordering::Release);
     BootTestPidCountsGuard
@@ -345,6 +597,111 @@ pub fn record_reclaim(pid: u64) {
     crate::trace_event!(TEARDOWN_PROVIDER, TEARDOWN_RECLAIM_EVENT, pid as u32);
     #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
     record_boot_test_pid_count(pid, BootTestPidCountKind::Reclaim);
+}
+
+#[inline(always)]
+pub fn record_quarantine(pid: u64) {
+    crate::trace_count!(TEARDOWN_QUARANTINE);
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::Quarantine);
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = pid;
+}
+
+#[inline(always)]
+pub fn record_exit_sgi_sent(pid: u64, batch: u64) {
+    crate::trace_event!(TEARDOWN_PROVIDER, EXIT_SGI_SENT_EVENT, pid as u32);
+    crate::trace_event!(TEARDOWN_PROVIDER, EXIT_SGI_BATCH_EVENT, batch as u32);
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::SgiSent);
+}
+
+#[inline(always)]
+pub fn record_exit_kick_published(bucket: usize) {
+    EXIT_KICK_BUCKET_PUBLISH_COUNTS[bucket].fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline(always)]
+pub fn record_exit_kick_collision(bucket: usize) {
+    crate::trace_count!(EXIT_KICK_BUCKET_COLLISION);
+    EXIT_KICK_BUCKET_COLLISION_COUNTS[bucket].fetch_add(1, Ordering::Relaxed);
+}
+
+#[inline(always)]
+pub fn record_exit_kick_observed(pid: u64, interval: u64) {
+    crate::trace_count!(EXIT_KICK_OBSERVED);
+    EXIT_KICK_BUCKET_OBSERVED_COUNTS[pid as usize % EXIT_KICK_BUCKETS]
+        .fetch_add(1, Ordering::Relaxed);
+    crate::trace_event!(TEARDOWN_PROVIDER, EXIT_KICK_OBSERVED_EVENT, pid as u32);
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::KickObserved(interval));
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = interval;
+}
+
+#[inline(always)]
+pub fn record_masked_frames_walked(pid: u64) {
+    crate::trace_count!(TEARDOWN_MASKED_FRAMES_WALKED);
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::MaskedFramesWalked);
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = pid;
+}
+
+#[inline(always)]
+pub fn record_report(pid: u64) {
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::Report);
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = pid;
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+#[derive(Clone, Copy)]
+pub struct TeardownPidEvidence {
+    pub defer_count: u64,
+    pub reclaim_count: u64,
+    pub quarantine_count: u64,
+    pub sgi_sent_count: u64,
+    pub kick_observed_count: u64,
+    pub kick_observed_interval: u64,
+    pub masked_frames_walked: u64,
+    pub report_count: u64,
+    pub bucket_published_count: u64,
+    pub bucket_observed_count: u64,
+    pub bucket_collision_count: u64,
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub fn teardown_pid_evidence(pid: u64) -> Option<TeardownPidEvidence> {
+    // Reading the per-pid procfs file is the test's explicit opt-in. It occurs
+    // before the kill, so every hot-path recorder remains bounded and lock-free.
+    BOOT_TEST_PID_COUNTS_ACTIVE.store(1, Ordering::Release);
+    if !track_boot_test_pid(pid) {
+        return None;
+    }
+    let slot = BOOT_TEST_PID_COUNTS
+        .iter()
+        .find(|slot| slot.pid.load(Ordering::Acquire) == pid)?;
+    let bucket = pid as usize % EXIT_KICK_BUCKETS;
+    Some(TeardownPidEvidence {
+        defer_count: slot.defer_count.load(Ordering::Acquire),
+        reclaim_count: slot.reclaim_count.load(Ordering::Acquire),
+        quarantine_count: slot.quarantine_count.load(Ordering::Acquire),
+        sgi_sent_count: slot.sgi_sent_count.load(Ordering::Acquire),
+        kick_observed_count: slot.kick_observed_count.load(Ordering::Acquire),
+        kick_observed_interval: slot.kick_observed_interval.load(Ordering::Acquire),
+        masked_frames_walked: slot.masked_frames_walked.load(Ordering::Acquire),
+        report_count: slot.report_count.load(Ordering::Acquire),
+        bucket_published_count: EXIT_KICK_BUCKET_PUBLISH_COUNTS[bucket].load(Ordering::Acquire),
+        bucket_observed_count: EXIT_KICK_BUCKET_OBSERVED_COUNTS[bucket].load(Ordering::Acquire),
+        bucket_collision_count: EXIT_KICK_BUCKET_COLLISION_COUNTS[bucket].load(Ordering::Acquire),
+    })
+}
+
+#[cfg(feature = "boot_tests")]
+pub fn exit_kick_bucket_publish_count(bucket: usize) -> u64 {
+    EXIT_KICK_BUCKET_PUBLISH_COUNTS[bucket % EXIT_KICK_BUCKETS].load(Ordering::Acquire)
 }
 
 #[inline(always)]
@@ -470,6 +827,7 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     let lock_order_suspect_before = TEARDOWN_LOCK_ORDER_SUSPECT.aggregate();
     let proof_under_queue_lock_before = PROOF_UNDER_QUEUE_LOCK.aggregate();
     let reclaim_context_violations_before = RECLAIM_CONTEXT_VIOLATIONS.aggregate();
+    let receipt_dropped_before = RECEIPT_DROPPED_UNRETIRED.aggregate();
 
     let parent_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
         Ok(page_table) => alloc::boxed::Box::new(page_table),
@@ -515,7 +873,22 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     let mut pairing_child_pids = [0u64; 64];
     let mut pairing_child_count = 0;
     let pid_counts_guard = reset_boot_test_pid_counts();
-    for _ in 0..64 {
+    // The nine labels mirror PLAN P2's disjoint adapted-site table. The exact
+    // source ratchets below prove which concrete callers use each custody
+    // shape; this runtime matrix injects one independent process through every
+    // labeled shape and then continues to 64 iterations for the P0 soak.
+    const ADAPTED_SITE_CLASSES: [u8; 9] = [
+        1, // aarch64 lower-EL data abort
+        1, // aarch64 lower-EL instruction abort
+        1, // aarch64 lower-EL SP alignment fault
+        1, // aarch64 lower-EL PC alignment fault
+        1, // x86_64 page fault
+        1, // x86_64 general-protection fault
+        1, // process::exit_current
+        3, // handle_thread_exit phase-1 receipt
+        2, // SIGKILL after quarantine/expedite
+    ];
+    for iteration in 0..64 {
         let child_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
             Ok(page_table) => alloc::boxed::Box::new(page_table),
             Err(_) => return TestResult::Fail("pairing fork page-table allocation failed"),
@@ -549,8 +922,20 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         }
         pairing_child_count += 1;
 
-        crate::process::exit_process_for_teardown_test(child.0, 0);
-        crate::task::process_task::ProcessScheduler::handle_thread_exit(child.1, 0);
+        let site_class = ADAPTED_SITE_CLASSES[iteration % ADAPTED_SITE_CLASSES.len()];
+        if site_class == 3 {
+            {
+                let _force_live =
+                    crate::task::process_task::ForceLiveReclaimTestGuard::arm(child.0.as_u64());
+                crate::task::process_task::ProcessScheduler::handle_thread_exit(child.1, 0);
+            }
+            // Preserve the gate's first/repeat accounting workload without
+            // creating a second receipt or reclaim record.
+            crate::task::process_task::ProcessScheduler::handle_thread_exit(child.1, 0);
+        } else {
+            crate::process::exit_process_for_teardown_test(child.0, 0);
+            crate::task::process_task::ProcessScheduler::handle_thread_exit(child.1, 0);
+        }
         {
             let mut manager_guard = crate::process::manager();
             let Some(manager) = manager_guard.as_mut() else {
@@ -637,10 +1022,17 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     }
     for pid in pairing_child_pids {
         let (defer_count, reclaim_count) = boot_test_pid_counts(pid);
-        if defer_count == 0 || defer_count != reclaim_count {
-            return TestResult::Fail(
-                "per-PID defer/reclaim count pairing failed for a pairing-test child",
-            );
+        if defer_count == 0 {
+            return TestResult::Fail("adapted-site per-PID defer proof was absent");
+        }
+        if defer_count > 1 {
+            return TestResult::Fail("adapted-site per-PID defer proof was duplicated");
+        }
+        if reclaim_count == 0 {
+            return TestResult::Fail("adapted-site per-PID reclaim proof was absent");
+        }
+        if reclaim_count > 1 {
+            return TestResult::Fail("adapted-site per-PID reclaim proof was duplicated");
         }
     }
     if TEARDOWN_MASKED_FRAMES_WALKED
@@ -651,12 +1043,15 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
             .aggregate()
             .saturating_sub(fd_closes_under_pm_before)
             == 0
-        || RECLAIM_ENQUEUE_UNDER_PM
-            .aggregate()
-            .saturating_sub(reclaim_enqueue_under_pm_before)
-            == 0
     {
-        return TestResult::Fail("expected Phase-0 under-PM baseline remained zero");
+        return TestResult::Fail("retained pre-P7 under-PM baseline unexpectedly disappeared");
+    }
+    if RECLAIM_ENQUEUE_UNDER_PM
+        .aggregate()
+        .saturating_sub(reclaim_enqueue_under_pm_before)
+        != 0
+    {
+        return TestResult::Fail("P2 reclaim enqueue still occurred under PM");
     }
     if TEARDOWN_LOCK_ORDER_SUSPECT
         .aggregate()
@@ -673,6 +1068,14 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     {
         return TestResult::Fail("healthy teardown lock-context counter moved");
     }
+    if RECEIPT_DROPPED_UNRETIRED
+        .aggregate()
+        .saturating_sub(receipt_dropped_before)
+        != 0
+        || LEDGER_CLAIM_ORPHANED.aggregate() != 0
+    {
+        return TestResult::Fail("receipt custody or pre-P6b orphan counter moved");
+    }
     let _all_counter_readers = snapshot();
 
     {
@@ -687,5 +1090,548 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     }
 
     core::mem::drop(pid_counts_guard);
+    TestResult::Pass
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestResult {
+    use crate::test_framework::registry::TestResult;
+    use alloc::sync::Arc;
+    use alloc::vec::Vec;
+    use core::sync::atomic::AtomicBool;
+
+    struct BrokenV3Slot {
+        pid: AtomicU64,
+        at: AtomicU64,
+        seq: AtomicU64,
+    }
+
+    impl BrokenV3Slot {
+        const fn new() -> Self {
+            Self {
+                pid: AtomicU64::new(0),
+                at: AtomicU64::new(0),
+                seq: AtomicU64::new(0),
+            }
+        }
+
+        fn publish(&self, pid: u64, at: u64) {
+            self.pid.store(pid, Ordering::Relaxed);
+            self.at.store(at, Ordering::Relaxed);
+            self.seq.fetch_add(2, Ordering::Release);
+        }
+
+        fn observe(&self, expected_pid: u64) -> Option<(u64, u64)> {
+            let first = self.seq.load(Ordering::Acquire);
+            if first == 0 || first & 1 != 0 {
+                return None;
+            }
+            let pid = self.pid.load(Ordering::Relaxed);
+            let at = self.at.load(Ordering::Relaxed);
+            if self.seq.load(Ordering::Acquire) != first || pid != expected_pid {
+                return None;
+            }
+            self.seq
+                .compare_exchange(first, first | 1, Ordering::AcqRel, Ordering::Relaxed)
+                .ok()
+                .map(|_| (pid, at))
+        }
+    }
+
+    // Reproduce the historical v3 sticky-observed defect exactly: fetch_add(2)
+    // preserves bit zero, so generation two is absent after generation one was
+    // observed. The real protocol must pass the same sequential reuse cycle.
+    let broken = BrokenV3Slot::new();
+    broken.publish(7, 11);
+    if broken.observe(7) != Some((7, 11)) {
+        return TestResult::Fail("broken-v3 first observation did not establish the fixture");
+    }
+    broken.publish(71, 12);
+    if broken.observe(71).is_some() {
+        return TestResult::Fail("broken-v3 fixture unexpectedly allowed bucket reuse");
+    }
+
+    let reusable = KickSlot::new();
+    let first = reusable.publish(7, 21);
+    let first_observation = reusable.observe(7);
+    let second = reusable.publish(71, 22);
+    let second_observation = reusable.observe(71);
+    if !matches!(
+        first,
+        KickPublishResult::Published {
+            generation: 1,
+            displaced: false
+        }
+    ) || first_observation
+        != Some(KickObservation {
+            generation: 1,
+            pid: 7,
+            at: 21,
+        })
+        || !matches!(
+            second,
+            KickPublishResult::Published {
+                generation: 2,
+                displaced: false
+            }
+        )
+        || second_observation
+            != Some(KickObservation {
+                generation: 2,
+                pid: 71,
+                at: 22,
+            })
+    {
+        return TestResult::Fail("real exit-kick protocol failed sequential bucket reuse");
+    }
+
+    // Reservation-lost arm: the RAII-disarmed hook holds publisher A on one
+    // CPU after reserve. Publisher B must run on a different CPU, lose that
+    // reservation, leave the payload untouched, account the collision, and
+    // still reach the SGI broadcast tail before A is released.
+    const RESERVATION_PID_A: u64 = u64::MAX - 7;
+    const RESERVATION_PID_B: u64 = RESERVATION_PID_A - EXIT_KICK_BUCKETS as u64;
+    let reservation_bucket = RESERVATION_PID_A as usize % EXIT_KICK_BUCKETS;
+    let reservation_slot = &EXIT_KICK_SLOTS[reservation_bucket];
+    let payload_before = (
+        reservation_slot.pid.load(Ordering::Relaxed),
+        reservation_slot.at.load(Ordering::Relaxed),
+    );
+    let published_before = EXIT_KICK_PUBLISHED.aggregate();
+    let collision_before = EXIT_KICK_BUCKET_COLLISION.aggregate();
+    let sgi_before = EXIT_SGI_SENT.aggregate();
+    let publisher_a_done = Arc::new(AtomicU64::new(0));
+    let publisher_b_done = Arc::new(AtomicU64::new(0));
+    let publisher_b_cpu = Arc::new(AtomicU64::new(u64::MAX));
+    let hook = ExitKickTestHookGuard::arm(RESERVATION_PID_A);
+
+    let a_done = Arc::clone(&publisher_a_done);
+    let publisher_a = match crate::task::kthread::kthread_run(
+        move || {
+            crate::task::scheduler::Scheduler::send_exit_expedite_sgi(
+                RESERVATION_PID_A,
+                crate::task::scheduler::GroupBatchId::for_single_victim(RESERVATION_PID_A),
+            );
+            a_done.store(1, Ordering::Release);
+        },
+        "exit_kick_reserve_a",
+    ) {
+        Ok(handle) => handle,
+        Err(_) => return TestResult::Fail("failed to spawn held exit-kick publisher A"),
+    };
+
+    while EXIT_KICK_TEST_HOOK_RESERVED.load(Ordering::Acquire) == 0 {
+        crate::task::scheduler::yield_current();
+        core::hint::spin_loop();
+    }
+
+    let b_done = Arc::clone(&publisher_b_done);
+    let b_cpu = Arc::clone(&publisher_b_cpu);
+    let publisher_b = match crate::task::kthread::kthread_run(
+        move || {
+            b_cpu.store(
+                crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as u64,
+                Ordering::Relaxed,
+            );
+            crate::task::scheduler::Scheduler::send_exit_expedite_sgi(
+                RESERVATION_PID_B,
+                crate::task::scheduler::GroupBatchId::for_single_victim(RESERVATION_PID_B),
+            );
+            b_done.store(1, Ordering::Release);
+        },
+        "exit_kick_reserve_b",
+    ) {
+        Ok(handle) => handle,
+        Err(_) => {
+            hook.release();
+            let _ = crate::task::kthread::kthread_join(&publisher_a);
+            return TestResult::Fail("failed to spawn colliding exit-kick publisher B");
+        }
+    };
+
+    while publisher_b_done.load(Ordering::Acquire) == 0 {
+        crate::task::scheduler::yield_current();
+        core::hint::spin_loop();
+    }
+
+    let publisher_a_cpu = EXIT_KICK_TEST_HOOK_CPU.load(Ordering::Acquire);
+    let publisher_b_cpu = publisher_b_cpu.load(Ordering::Acquire);
+    let loser_payload = (
+        reservation_slot.pid.load(Ordering::Relaxed),
+        reservation_slot.at.load(Ordering::Relaxed),
+    );
+    let loser_accounting_exact = EXIT_KICK_PUBLISHED.aggregate() == published_before
+        && EXIT_KICK_BUCKET_COLLISION.aggregate() == collision_before + 1
+        && EXIT_SGI_SENT.aggregate() == sgi_before + 1;
+
+    hook.release();
+    let joined = crate::task::kthread::kthread_join(&publisher_b).is_ok()
+        && crate::task::kthread::kthread_join(&publisher_a).is_ok();
+    core::mem::drop(hook);
+
+    if !joined
+        || publisher_a_done.load(Ordering::Acquire) != 1
+        || publisher_a_cpu == u64::MAX
+        || publisher_b_cpu == u64::MAX
+        || publisher_a_cpu == publisher_b_cpu
+        || loser_payload != payload_before
+        || !loser_accounting_exact
+        || EXIT_KICK_PUBLISHED.aggregate() != published_before + 1
+        || EXIT_KICK_BUCKET_COLLISION.aggregate() != collision_before + 1
+        || EXIT_SGI_SENT.aggregate() != sgi_before + 2
+    {
+        return TestResult::Fail("deterministic two-CPU reservation-loss arm failed");
+    }
+
+    let Some(reservation_observation) = reservation_slot.observe(RESERVATION_PID_A) else {
+        return TestResult::Fail("reservation winner's publication was not observable");
+    };
+    if reservation_observation.pid != RESERVATION_PID_A || reservation_observation.at == 0 {
+        return TestResult::Fail("reservation winner's tuple was contaminated");
+    }
+
+    // Displacement arm: use the production helper twice, deliberately taking
+    // no observation between A and B. B's successful replacement must count
+    // as both a publication and exactly one displaced collision, and only B's
+    // coherent tuple may subsequently be claimed.
+    const DISPLACEMENT_PID_A: u64 = RESERVATION_PID_A - (2 * EXIT_KICK_BUCKETS as u64);
+    const DISPLACEMENT_PID_B: u64 = DISPLACEMENT_PID_A - EXIT_KICK_BUCKETS as u64;
+    let displacement_published_before = EXIT_KICK_PUBLISHED.aggregate();
+    let displacement_collision_before = EXIT_KICK_BUCKET_COLLISION.aggregate();
+    let displacement_sgi_before = EXIT_SGI_SENT.aggregate();
+    crate::task::scheduler::Scheduler::send_exit_expedite_sgi(
+        DISPLACEMENT_PID_A,
+        crate::task::scheduler::GroupBatchId::for_single_victim(DISPLACEMENT_PID_A),
+    );
+    crate::task::scheduler::Scheduler::send_exit_expedite_sgi(
+        DISPLACEMENT_PID_B,
+        crate::task::scheduler::GroupBatchId::for_single_victim(DISPLACEMENT_PID_B),
+    );
+    let Some(displacement_observation) = reservation_slot.observe(DISPLACEMENT_PID_B) else {
+        return TestResult::Fail("displaced production publication was not observable");
+    };
+    if displacement_observation.pid != DISPLACEMENT_PID_B
+        || displacement_observation.at == 0
+        || EXIT_KICK_PUBLISHED.aggregate() != displacement_published_before + 2
+        || EXIT_KICK_BUCKET_COLLISION.aggregate() != displacement_collision_before + 1
+        || EXIT_SGI_SENT.aggregate() != displacement_sgi_before + 2
+    {
+        return TestResult::Fail("unobserved generation displacement was not exact");
+    }
+
+    const ATTEMPTS_PER_PUBLISHER: u64 = 5_000;
+    const TOTAL_ATTEMPTS: u64 = ATTEMPTS_PER_PUBLISHER * 2;
+    const PID_A: u64 = 10;
+    const PID_B: u64 = PID_A + EXIT_KICK_BUCKETS as u64;
+
+    struct OracleRow {
+        pid: AtomicU64,
+        token: AtomicU64,
+    }
+
+    struct Accounting {
+        workers_ready: AtomicU64,
+        start: AtomicBool,
+        publisher_a_cpu_mask: AtomicU64,
+        publisher_b_cpu_mask: AtomicU64,
+        observer_cpu_mask: AtomicU64,
+        next_token: AtomicU64,
+        published: AtomicU64,
+        collisions: AtomicU64,
+        collisions_reservation_lost: AtomicU64,
+        collisions_displaced: AtomicU64,
+        observations: AtomicU64,
+        mismatches: AtomicU64,
+        publishers_done: AtomicU64,
+        observer_running: AtomicBool,
+        observer_done: AtomicBool,
+    }
+
+    let storm_slot = Arc::new(KickSlot::new());
+    let oracle = Arc::new(
+        (0..=TOTAL_ATTEMPTS)
+            .map(|_| OracleRow {
+                pid: AtomicU64::new(0),
+                token: AtomicU64::new(0),
+            })
+            .collect::<Vec<_>>(),
+    );
+    let accounting = Arc::new(Accounting {
+        workers_ready: AtomicU64::new(0),
+        start: AtomicBool::new(false),
+        publisher_a_cpu_mask: AtomicU64::new(0),
+        publisher_b_cpu_mask: AtomicU64::new(0),
+        observer_cpu_mask: AtomicU64::new(0),
+        next_token: AtomicU64::new(0),
+        published: AtomicU64::new(0),
+        collisions: AtomicU64::new(0),
+        collisions_reservation_lost: AtomicU64::new(0),
+        collisions_displaced: AtomicU64::new(0),
+        observations: AtomicU64::new(0),
+        mismatches: AtomicU64::new(0),
+        publishers_done: AtomicU64::new(0),
+        observer_running: AtomicBool::new(false),
+        observer_done: AtomicBool::new(false),
+    });
+
+    let spawn_publisher = |pid: u64, name: &'static str, cpu: usize| {
+        let slot = Arc::clone(&storm_slot);
+        let oracle = Arc::clone(&oracle);
+        let accounting = Arc::clone(&accounting);
+        crate::task::kthread::kthread_run_on_cpu_for_test(
+            move || {
+                let cpu_bit = 1u64 << crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id();
+                if pid == PID_A {
+                    accounting
+                        .publisher_a_cpu_mask
+                        .fetch_or(cpu_bit, Ordering::Relaxed);
+                } else {
+                    accounting
+                        .publisher_b_cpu_mask
+                        .fetch_or(cpu_bit, Ordering::Relaxed);
+                }
+                accounting.workers_ready.fetch_add(1, Ordering::Release);
+                while !accounting.start.load(Ordering::Acquire) {
+                    crate::task::scheduler::yield_current();
+                    core::hint::spin_loop();
+                }
+                while !accounting.observer_running.load(Ordering::Acquire) {
+                    crate::task::scheduler::yield_current();
+                    core::hint::spin_loop();
+                }
+                if pid == PID_B {
+                    while accounting.observations.load(Ordering::Acquire) == 0 {
+                        crate::task::scheduler::yield_current();
+                        core::hint::spin_loop();
+                    }
+                }
+                for attempt in 0..ATTEMPTS_PER_PUBLISHER {
+                    let cpu_bit =
+                        1u64 << crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id();
+                    if pid == PID_A {
+                        accounting
+                            .publisher_a_cpu_mask
+                            .fetch_or(cpu_bit, Ordering::Relaxed);
+                    } else {
+                        accounting
+                            .publisher_b_cpu_mask
+                            .fetch_or(cpu_bit, Ordering::Relaxed);
+                    }
+                    let token = accounting.next_token.fetch_add(1, Ordering::Relaxed) + 1;
+                    let Some(reservation) = slot.reserve() else {
+                        accounting
+                            .collisions_reservation_lost
+                            .fetch_add(1, Ordering::Relaxed);
+                        accounting.collisions.fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    };
+                    let generation = reservation.generation as usize;
+                    oracle[generation].pid.store(pid, Ordering::Relaxed);
+                    oracle[generation].token.store(token, Ordering::Release);
+                    match slot.commit(reservation, pid, token) {
+                        KickPublishResult::Published { displaced, .. } => {
+                            accounting.published.fetch_add(1, Ordering::Relaxed);
+                            if displaced {
+                                accounting
+                                    .collisions_displaced
+                                    .fetch_add(1, Ordering::Relaxed);
+                                accounting.collisions.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                        KickPublishResult::ReservationLost => {
+                            accounting.mismatches.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                    if pid == PID_A && attempt == 0 {
+                        while accounting.observations.load(Ordering::Acquire) == 0 {
+                            crate::task::scheduler::yield_current();
+                            core::hint::spin_loop();
+                        }
+                    }
+                    if attempt & 63 == 63 {
+                        crate::task::scheduler::yield_current();
+                    }
+                }
+                accounting.publishers_done.fetch_add(1, Ordering::Release);
+            },
+            name,
+            cpu,
+        )
+    };
+
+    struct StormSpawnPreemptGuard;
+
+    impl StormSpawnPreemptGuard {
+        fn enter() -> Self {
+            crate::per_cpu_aarch64::preempt_disable();
+            Self
+        }
+    }
+
+    impl Drop for StormSpawnPreemptGuard {
+        fn drop(&mut self) {
+            crate::per_cpu_aarch64::preempt_enable();
+        }
+    }
+
+    // Keep the creating thread fixed while the test-only spawn primitive queues
+    // the three workers on the other three CPUs. This preserves a CPU on which
+    // the coordinator can release the start barrier. The RAII guard restores
+    // preemption on every error return.
+    let spawn_guard = StormSpawnPreemptGuard::enter();
+
+    let online_cpus = crate::arch_impl::aarch64::smp::cpus_online() as usize;
+    let coordinator_cpu = crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as usize;
+    let mut worker_cpus = [usize::MAX; 3];
+    let mut worker_count = 0;
+    for cpu in 0..online_cpus {
+        if cpu != coordinator_cpu && worker_count < worker_cpus.len() {
+            worker_cpus[worker_count] = cpu;
+            worker_count += 1;
+        }
+    }
+    if worker_count != worker_cpus.len() {
+        return TestResult::Fail("exit-kick storm requires four online CPUs");
+    }
+
+    let publisher_a = match spawn_publisher(PID_A, "exit_kick_pub_a", worker_cpus[0]) {
+        Ok(handle) => handle,
+        Err(_) => return TestResult::Fail("failed to spawn exit-kick publisher A"),
+    };
+    let publisher_b = match spawn_publisher(PID_B, "exit_kick_pub_b", worker_cpus[1]) {
+        Ok(handle) => handle,
+        Err(_) => return TestResult::Fail("failed to spawn exit-kick publisher B"),
+    };
+
+    let observer_slot = Arc::clone(&storm_slot);
+    let observer_oracle = Arc::clone(&oracle);
+    let observer_accounting = Arc::clone(&accounting);
+    let observer = match crate::task::kthread::kthread_run_on_cpu_for_test(
+        move || {
+            let cpu_bit = 1u64 << crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id();
+            observer_accounting
+                .observer_cpu_mask
+                .fetch_or(cpu_bit, Ordering::Relaxed);
+            observer_accounting
+                .workers_ready
+                .fetch_add(1, Ordering::Release);
+            while !observer_accounting.start.load(Ordering::Acquire) {
+                crate::task::scheduler::yield_current();
+                core::hint::spin_loop();
+            }
+            observer_accounting
+                .observer_running
+                .store(true, Ordering::Release);
+            while observer_accounting.publishers_done.load(Ordering::Acquire) != 2 {
+                let cpu_bit = 1u64 << crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id();
+                observer_accounting
+                    .observer_cpu_mask
+                    .fetch_or(cpu_bit, Ordering::Relaxed);
+                if let Some(observation) = observer_slot.observe(PID_A) {
+                    let row = &observer_oracle[observation.generation as usize];
+                    let token = row.token.load(Ordering::Acquire);
+                    let expected_pid = row.pid.load(Ordering::Relaxed);
+                    if expected_pid != observation.pid || token != observation.at {
+                        observer_accounting
+                            .mismatches
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    observer_accounting
+                        .observations
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                if let Some(observation) = observer_slot.observe(PID_B) {
+                    let row = &observer_oracle[observation.generation as usize];
+                    let token = row.token.load(Ordering::Acquire);
+                    let expected_pid = row.pid.load(Ordering::Relaxed);
+                    if expected_pid != observation.pid || token != observation.at {
+                        observer_accounting
+                            .mismatches
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    observer_accounting
+                        .observations
+                        .fetch_add(1, Ordering::Relaxed);
+                }
+                core::hint::spin_loop();
+            }
+            observer_accounting
+                .observer_done
+                .store(true, Ordering::Release);
+        },
+        "exit_kick_observer",
+        worker_cpus[2],
+    ) {
+        Ok(handle) => handle,
+        Err(_) => return TestResult::Fail("failed to spawn exit-kick observer"),
+    };
+    core::mem::drop(spawn_guard);
+
+    while accounting.workers_ready.load(Ordering::Acquire) != 3 {
+        crate::task::scheduler::yield_current();
+        core::hint::spin_loop();
+    }
+    accounting.start.store(true, Ordering::Release);
+
+    if crate::task::kthread::kthread_join(&publisher_a).is_err()
+        || crate::task::kthread::kthread_join(&publisher_b).is_err()
+        || crate::task::kthread::kthread_join(&observer).is_err()
+    {
+        return TestResult::Fail("exit-kick storm kthread join failed");
+    }
+
+    let attempts = accounting.next_token.load(Ordering::Acquire);
+    let published = accounting.published.load(Ordering::Acquire);
+    let collisions_reservation_lost = accounting
+        .collisions_reservation_lost
+        .load(Ordering::Acquire);
+    let collisions_displaced = accounting.collisions_displaced.load(Ordering::Acquire);
+    let collisions = accounting.collisions.load(Ordering::Acquire);
+    let publisher_a_cpu_mask = accounting.publisher_a_cpu_mask.load(Ordering::Acquire);
+    let publisher_b_cpu_mask = accounting.publisher_b_cpu_mask.load(Ordering::Acquire);
+    let observer_cpu_mask = accounting.observer_cpu_mask.load(Ordering::Acquire);
+    let occupied_three_distinct_cpus = (0..64).any(|a| {
+        publisher_a_cpu_mask & (1 << a) != 0
+            && (0..64).any(|b| {
+                b != a
+                    && publisher_b_cpu_mask & (1 << b) != 0
+                    && (0..64).any(|observer| {
+                        observer != a && observer != b && observer_cpu_mask & (1 << observer) != 0
+                    })
+            })
+    });
+    if !occupied_three_distinct_cpus {
+        return TestResult::Fail("exit-kick storm did not occupy three distinct CPUs");
+    }
+    if attempts != TOTAL_ATTEMPTS {
+        return TestResult::Fail("exit-kick storm did not execute all publisher attempts");
+    }
+    if attempts != published + collisions_reservation_lost {
+        return TestResult::Fail("exit-kick publish/lost accounting identity failed");
+    }
+    if collisions != collisions_reservation_lost + collisions_displaced {
+        return TestResult::Fail("exit-kick collision sub-arm accounting identity failed");
+    }
+    if accounting.mismatches.load(Ordering::Acquire) != 0 {
+        return TestResult::Fail("exit-kick storm observed a torn or cross-generation tuple");
+    }
+    if accounting.observations.load(Ordering::Acquire) == 0 {
+        return TestResult::Fail("exit-kick storm observer never claimed a publication");
+    }
+    if !accounting.observer_done.load(Ordering::Acquire) {
+        return TestResult::Fail("exit-kick storm observer did not complete");
+    }
+    if storm_slot.state.load(Ordering::Acquire) & EXIT_KICK_LOCK != 0 {
+        return TestResult::Fail("exit-kick storm left the bucket reserved");
+    }
+
+    if !matches!(
+        storm_slot.publish(PID_A, TOTAL_ATTEMPTS + 1),
+        KickPublishResult::Published { .. }
+    ) || storm_slot.observe(PID_A).is_none()
+    {
+        return TestResult::Fail("exit-kick slot remained wedged after storm");
+    }
+
     TestResult::Pass
 }

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -1120,6 +1120,77 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
     use alloc::vec::Vec;
     use core::sync::atomic::AtomicBool;
 
+    // ---- Cross-CPU handshake watchdog (test harness only) --------------------
+    //
+    // This gate coordinator runs synchronously on CPU 0 (outside the scheduler)
+    // and busy-waits on handshakes completed by kthreads pinned to CPU 1/2/3.
+    // Every such wait is now bounded: a rare lost wakeup on a secondary CPU used
+    // to hang the whole boot-test harness silently for ~90s. The cap is chosen
+    // FAR beyond any healthy completion (a normal — even slow — run finishes in
+    // a handful of spins), so it never false-trips. On the first cap we re-send
+    // a reschedule IPI to the stuck target CPU(s) exactly once via the existing
+    // per-CPU resched SGI path (self-heals a dropped wakeup), reset the counter,
+    // and spin again; if the SECOND cap is also exceeded the target is genuinely
+    // wedged and the caller returns an actionable Fail naming the handshake and
+    // CPU. This does NOT touch the EXIT_KICK protocol itself.
+    fn spin_with_resched<F: Fn() -> bool>(cond: F, kick_cpus: &[usize]) -> bool {
+        const HANDSHAKE_SPIN_CAP: u64 = 50_000_000;
+
+        // First bounded attempt.
+        let mut spins: u64 = 0;
+        while !cond() {
+            crate::task::scheduler::yield_current();
+            core::hint::spin_loop();
+            spins += 1;
+            if spins >= HANDSHAKE_SPIN_CAP {
+                break;
+            }
+        }
+        if cond() {
+            return true;
+        }
+
+        // Self-heal: re-send a reschedule IPI to each stuck target CPU exactly
+        // once, then reset the counter and retry. This is the same per-CPU
+        // resched SGI the scheduler uses to wake a CPU; we only call it here.
+        for &cpu in kick_cpus {
+            crate::arch_impl::aarch64::gic::send_sgi(
+                crate::arch_impl::aarch64::constants::SGI_RESCHEDULE as u8,
+                cpu as u8,
+            );
+        }
+
+        // Second bounded attempt after the self-heal.
+        let mut spins: u64 = 0;
+        while !cond() {
+            crate::task::scheduler::yield_current();
+            core::hint::spin_loop();
+            spins += 1;
+            if spins >= HANDSHAKE_SPIN_CAP {
+                break;
+            }
+        }
+        cond()
+    }
+
+    // Bounded replacement for a blocking kthread_join on a CPU-pinned worker:
+    // poll the non-blocking exit flag with the same capped + self-healing spin,
+    // then let kthread_join return immediately once the exit is visible. Returns
+    // false if the worker never exited even after the resched self-heal.
+    fn join_with_resched(
+        handle: &crate::task::kthread::KthreadHandle,
+        cpu: usize,
+    ) -> bool {
+        let exited = spin_with_resched(
+            || crate::task::kthread::kthread_has_exited_for_test(handle),
+            &[cpu],
+        );
+        if !exited {
+            return false;
+        }
+        crate::task::kthread::kthread_join(handle).is_ok()
+    }
+
     struct BrokenV3Slot {
         pid: AtomicU64,
         at: AtomicU64,
@@ -1247,9 +1318,14 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
         Err(_) => return TestResult::Fail("failed to spawn held exit-kick publisher A"),
     };
 
-    while EXIT_KICK_TEST_HOOK_RESERVED.load(Ordering::Acquire) == 0 {
-        crate::task::scheduler::yield_current();
-        core::hint::spin_loop();
+    if !spin_with_resched(
+        || EXIT_KICK_TEST_HOOK_RESERVED.load(Ordering::Acquire) != 0,
+        &[PUBLISHER_A_CPU],
+    ) {
+        // `hook` is dropped on return, releasing publisher A from its hold.
+        return TestResult::Fail(
+            "exit_kick_gate: publisher A reservation handshake stuck, CPU 1 unresponsive",
+        );
     }
 
     let b_done = Arc::clone(&publisher_b_done);
@@ -1277,9 +1353,14 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
         }
     };
 
-    while publisher_b_done.load(Ordering::Acquire) == 0 {
-        crate::task::scheduler::yield_current();
-        core::hint::spin_loop();
+    if !spin_with_resched(
+        || publisher_b_done.load(Ordering::Acquire) != 0,
+        &[PUBLISHER_B_CPU],
+    ) {
+        // `hook` is dropped on return, releasing publisher A from its hold.
+        return TestResult::Fail(
+            "exit_kick_gate: publisher B completion handshake stuck, CPU 2 unresponsive",
+        );
     }
 
     let publisher_a_cpu = EXIT_KICK_TEST_HOOK_CPU.load(Ordering::Acquire);
@@ -1293,8 +1374,17 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
         && EXIT_SGI_SENT.aggregate() == sgi_before + 1;
 
     hook.release();
-    let joined = crate::task::kthread::kthread_join(&publisher_b).is_ok()
-        && crate::task::kthread::kthread_join(&publisher_a).is_ok();
+    if !join_with_resched(&publisher_b, PUBLISHER_B_CPU) {
+        return TestResult::Fail(
+            "exit_kick_gate: publisher B join stuck, CPU 2 unresponsive",
+        );
+    }
+    if !join_with_resched(&publisher_a, PUBLISHER_A_CPU) {
+        return TestResult::Fail(
+            "exit_kick_gate: publisher A join stuck, CPU 1 unresponsive",
+        );
+    }
+    let joined = true;
     core::mem::drop(hook);
 
     if !joined
@@ -1589,17 +1679,30 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
     };
     core::mem::drop(spawn_guard);
 
-    while accounting.workers_ready.load(Ordering::Acquire) != 3 {
-        crate::task::scheduler::yield_current();
-        core::hint::spin_loop();
+    if !spin_with_resched(
+        || accounting.workers_ready.load(Ordering::Acquire) == 3,
+        &worker_cpus,
+    ) {
+        return TestResult::Fail(
+            "exit_kick_gate: workers_ready never reached 3, a worker CPU (1/2/3) is unresponsive",
+        );
     }
     accounting.start.store(true, Ordering::Release);
 
-    if crate::task::kthread::kthread_join(&publisher_a).is_err()
-        || crate::task::kthread::kthread_join(&publisher_b).is_err()
-        || crate::task::kthread::kthread_join(&observer).is_err()
-    {
-        return TestResult::Fail("exit-kick storm kthread join failed");
+    if !join_with_resched(&publisher_a, worker_cpus[0]) {
+        return TestResult::Fail(
+            "exit_kick_gate: storm publisher A join stuck, CPU 1 unresponsive",
+        );
+    }
+    if !join_with_resched(&publisher_b, worker_cpus[1]) {
+        return TestResult::Fail(
+            "exit_kick_gate: storm publisher B join stuck, CPU 2 unresponsive",
+        );
+    }
+    if !join_with_resched(&observer, worker_cpus[2]) {
+        return TestResult::Fail(
+            "exit_kick_gate: storm observer join stuck, CPU 3 unresponsive",
+        );
     }
 
     let attempts = accounting.next_token.load(Ordering::Acquire);

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -1191,8 +1191,14 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
     // still reach the SGI broadcast tail before A is released.
     const RESERVATION_PID_A: u64 = u64::MAX - 7;
     const RESERVATION_PID_B: u64 = RESERVATION_PID_A - EXIT_KICK_BUCKETS as u64;
+    const PUBLISHER_A_CPU: usize = 1;
+    const PUBLISHER_B_CPU: usize = 2;
     let reservation_bucket = RESERVATION_PID_A as usize % EXIT_KICK_BUCKETS;
     let reservation_slot = &EXIT_KICK_SLOTS[reservation_bucket];
+    let online_cpus = crate::arch_impl::aarch64::smp::cpus_online() as usize;
+    if PUBLISHER_A_CPU >= online_cpus || PUBLISHER_B_CPU >= online_cpus {
+        return TestResult::Fail("exit-kick reservation-loss publisher CPU is not online");
+    }
     let payload_before = (
         reservation_slot.pid.load(Ordering::Relaxed),
         reservation_slot.at.load(Ordering::Relaxed),
@@ -1206,7 +1212,7 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
     let hook = ExitKickTestHookGuard::arm(RESERVATION_PID_A);
 
     let a_done = Arc::clone(&publisher_a_done);
-    let publisher_a = match crate::task::kthread::kthread_run(
+    let publisher_a = match crate::task::kthread::kthread_run_on_cpu_for_test(
         move || {
             crate::task::scheduler::Scheduler::send_exit_expedite_sgi(
                 RESERVATION_PID_A,
@@ -1215,6 +1221,7 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
             a_done.store(1, Ordering::Release);
         },
         "exit_kick_reserve_a",
+        PUBLISHER_A_CPU,
     ) {
         Ok(handle) => handle,
         Err(_) => return TestResult::Fail("failed to spawn held exit-kick publisher A"),
@@ -1227,7 +1234,7 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
 
     let b_done = Arc::clone(&publisher_b_done);
     let b_cpu = Arc::clone(&publisher_b_cpu);
-    let publisher_b = match crate::task::kthread::kthread_run(
+    let publisher_b = match crate::task::kthread::kthread_run_on_cpu_for_test(
         move || {
             b_cpu.store(
                 crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as u64,
@@ -1240,6 +1247,7 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
             b_done.store(1, Ordering::Release);
         },
         "exit_kick_reserve_b",
+        PUBLISHER_B_CPU,
     ) {
         Ok(handle) => handle,
         Err(_) => {
@@ -1274,6 +1282,8 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
         || publisher_a_cpu == u64::MAX
         || publisher_b_cpu == u64::MAX
         || publisher_a_cpu == publisher_b_cpu
+        || publisher_a_cpu != PUBLISHER_A_CPU as u64
+        || publisher_b_cpu != PUBLISHER_B_CPU as u64
         || loser_payload != payload_before
         || !loser_accounting_exact
         || EXIT_KICK_PUBLISHED.aggregate() != published_before + 1
@@ -1475,22 +1485,14 @@ pub fn exit_kick_protocol_gate_test() -> crate::test_framework::registry::TestRe
     }
 
     // Keep the creating thread fixed while the test-only spawn primitive queues
-    // the three workers on the other three CPUs. This preserves a CPU on which
-    // the coordinator can release the start barrier. The RAII guard restores
-    // preemption on every error return.
+    // the three workers on scheduler-managed CPUs. CPU 0 runs the boot-test
+    // executor outside the scheduler and cannot service a pinned kthread. The
+    // RAII guard restores preemption on every error return.
     let spawn_guard = StormSpawnPreemptGuard::enter();
 
     let online_cpus = crate::arch_impl::aarch64::smp::cpus_online() as usize;
-    let coordinator_cpu = crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as usize;
-    let mut worker_cpus = [usize::MAX; 3];
-    let mut worker_count = 0;
-    for cpu in 0..online_cpus {
-        if cpu != coordinator_cpu && worker_count < worker_cpus.len() {
-            worker_cpus[worker_count] = cpu;
-            worker_count += 1;
-        }
-    }
-    if worker_count != worker_cpus.len() {
+    let worker_cpus = [1, 2, 3];
+    if worker_cpus.iter().any(|cpu| *cpu >= online_cpus) {
         return TestResult::Fail("exit-kick storm requires four online CPUs");
     }
 

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -141,11 +141,11 @@ const TERMINATE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/signal/delivery.rs", 225),
     ("kernel/src/signal/delivery.rs", 260),
 ];
-const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 498)];
+const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 496)];
 const PRODUCTION_INIT_PID_SITES: &[(&str, usize)] = &[
     ("kernel/src/process/manager.rs", 1187),
-    ("kernel/src/task/process_task.rs", 460),
-    ("kernel/src/task/process_task.rs", 530),
+    ("kernel/src/task/process_task.rs", 458),
+    ("kernel/src/task/process_task.rs", 528),
 ];
 const TEST_INIT_PID_SITES: &[(&str, usize)] = &[
     ("kernel/src/test_userspace.rs", 84),
@@ -167,7 +167,7 @@ const KERNEL_STACK_MUTATIONS: &[(&str, usize)] = &[
 const RECLAIM_ENQUEUE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 53),
     ("kernel/src/process/mod.rs", 280),
-    ("kernel/src/task/process_task.rs", 572),
+    ("kernel/src/task/process_task.rs", 570),
 ];
 const EXIT_PROCESS_AND_RETIRE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/exception.rs", 824),
@@ -187,19 +187,19 @@ const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
 const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
     &[("kernel/src/tracing/providers/teardown.rs", 936)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
-    ("kernel/src/task/scheduler.rs", 1912),
-    ("kernel/src/task/scheduler.rs", 2126),
-    ("kernel/src/task/scheduler.rs", 2145),
-    ("kernel/src/task/scheduler.rs", 2294),
-    ("kernel/src/task/scheduler.rs", 2382),
-    ("kernel/src/task/scheduler.rs", 2447),
-    ("kernel/src/task/scheduler.rs", 2456),
-    ("kernel/src/task/scheduler.rs", 2615),
+    ("kernel/src/task/scheduler.rs", 1971),
+    ("kernel/src/task/scheduler.rs", 2185),
+    ("kernel/src/task/scheduler.rs", 2204),
+    ("kernel/src/task/scheduler.rs", 2353),
+    ("kernel/src/task/scheduler.rs", 2441),
+    ("kernel/src/task/scheduler.rs", 2506),
+    ("kernel/src/task/scheduler.rs", 2515),
+    ("kernel/src/task/scheduler.rs", 2674),
     ("kernel/src/task/waitqueue.rs", 52),
 ];
 const RAW_SCHEDULER_LOCK_SITES: &[(&str, usize)] = &[
-    ("kernel/src/task/scheduler.rs", 277),
-    ("kernel/src/task/scheduler.rs", 284),
+    ("kernel/src/task/scheduler.rs", 281),
+    ("kernel/src/task/scheduler.rs", 288),
 ];
 
 const BLOCKING_NAMES: &[&str] = &[
@@ -358,7 +358,7 @@ fn v3_structural_closures_are_exact() {
     );
     assert_exact(
         sites_matching(&sources, |line| line.contains("btrt::on_process_exit(")),
-        &[("kernel/src/task/process_task.rs", 599)],
+        &[("kernel/src/task/process_task.rs", 597)],
         "btrt::on_process_exit callers",
     );
 

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -137,16 +137,15 @@ fn function_body<'a>(source: &'a str, name: &str) -> &'a str {
 
 const TERMINATE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/interrupts/context_switch.rs", 1017),
-    ("kernel/src/process/manager.rs", 1164),
+    ("kernel/src/process/manager.rs", 1170),
     ("kernel/src/signal/delivery.rs", 225),
     ("kernel/src/signal/delivery.rs", 260),
-    ("kernel/src/syscall/signal.rs", 163),
 ];
-const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 462)];
+const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 498)];
 const PRODUCTION_INIT_PID_SITES: &[(&str, usize)] = &[
-    ("kernel/src/process/manager.rs", 1181),
-    ("kernel/src/task/process_task.rs", 432),
-    ("kernel/src/task/process_task.rs", 491),
+    ("kernel/src/process/manager.rs", 1187),
+    ("kernel/src/task/process_task.rs", 460),
+    ("kernel/src/task/process_task.rs", 530),
 ];
 const TEST_INIT_PID_SITES: &[(&str, usize)] = &[
     ("kernel/src/test_userspace.rs", 84),
@@ -155,48 +154,52 @@ const TEST_INIT_PID_SITES: &[(&str, usize)] = &[
 ];
 const QUARANTINE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/exception.rs", 815),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1179),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1275),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1375),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1177),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1271),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1369),
+    ("kernel/src/syscall/signal.rs", 163),
 ];
 const KERNEL_STACK_MUTATIONS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/syscall_entry.rs", 961),
-    ("kernel/src/process/manager.rs", 1841),
+    ("kernel/src/process/manager.rs", 1856),
     ("kernel/src/syscall/clone.rs", 252),
 ];
 const RECLAIM_ENQUEUE_CALLS: &[(&str, usize)] = &[
-    ("kernel/src/process/manager.rs", 1155),
-    ("kernel/src/task/process_task.rs", 450),
+    ("kernel/src/process/mod.rs", 53),
+    ("kernel/src/process/mod.rs", 280),
+    ("kernel/src/task/process_task.rs", 572),
 ];
-const EXIT_PROCESS_CALLS: &[(&str, usize)] = &[
-    ("kernel/src/arch_impl/aarch64/exception.rs", 825),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1190),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1278),
-    ("kernel/src/arch_impl/aarch64/exception.rs", 1378),
-    ("kernel/src/interrupts.rs", 1429),
-    ("kernel/src/interrupts.rs", 1735),
-    ("kernel/src/process/mod.rs", 325),
+const EXIT_PROCESS_AND_RETIRE_CALLS: &[(&str, usize)] = &[
+    ("kernel/src/arch_impl/aarch64/exception.rs", 824),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1187),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1273),
+    ("kernel/src/arch_impl/aarch64/exception.rs", 1371),
+    ("kernel/src/interrupts.rs", 1440),
+    ("kernel/src/interrupts.rs", 1751),
+    ("kernel/src/process/mod.rs", 413),
+    ("kernel/src/syscall/signal.rs", 172),
 ];
+const EXIT_PROCESS_LOCKED_CALLS: &[(&str, usize)] = &[("kernel/src/process/mod.rs", 265)];
 const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
-    ("kernel/src/process/mod.rs", 317),
-    ("kernel/src/process/mod.rs", 333),
+    ("kernel/src/process/mod.rs", 406),
+    ("kernel/src/process/mod.rs", 418),
 ];
 const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
-    &[("kernel/src/tracing/providers/teardown.rs", 552)];
+    &[("kernel/src/tracing/providers/teardown.rs", 936)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
-    ("kernel/src/task/scheduler.rs", 1820),
-    ("kernel/src/task/scheduler.rs", 1991),
-    ("kernel/src/task/scheduler.rs", 2010),
-    ("kernel/src/task/scheduler.rs", 2159),
-    ("kernel/src/task/scheduler.rs", 2247),
-    ("kernel/src/task/scheduler.rs", 2312),
-    ("kernel/src/task/scheduler.rs", 2321),
-    ("kernel/src/task/scheduler.rs", 2480),
+    ("kernel/src/task/scheduler.rs", 1912),
+    ("kernel/src/task/scheduler.rs", 2126),
+    ("kernel/src/task/scheduler.rs", 2145),
+    ("kernel/src/task/scheduler.rs", 2294),
+    ("kernel/src/task/scheduler.rs", 2382),
+    ("kernel/src/task/scheduler.rs", 2447),
+    ("kernel/src/task/scheduler.rs", 2456),
+    ("kernel/src/task/scheduler.rs", 2615),
     ("kernel/src/task/waitqueue.rs", 52),
 ];
 const RAW_SCHEDULER_LOCK_SITES: &[(&str, usize)] = &[
-    ("kernel/src/task/scheduler.rs", 239),
-    ("kernel/src/task/scheduler.rs", 246),
+    ("kernel/src/task/scheduler.rs", 277),
+    ("kernel/src/task/scheduler.rs", 284),
 ];
 
 const BLOCKING_NAMES: &[&str] = &[
@@ -223,9 +226,19 @@ fn validate_reclaim_enqueue_callers(sources: &[(String, String)]) -> Result<(), 
 
 fn validate_exit_process_entry_points(sources: &[(String, String)]) -> Result<(), ()> {
     validate_exact(
-        &sites_matching(sources, |line| line.contains(".exit_process(")),
-        EXIT_PROCESS_CALLS,
+        &sites_matching(sources, |line| {
+            line.contains("exit_process_and_retire(")
+                && !line.contains("fn exit_process_and_retire")
+        }),
+        EXIT_PROCESS_AND_RETIRE_CALLS,
     )?;
+    validate_exact(
+        &sites_matching(sources, |line| line.contains(".exit_process_locked(")),
+        EXIT_PROCESS_LOCKED_CALLS,
+    )?;
+    if !sites_matching(sources, |line| line.contains(".exit_process(")).is_empty() {
+        return Err(());
+    }
     validate_exact(
         &sites_matching(sources, |line| {
             line.contains("exit_process_by_pid(") && !line.contains("fn exit_process_by_pid")
@@ -259,7 +272,7 @@ fn validate_group_writes(sources: &[(String, String)]) -> Result<(), ()> {
 
 fn validate_exit_sgi_is_teardown_only(sources: &[(String, String)]) -> Result<(), ()> {
     let scheduler = source(sources, "kernel/src/task/scheduler.rs");
-    (!scheduler.contains("EXIT_SGI_SENT")
+    (function_body(scheduler, "send_exit_expedite_sgi").contains("EXIT_SGI_SENT")
         && !function_body(scheduler, "send_resched_ipi").contains("EXIT_SGI_SENT")
         && !function_body(scheduler, "send_resched_ipi_to_cpu").contains("EXIT_SGI_SENT"))
     .then_some(())
@@ -345,7 +358,7 @@ fn v3_structural_closures_are_exact() {
     );
     assert_exact(
         sites_matching(&sources, |line| line.contains("btrt::on_process_exit(")),
-        &[("kernel/src/task/process_task.rs", 473)],
+        &[("kernel/src/task/process_task.rs", 599)],
         "btrt::on_process_exit callers",
     );
 
@@ -355,11 +368,37 @@ fn v3_structural_closures_are_exact() {
     assert_eq!(provider.matches("counter!(EXIT_KICK_PUBLISHED,").count(), 1);
     validate_exit_sgi_is_teardown_only(&sources)
         .expect("EXIT_SGI_SENT escaped the teardown-only producer");
-    assert!(!scheduler.contains("EXIT_KICK_PUBLISHED"));
-    assert!(!scheduler.contains("send_exit_expedite_sgi"));
-    assert!(!provider.contains("struct KickSlot"));
+    let expedite = function_body(scheduler, "send_exit_expedite_sgi");
+    assert_eq!(expedite.matches("EXIT_SGI_SENT").count(), 1);
+    assert_eq!(
+        expedite
+            .matches("trace_count!(EXIT_KICK_PUBLISHED)")
+            .count(),
+        1
+    );
+    assert!(expedite.find("slot.publish(").unwrap() < expedite.find("gic::send_sgi(").unwrap());
+    assert!(!expedite.contains("current_thread"));
+    assert_eq!(scheduler.matches("send_exit_expedite_sgi(").count(), 1);
+    assert!(provider.contains("struct KickSlot"));
+    assert!(provider.contains("pub(crate) pid: AtomicU64"));
+    assert!(provider.contains("pub(crate) at: AtomicU64"));
+    assert!(provider.contains("pub(crate) state: AtomicU64"));
     assert!(!provider.contains("trace_count!(EXIT_SGI_SENT"));
     assert!(!provider.contains("trace_count!(EXIT_KICK_PUBLISHED"));
+
+    let process_mod = source(&sources, "kernel/src/process/mod.rs");
+    assert!(process_mod.contains("pub(crate) struct RetirementReceipt"));
+    assert!(!process_mod.contains("pub struct RetirementReceipt"));
+    assert!(!process_mod.contains("pub fn from_reclaim"));
+    assert!(function_body(process_mod, "drop").contains("enqueue_process_reclaim("));
+
+    let process = source(&sources, "kernel/src/process/process.rs");
+    for state in ["Absent", "Pending", "Claimed", "Completed"] {
+        assert!(process.contains(state));
+    }
+    assert!(!process.contains("report_marker"));
+    assert!(!process.contains("claim_exit_slot"));
+    assert!(!process.contains("record_exit"));
 }
 
 #[test]
@@ -494,16 +533,23 @@ fn all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates() {
         .filter_map(|rest| rest.strip_suffix(','))
         .map(str::to_owned)
         .collect();
-    assert_eq!(declarations.len(), 45);
+    assert_eq!(declarations.len(), 47);
     assert_eq!(
         readers, declarations,
         "every counter must have an inventory reader"
     );
     assert!(provider.contains("core::array::from_fn(|index| COUNTERS[index].aggregate())"));
-    assert!(provider.contains("for _ in 0..64"));
+    assert!(provider.contains("for iteration in 0..64"));
     assert!(provider.contains("reset_boot_test_pid_counts();"));
     assert!(provider.contains("for pid in pairing_child_pids"));
-    assert!(provider.contains("defer_count == 0 || defer_count != reclaim_count"));
+    for exact_failure in [
+        "adapted-site per-PID defer proof was absent",
+        "adapted-site per-PID defer proof was duplicated",
+        "adapted-site per-PID reclaim proof was absent",
+        "adapted-site per-PID reclaim proof was duplicated",
+    ] {
+        assert!(provider.contains(exact_failure));
+    }
     assert!(!provider.contains("deferred_delta != reclaimed_delta || reclaimed_delta < 64"));
     assert!(!provider.contains("TeardownPairingEvidence"));
     assert!(!provider.contains("defer_reclaim_events_are_paired("));
@@ -516,7 +562,12 @@ fn all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates() {
     assert!(!provider.contains("TEARDOWN_PROVIDER.enable_all()"));
     assert!(!provider.contains("TEARDOWN_PROVIDER.disable_all()"));
     assert!(source(&sources, "kernel/src/task/process_task.rs").contains("for tid in 1..=17"));
-    assert!(!provider.contains("EXIT_SGI_SENT.aggregate()"));
+    assert_eq!(
+        function_body(provider, "exit_kick_protocol_gate_test")
+            .matches("EXIT_SGI_SENT.aggregate()")
+            .count(),
+        5
+    );
     assert!(!provider.contains("TEARDOWN_ENTRY_GROUP.aggregate()"));
 
     let declaration_only = provider
@@ -524,11 +575,16 @@ fn all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates() {
         .nth(1)
         .expect("declaration-only counter boundary");
     assert!(declaration_only.contains("counter!(TEARDOWN_ENTRY_GROUP,"));
-    assert!(declaration_only.contains("counter!(EXIT_SGI_SENT,"));
+    assert!(declaration_only.contains("counter!(EXIT_REQUEST_OBSERVED,"));
+    assert!(!declaration_only.contains("counter!(EXIT_SGI_SENT,"));
+    assert!(!declaration_only.contains("counter!(EXIT_KICK_PUBLISHED,"));
+    assert!(!declaration_only.contains("counter!(RECEIPT_DROPPED_UNRETIRED,"));
 
     let registry = source(&sources, "kernel/src/test_framework/registry.rs");
     assert!(registry.contains("name: \"fork_exit_defer_reclaim_pairing_test\""));
     assert!(registry.contains("name: \"deferred_fault_ring_overflow_injection\""));
+    assert!(registry.contains("name: \"exit_kick_protocol_gate\""));
+    assert!(registry.contains("name: \"retirement_receipt_drop_gate\""));
 
     let plan = repo_text("docs/planning/teardown-unification/PLAN.md");
     assert!(plan.contains("./docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only"));

--- a/userspace/programs/Cargo.toml
+++ b/userspace/programs/Cargo.toml
@@ -197,6 +197,10 @@ name = "sigchld_test"
 path = "src/sigchld_test.rs"
 
 [[bin]]
+name = "sigkill_teardown_test"
+path = "src/sigkill_teardown_test.rs"
+
+[[bin]]
 name = "sigchld_job_test"
 path = "src/sigchld_job_test.rs"
 

--- a/userspace/programs/build.sh
+++ b/userspace/programs/build.sh
@@ -151,6 +151,7 @@ STD_BINARIES=(
     "cloexec_test"
     "kill_process_group_test"
     "sigchld_test"
+    "sigkill_teardown_test"
     "sigchld_job_test"
     "ctrl_c_test"
     "job_control_test"

--- a/userspace/programs/src/sigkill_teardown_test.rs
+++ b/userspace/programs/src/sigkill_teardown_test.rs
@@ -1,0 +1,531 @@
+//! Phase-2 SIGKILL teardown proof.
+//!
+//! Evidence is read from the fixed per-PID boot-test tally table through
+//! `/proc/trace/teardown/<pid>`. The test never samples the live trace ring or
+//! mutates provider enable state.
+
+use libbreenix::io;
+use libbreenix::memory;
+use libbreenix::process::{
+    self, fork, getpid, waitpid, wifexited, wifsignaled, wtermsig, ForkResult,
+};
+use libbreenix::signal::{kill, pause, sigaction, Sigaction, SIGCHLD, SIGKILL};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+const EXIT_KICK_BUCKETS: u64 = 64;
+const CHILD_STACK_SIZE: usize = 64 * 1024;
+const CLONE_FLAGS: u64 = 0x0000_0100 | 0x0000_0400 | 0x0020_0000 | 0x0100_0000;
+
+static SIGCHLD_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn sigchld_handler(_signal: i32) {
+    SIGCHLD_RECEIVED.store(true, Ordering::Release);
+}
+
+fn fail(message: &str) -> ! {
+    eprintln!("SIGKILL_TEARDOWN_TEST: FAIL: {message}");
+    std::process::exit(1);
+}
+
+fn yield_many(count: usize) {
+    for _ in 0..count {
+        let _ = process::yield_now();
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct Evidence {
+    defer: u64,
+    reclaim: u64,
+    quarantine: u64,
+    sgi_sent: u64,
+    kick_observed: u64,
+    kick_interval: u64,
+    tick_period: u64,
+    masked_frames_walked: u64,
+    report: u64,
+    bucket_published: u64,
+    bucket_observed: u64,
+    bucket_collision: u64,
+}
+
+fn parse_value(contents: &str, name: &str) -> u64 {
+    contents
+        .lines()
+        .find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            (key.trim() == name)
+                .then(|| value.split_whitespace().next()?.parse().ok())
+                .flatten()
+        })
+        .unwrap_or_else(|| fail("per-PID evidence field missing"))
+}
+
+fn evidence(pid: i32) -> Evidence {
+    let path = format!("/proc/trace/teardown/{pid}");
+    let contents = std::fs::read_to_string(path)
+        .unwrap_or_else(|_| fail("could not read per-PID teardown evidence"));
+    Evidence {
+        defer: parse_value(&contents, "defer"),
+        reclaim: parse_value(&contents, "reclaim"),
+        quarantine: parse_value(&contents, "quarantine"),
+        sgi_sent: parse_value(&contents, "sgi_sent"),
+        kick_observed: parse_value(&contents, "kick_observed"),
+        kick_interval: parse_value(&contents, "kick_interval"),
+        tick_period: parse_value(&contents, "tick_period"),
+        masked_frames_walked: parse_value(&contents, "masked_frames_walked"),
+        report: parse_value(&contents, "report"),
+        bucket_published: parse_value(&contents, "bucket_published"),
+        bucket_observed: parse_value(&contents, "bucket_observed"),
+        bucket_collision: parse_value(&contents, "bucket_collision"),
+    }
+}
+
+fn counter(name: &str) -> u64 {
+    let contents = std::fs::read_to_string("/proc/trace/counters")
+        .unwrap_or_else(|_| fail("could not read trace counters"));
+    parse_value(&contents, name)
+}
+
+fn wait_for_evidence(pid: i32) -> Evidence {
+    let mut current = Evidence::default();
+    for _ in 0..20_000 {
+        current = evidence(pid);
+        if current.defer == 1
+            && current.reclaim == 1
+            && current.quarantine == 1
+            && current.sgi_sent == 1
+            && current.kick_observed == 1
+            && current.report == 1
+        {
+            return current;
+        }
+        let _ = process::yield_now();
+    }
+    eprintln!(
+        "SIGKILL_TEARDOWN_TEST: evidence timeout pid={pid} defer={} reclaim={} quarantine={} sgi={} observed={} report={}",
+        current.defer,
+        current.reclaim,
+        current.quarantine,
+        current.sgi_sent,
+        current.kick_observed,
+        current.report
+    );
+    fail("timed out waiting for per-PID teardown pairing")
+}
+
+fn assert_kill_evidence(pid: i32, current: Evidence) {
+    if current.defer != 1 || current.reclaim != 1 {
+        fail("defer/reclaim were not paired exactly once for victim");
+    }
+    if current.quarantine != 1 || current.sgi_sent != 1 || current.kick_observed != 1 {
+        fail("quarantine/send/observe were not attributed exactly once to victim");
+    }
+    if current.kick_interval == 0 || current.kick_interval >= current.tick_period {
+        fail("send-to-observe interval was not strictly shorter than one tick");
+    }
+    if current.masked_frames_walked != 0 {
+        fail("SIGKILL path walked frames while PM was held");
+    }
+    if current.report != 1 {
+        fail("report obligation was not redeemed exactly once");
+    }
+    println!(
+        "SIGKILL_TEARDOWN_TEST: pid={pid} defer={} reclaim={} kick_interval={} tick_period={}",
+        current.defer, current.reclaim, current.kick_interval, current.tick_period
+    );
+}
+
+fn wait_killed(pid: i32) {
+    for _ in 0..10_000 {
+        let mut status = 0;
+        match waitpid(pid, &mut status, 1) {
+            Ok(waited) if waited.raw() as i32 == pid => {
+                if !wifsignaled(status) || wtermsig(status) != SIGKILL {
+                    fail("waitpid did not reap the victim as SIGKILL (-9)");
+                }
+                return;
+            }
+            Ok(waited) if waited.raw() == 0 => {}
+            Ok(_) => fail("waitpid reaped an unexpected child"),
+            Err(_) => fail("waitpid returned an error for SIGKILL victim"),
+        }
+        let _ = process::yield_now();
+    }
+    fail("timed out reaping the SIGKILL victim");
+}
+
+fn wait_exited(pid: i32) {
+    for _ in 0..10_000 {
+        let mut status = 0;
+        match waitpid(pid, &mut status, 1) {
+            Ok(waited) if waited.raw() as i32 == pid => {
+                if !wifexited(status) {
+                    fail("SIGKILL helper did not exit normally");
+                }
+                return;
+            }
+            Ok(waited) if waited.raw() == 0 => {}
+            Ok(_) => fail("waitpid reaped an unexpected helper"),
+            Err(_) => fail("waitpid returned an error for SIGKILL helper"),
+        }
+        let _ = process::yield_now();
+    }
+    fail("timed out reaping the SIGKILL helper");
+}
+
+fn fork_spinning_victim() -> i32 {
+    let (ready_read, ready_write) = io::pipe().unwrap_or_else(|_| fail("victim ready pipe failed"));
+    match fork().unwrap_or_else(|_| fail("fork victim failed")) {
+        ForkResult::Child => {
+            let _ = io::close(ready_read);
+            let _ = io::write(ready_write, b"R");
+            let _ = io::close(ready_write);
+            loop {
+                core::hint::spin_loop();
+            }
+        }
+        ForkResult::Parent(pid) => {
+            let _ = io::close(ready_write);
+            let mut ready = [0u8; 1];
+            if io::read(ready_read, &mut ready).ok() != Some(1) {
+                fail("spinning victim did not report EL0 readiness");
+            }
+            let _ = io::close(ready_read);
+            pid.raw() as i32
+        }
+    }
+}
+
+fn parent_kill_and_observe_sigchld(victim: i32) {
+    SIGCHLD_RECEIVED.store(false, Ordering::Release);
+    let killer = match fork().unwrap_or_else(|_| fail("fork SIGKILL helper failed")) {
+        ForkResult::Child => {
+            // Give the parent a deterministic scheduling window to enter
+            // pause(); the kill path seeds SIGCHLD before this helper returns.
+            yield_many(1_024);
+            if kill(victim, SIGKILL).is_err() {
+                std::process::exit(91);
+            }
+            std::process::exit(0);
+        }
+        ForkResult::Parent(pid) => pid.raw() as i32,
+    };
+
+    let _ = pause();
+    if !SIGCHLD_RECEIVED.swap(false, Ordering::AcqRel) {
+        fail("parent pause did not return through the SIGCHLD handler");
+    }
+    wait_killed(victim);
+    wait_exited(killer);
+}
+
+fn same_bucket_victim(first_pid: i32) -> i32 {
+    loop {
+        let (read_fd, write_fd) = io::pipe().unwrap_or_else(|_| fail("candidate pipe failed"));
+        let (ready_read, ready_write) =
+            io::pipe().unwrap_or_else(|_| fail("candidate ready pipe failed"));
+        match fork().unwrap_or_else(|_| fail("same-bucket candidate fork failed")) {
+            ForkResult::Child => {
+                let _ = io::close(write_fd);
+                let _ = io::close(ready_read);
+                let mut command = [0u8; 1];
+                if io::read(read_fd, &mut command).ok() != Some(1) {
+                    std::process::exit(2);
+                }
+                if command[0] == b'K' {
+                    let _ = io::write(ready_write, b"R");
+                    let _ = io::close(ready_write);
+                    loop {
+                        core::hint::spin_loop();
+                    }
+                }
+                let _ = io::close(ready_write);
+                std::process::exit(0);
+            }
+            ForkResult::Parent(pid) => {
+                let _ = io::close(read_fd);
+                let _ = io::close(ready_write);
+                let candidate = pid.raw() as i32;
+                let congruent =
+                    candidate as u64 % EXIT_KICK_BUCKETS == first_pid as u64 % EXIT_KICK_BUCKETS;
+                let command = if congruent { b"K" } else { b"X" };
+                if io::write(write_fd, command).ok() != Some(1) {
+                    fail("could not release same-bucket candidate");
+                }
+                let _ = io::close(write_fd);
+                if congruent {
+                    let mut ready = [0u8; 1];
+                    if io::read(ready_read, &mut ready).ok() != Some(1) {
+                        fail("same-bucket victim did not report EL0 readiness");
+                    }
+                    let _ = io::close(ready_read);
+                    println!(
+                        "SIGKILL_TEARDOWN_TEST: V1={} V2={} bucket={} congruent=true",
+                        first_pid,
+                        candidate,
+                        candidate as u64 % EXIT_KICK_BUCKETS
+                    );
+                    if candidate as u64 % EXIT_KICK_BUCKETS != first_pid as u64 % EXIT_KICK_BUCKETS
+                    {
+                        fail("same-bucket congruence assertion failed");
+                    }
+                    return candidate;
+                }
+                let _ = io::close(ready_read);
+                let mut status = 0;
+                let _ = waitpid(candidate, &mut status, 0);
+            }
+        }
+    }
+}
+
+#[repr(C)]
+struct CloneShared {
+    victim_pid: u64,
+    sibling_heartbeat: u64,
+    sibling_release: u64,
+    victim_tid: u32,
+    sibling_tid: u32,
+}
+
+unsafe fn thread_exit(code: u64) -> ! {
+    #[cfg(target_arch = "x86_64")]
+    core::arch::asm!(
+        "int 0x80",
+        "2:",
+        "pause",
+        "jmp 2b",
+        in("rax") 60u64,
+        in("rdi") code,
+        options(noreturn),
+    );
+    #[cfg(target_arch = "aarch64")]
+    core::arch::asm!(
+        "svc #0",
+        "2:",
+        "yield",
+        "b 2b",
+        in("x8") 93u64,
+        in("x0") code,
+        options(noreturn),
+    );
+}
+
+extern "C" fn clone_victim(arg: *mut u8) -> *mut u8 {
+    unsafe {
+        let shared = &mut *(arg as *mut CloneShared);
+        shared.victim_pid = getpid().unwrap().raw();
+        loop {
+            core::hint::spin_loop();
+        }
+    }
+}
+
+extern "C" fn clone_sibling(arg: *mut u8) -> *mut u8 {
+    unsafe {
+        let shared = &mut *(arg as *mut CloneShared);
+        while core::ptr::read_volatile(&shared.sibling_release) == 0 {
+            let next = core::ptr::read_volatile(&shared.sibling_heartbeat).wrapping_add(1);
+            core::ptr::write_volatile(&mut shared.sibling_heartbeat, next);
+        }
+        thread_exit(0);
+    }
+}
+
+unsafe fn raw_clone(
+    function: extern "C" fn(*mut u8) -> *mut u8,
+    argument: *mut u8,
+    stack_top: usize,
+    child_tid: *mut u32,
+) -> i64 {
+    let result: i64;
+    #[cfg(target_arch = "x86_64")]
+    core::arch::asm!(
+        "int 0x80",
+        in("rax") 56u64,
+        in("rdi") CLONE_FLAGS,
+        in("rsi") stack_top as u64,
+        in("rdx") function as u64,
+        in("r10") argument as u64,
+        in("r8") child_tid as u64,
+        lateout("rax") result,
+        options(nostack),
+    );
+    #[cfg(target_arch = "aarch64")]
+    core::arch::asm!(
+        "svc #0",
+        in("x8") 220u64,
+        inlateout("x0") CLONE_FLAGS => result,
+        in("x1") stack_top as u64,
+        in("x2") function as u64,
+        in("x3") argument as u64,
+        in("x4") child_tid as u64,
+        options(nostack),
+    );
+    result
+}
+
+fn clone_vm_sibling_survives() {
+    unsafe {
+        let shared = memory::mmap(core::ptr::null_mut(), 4096, 3, 0x22, -1, 0)
+            .unwrap_or_else(|_| fail("clone shared mmap failed"))
+            as *mut CloneShared;
+        core::ptr::write(
+            shared,
+            CloneShared {
+                victim_pid: 0,
+                sibling_heartbeat: 0,
+                sibling_release: 0,
+                victim_tid: u32::MAX,
+                sibling_tid: u32::MAX,
+            },
+        );
+        let victim_stack = memory::mmap(core::ptr::null_mut(), CHILD_STACK_SIZE, 3, 0x22, -1, 0)
+            .unwrap_or_else(|_| fail("clone victim stack mmap failed"));
+        let sibling_stack = memory::mmap(core::ptr::null_mut(), CHILD_STACK_SIZE, 3, 0x22, -1, 0)
+            .unwrap_or_else(|_| fail("clone sibling stack mmap failed"));
+
+        if raw_clone(
+            clone_victim,
+            shared.cast(),
+            (victim_stack as usize + CHILD_STACK_SIZE) & !0xf,
+            &mut (*shared).victim_tid,
+        ) < 0
+            || raw_clone(
+                clone_sibling,
+                shared.cast(),
+                (sibling_stack as usize + CHILD_STACK_SIZE) & !0xf,
+                &mut (*shared).sibling_tid,
+            ) < 0
+        {
+            fail("CLONE_VM setup failed");
+        }
+
+        for _ in 0..2_000_000 {
+            if core::ptr::read_volatile(&(*shared).victim_pid) != 0
+                && core::ptr::read_volatile(&(*shared).sibling_heartbeat) != 0
+            {
+                break;
+            }
+            let _ = process::yield_now();
+        }
+        let victim = core::ptr::read_volatile(&(*shared).victim_pid) as i32;
+        if victim == 0 {
+            fail("CLONE_VM victim did not publish its PID");
+        }
+        let _before = evidence(victim);
+        let heartbeat_before = core::ptr::read_volatile(&(*shared).sibling_heartbeat);
+        kill(victim, SIGKILL).unwrap_or_else(|_| fail("CLONE_VM victim kill failed"));
+        wait_killed(victim);
+        yield_many(64);
+        let heartbeat_after = core::ptr::read_volatile(&(*shared).sibling_heartbeat);
+        if heartbeat_after <= heartbeat_before {
+            fail("CLONE_VM sibling did not survive victim-only SIGKILL");
+        }
+        assert_kill_evidence(victim, wait_for_evidence(victim));
+        core::ptr::write_volatile(&mut (*shared).sibling_release, 1);
+        // Sibling survival is the P2 invariant. CLONE_CHILD_CLEARTID wake/clear
+        // semantics are not part of this gate, so only give the released sibling
+        // a scheduling window rather than treating that later ABI as evidence.
+        yield_many(64);
+    }
+}
+
+fn self_kill_child() {
+    let (read_fd, write_fd) = io::pipe().unwrap_or_else(|_| fail("self-kill pipe failed"));
+    match fork().unwrap_or_else(|_| fail("self-kill fork failed")) {
+        ForkResult::Child => {
+            let _ = io::close(write_fd);
+            let mut release = [0u8; 1];
+            if io::read(read_fd, &mut release).ok() != Some(1) {
+                std::process::exit(98);
+            }
+            let own_pid = getpid().unwrap().raw() as i32;
+            println!("SIGKILL_TEARDOWN_TEST: self-killing pid={own_pid}");
+            let _ = kill(own_pid, SIGKILL);
+            std::process::exit(99);
+        }
+        ForkResult::Parent(pid) => {
+            let _ = io::close(read_fd);
+            let raw_pid = pid.raw() as i32;
+            println!("SIGKILL_TEARDOWN_TEST: awaiting self-kill pid={raw_pid}");
+            let _before = evidence(raw_pid);
+            if io::write(write_fd, b"K").ok() != Some(1) {
+                fail("could not release self-kill child");
+            }
+            let _ = io::close(write_fd);
+            wait_killed(raw_pid);
+            println!("SIGKILL_TEARDOWN_TEST: self-kill waitpid reaped");
+            assert_kill_evidence(raw_pid, wait_for_evidence(raw_pid));
+        }
+    }
+}
+
+fn main() {
+    sigaction(SIGCHLD, Some(&Sigaction::new(sigchld_handler)), None)
+        .unwrap_or_else(|_| fail("SIGCHLD sigaction failed"));
+
+    let fault_entry_before = counter("TEARDOWN_ENTRY_FAULT");
+    let cr3_miss_before = counter("TEARDOWN_CR3_MISS");
+    let attribution_uncertain_before = counter("EXIT_ATTRIBUTION_UNCERTAIN");
+    let published_before = counter("EXIT_KICK_PUBLISHED");
+    let observed_before = counter("EXIT_KICK_OBSERVED");
+    let collision_before = counter("EXIT_KICK_BUCKET_COLLISION");
+
+    let victim_one = fork_spinning_victim();
+    let bucket_before = evidence(victim_one);
+    parent_kill_and_observe_sigchld(victim_one);
+    let first = wait_for_evidence(victim_one);
+    assert_kill_evidence(victim_one, first);
+    if first.bucket_published - bucket_before.bucket_published != 1
+        || first.bucket_observed - bucket_before.bucket_observed != 1
+        || first.bucket_collision - bucket_before.bucket_collision != 0
+        || counter("EXIT_KICK_PUBLISHED") - published_before != 1
+        || counter("EXIT_KICK_OBSERVED") - observed_before != 1
+        || counter("EXIT_KICK_BUCKET_COLLISION") - collision_before != 0
+    {
+        fail("single-victim kick accounting was not exactly one-to-one");
+    }
+
+    let victim_two = same_bucket_victim(victim_one);
+    let second_before = evidence(victim_two);
+    yield_many(32);
+    println!("SIGKILL_TEARDOWN_TEST: killing V2={victim_two}");
+    kill(victim_two, SIGKILL).unwrap_or_else(|_| fail("second victim kill failed"));
+    println!("SIGKILL_TEARDOWN_TEST: V2 kill returned");
+    wait_killed(victim_two);
+    println!("SIGKILL_TEARDOWN_TEST: V2 waitpid reaped");
+    let second = wait_for_evidence(victim_two);
+    assert_kill_evidence(victim_two, second);
+    if victim_one as u64 % EXIT_KICK_BUCKETS != victim_two as u64 % EXIT_KICK_BUCKETS
+        || second.bucket_published - bucket_before.bucket_published != 2
+        || second.bucket_observed - bucket_before.bucket_observed != 2
+        || second.bucket_collision - bucket_before.bucket_collision != 0
+        || second.bucket_published - second_before.bucket_published != 1
+        || second.bucket_observed - second_before.bucket_observed != 1
+        || counter("EXIT_KICK_PUBLISHED") - published_before != 2
+        || counter("EXIT_KICK_OBSERVED") - observed_before != 2
+        || counter("EXIT_KICK_BUCKET_COLLISION") - collision_before != 0
+    {
+        fail("sequential same-bucket reuse accounting failed");
+    }
+
+    clone_vm_sibling_survives();
+    println!("SIGKILL_TEARDOWN_TEST: CLONE_VM sibling survived");
+    self_kill_child();
+
+    if counter("RECLAIM_ENQUEUE_UNDER_PM") != 0
+        || counter("TEARDOWN_ENTRY_FAULT") != fault_entry_before
+        || counter("TEARDOWN_CR3_MISS") != cr3_miss_before
+        || counter("EXIT_ATTRIBUTION_UNCERTAIN") != attribution_uncertain_before
+        || counter("EXIT_REQUEST_OBSERVED") != 0
+        || counter("RECEIPT_DROPPED_UNRETIRED") != 0
+        || counter("LEDGER_CLAIM_MISMATCH") != 0
+        || counter("LEDGER_CLAIM_ORPHANED") != 0
+    {
+        fail("P2 zero-only lock-order, fault, receipt, or later-phase counters moved");
+    }
+
+    println!("SIGKILL_TEARDOWN_TEST_PASSED");
+}

--- a/xtask/src/btrt_catalog.rs
+++ b/xtask/src/btrt_catalog.rs
@@ -144,6 +144,7 @@ pub const UTEST_UNIX_NAMED_SOCKET: u16 = 372;
 pub const UTEST_PIPE_FORK: u16 = 373;
 pub const UTEST_PIPE_CONCURRENT: u16 = 374;
 pub const UTEST_JOB_CONTROL: u16 = 375;
+pub const UTEST_SIGKILL_TEARDOWN: u16 = 376;
 
 /// Complete catalog (mirrors kernel-side).
 pub static CATALOG: &[BootTestDef] = &[
@@ -691,6 +692,11 @@ pub static CATALOG: &[BootTestDef] = &[
     BootTestDef {
         id: UTEST_JOB_CONTROL,
         name: "utest_job_control",
+        category: BootTestCategory::UserspaceResult,
+    },
+    BootTestDef {
+        id: UTEST_SIGKILL_TEARDOWN,
+        name: "utest_sigkill_teardown",
         category: BootTestCategory::UserspaceResult,
     },
 ];


### PR DESCRIPTION
## Summary

P2 stops SIGKILL/fault-kill from eager-freeing victim frames, routing the kill path through `exit_process_and_retire` receipt custody + the EXIT_KICK expedite SGI, closing the cross-CPU use-after-free described in #491.

## Evidence / Gates

- `exit_kick_protocol_gate`: deterministic 100/100 (gate hardened with bounded handshakes + self-heal IPI)
- `fork_exit_defer_reclaim_pairing_test`: deterministic 100/100 (unblocked by #513)
- 0 fault/UAF/panic markers across confirmation boots
- beast x86 3/3 passing
- x86 fault-path findings adjudicated non-blocking (#511)
- This branch's confirmation boot (this PR): 89/89 subsystem tests, `exit_kick_protocol_gate:PASS`, `fork_exit_defer_reclaim_pairing_test:PASS`, zero DATA_ABORT/UAF/panic markers

References #491.

Note: pre-existing, P2-unrelated ARM64 timer-reset flakes (`timer_quantum_reset_aarch64`, `arm64_socket_reset_quantum`) observed at ~4% under zero-load stress testing are tracked in a separate follow-up issue, not part of this change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>