### PR TITLE
docs: remove gold-master FROZEN gate, keep rationale as plain comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,27 +375,6 @@ prlctl start breenix-dev
 - Red zone: disabled for interrupt safety
 - Features: `-mmx,-sse,+soft-float`
 
-## 🔒 GOLD-MASTER REGIONS — FROZEN 🔒
-
-Specific code regions are **frozen as gold-master** and must not be modified
-without reading the linked forensic record and obtaining PR signoff from the
-project owner. Each region carries an inline comment block that calls out
-the constraints.
-
-| File:line | Region | Autopsy |
-|---|---|---|
-| `kernel/src/arch_impl/aarch64/context_switch.rs` (EL0 dispatch site) | NO CPU0-specific EL0 dispatch guard | `docs/planning/cpu0-user-guard-autopsy/README.md` |
-| `kernel/src/arch_impl/aarch64/context_switch.rs::idle_loop_arm64` | Sleep gate + `dsb sy; wfi; daifclr` sequence | same |
-| `kernel/src/arch_impl/aarch64/context_switch.rs::aarch64_enter_exception_frame` | ISB before dispatch ERET (narrow placement — do NOT add ISBs at other ERETs) | same |
-| `kernel/src/arch_impl/aarch64/gic.rs::init_gicv3_redistributor` (SGI enable block) | `GICR_ISENABLER0` write for SGI_RESCHEDULE + SGI_TIMER_REARM | same |
-| `kernel/src/arch_impl/aarch64/timer_interrupt.rs` (handler arm-at-top) | Unconditional re-arm BEFORE any handler work (prevents IMASK death if handler hangs) | same |
-| `kernel/src/arch_impl/aarch64/timer_interrupt.rs` (CPU0 regression alarm) | Panic at 30s if CPU0 tick_count < 10% of max peer | same |
-
-The CPU0 user-guard regression (PR #334 fixed it) burned ~1 week because
-agents kept accepting "HVF kills CPU0 vtimer on EL0 return" as truth without
-evidence. The markers in these regions exist to break that pattern. If you
-think you need to modify one, read the autopsy first.
-
 ## 🚨 PROHIBITED CODE SECTIONS 🚨
 
 The following files are on the **prohibited modifications list**. Agents MUST NOT modify these files without explicit user approval.

--- a/docs/planning/cpu0-user-guard-autopsy/README.md
+++ b/docs/planning/cpu0-user-guard-autopsy/README.md
@@ -5,7 +5,8 @@
 This document is the definitive post-mortem on the "CPU0 regression" that
 burned approximately one week of engineering time across factories F32i,
 F32j, F33, F34, and several ad-hoc investigations in early- to mid-April
-2026. Read this *first* before touching any CPU0-adjacent code.
+2026. It explains why the CPU0-adjacent code is shaped the way it is; worth
+reading before you change any of it, so you don't re-create the bug.
 
 ---
 
@@ -224,8 +225,9 @@ If you believe CPU0 needs special handling that CPUs 1-7 do not:
 4. **Expect the detection alarm to fire** if you break this. The panic
    message will reference this document.
 
-5. **PR signoff from the project owner is required** for any change to
-   the gold-master code regions that reference this autopsy.
+These regions are not frozen — change them with discipline when you have the
+evidence above. The point of this record is that the reasons are understood,
+not that the code is untouchable.
 
 ---
 
@@ -234,7 +236,7 @@ If you believe CPU0 needs special handling that CPUs 1-7 do not:
 - This document: `docs/planning/cpu0-user-guard-autopsy/README.md`
 - Fix commit: `9da897f4` (PR #334)
 - Probe branch: `origin/cpu0-trace-dump-probe`
-- Gold-master markers in:
+- Load-bearing regions that reference this autopsy:
   - `kernel/src/arch_impl/aarch64/context_switch.rs` (dispatch site)
   - `kernel/src/arch_impl/aarch64/context_switch.rs` (`idle_loop_arm64`)
   - `kernel/src/arch_impl/aarch64/gic.rs` (`init_gicv3_redistributor`

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -717,37 +717,31 @@ aarch64_enter_exception_frame:
     str x17, [x16]
 5:
 
-    // ═════════════════════════════════════════════════════════════════════
-    // 🔒 GOLD-MASTER REGION — ISB before dispatch ERET
-    // ═════════════════════════════════════════════════════════════════════
+    // ISB before dispatch ERET — narrow placement is load-bearing.
     //
-    // Frozen by PR #336. Original fix: aeb3e989 (added ISB at 6 ERET sites)
-    // then aade0871 (narrowed to this ONE site). Narrow placement is
-    // load-bearing: ISBs at the other ERET sites (IRQ return, syscall
-    // return, first-entry-to-userspace) caused a DIFFERENT timer death at
-    // ~10K ticks. Only the dispatch ERET needs the ISB.
+    // Added in PR #336. Original fix: aeb3e989 (added ISB at 6 ERET sites)
+    // then aade0871 (narrowed to this ONE site). ISBs at the other ERET
+    // sites (IRQ return, syscall return, first-entry-to-userspace) caused a
+    // DIFFERENT timer death at ~10K ticks. Only the dispatch ERET needs the
+    // ISB, so do NOT add ISBs before the other ERETs.
     //
     // Bisection evidence (aeb3e989 commit message):
     //   - ret-based dispatch (no ERET): timer survives 55000+ ticks
     //   - ERET without ISB: timer dies after ~4 ticks
     //   - ERET with ISB: timer survives 300000+ ticks indefinitely
     //
-    // Rationale: HVF intercepts ERET before it executes as a context-sync
+    // Why: HVF intercepts ERET before it executes as a context-sync
     // event. Without the ISB, HVF reads guest SPSR_EL1/ELR_EL1 pre-sync.
     // On real hardware ERET is itself a sync, so this ISB is architecturally
     // redundant — but HVF doesn't get the sync until it runs the interception.
     //
-    // DO NOT:
-    //   - Remove this isb.
-    //   - Add ISBs before other ERETs (boot.S sync/irq handlers, syscall
-    //     return in syscall_entry.S). aade0871 specifically removed them
-    //     from those sites because they caused timer death.
-    //   - Inline additional instructions between this isb and the eret
-    //     below unless you've verified (via boot + 30s trace) that the
-    //     timer still survives.
+    // If you change this, re-verify (via boot + 30s trace) that the timer
+    // survives — in particular don't add ISBs before the other ERETs (boot.S
+    // sync/irq handlers, syscall return in syscall_entry.S; aade0871 removed
+    // them there precisely because they caused timer death), and don't inline
+    // extra instructions between this isb and the eret below without checking.
     //
-    // See docs/planning/cpu0-user-guard-autopsy/README.md.
-    // ═════════════════════════════════════════════════════════════════════
+    // Background: docs/planning/cpu0-user-guard-autopsy/README.md.
     isb
     mrs x16, mpidr_el1
     and x16, x16, #0xFF
@@ -1375,10 +1369,10 @@ pub fn dump_all_inline_save_skew_snapshots() {
 // frame was not (fully) rebuilt from context before consumption -- exactly
 // the mechanism by which a stale idle/scheduler frame physically resident on
 // a reused kstack slot could reach ERET/branch instead of the thread's real
-// saved state. Placed in the RUST callers only, per the gold-master
-// constraints on aarch64_enter_exception_frame / idle_loop_arm64 / the EL0
-// dispatch site (see CLAUDE.md's frozen-region table and
-// docs/planning/cpu0-user-guard-autopsy/README.md) -- never inside those
+// saved state. Placed in the RUST callers only -- keep the timing-sensitive
+// aarch64_enter_exception_frame / idle_loop_arm64 / EL0 dispatch site
+// sequences (see docs/planning/cpu0-user-guard-autopsy/README.md for why they
+// are shaped the way they are) untouched, never instrumenting inside those
 // regions. Strictly lock-free atomics, last-wins per CPU; record-and-continue
 // only, no behavior change.
 static DISPATCH_MISMATCH_SEEN: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS] =
@@ -1467,11 +1461,11 @@ pub fn dump_all_dispatch_mismatch_snapshots() {
 // nested exception reusing the same stack-local frame storage), or that
 // carries idle's live register-file fingerprint per
 // `frame_is_idle_register_file` even when its elr happens to equal the
-// dispatched thread's context.elr_el1. Placed in the RUST callers only, per
-// the gold-master constraints on aarch64_enter_exception_frame /
-// idle_loop_arm64 / the EL0 dispatch site (CLAUDE.md's frozen-region table,
-// docs/planning/cpu0-user-guard-autopsy/README.md) -- never inside those
-// regions. Strictly lock-free atomics, last-wins per CPU; record-and-
+// dispatched thread's context.elr_el1. Placed in the RUST callers only --
+// keep the timing-sensitive aarch64_enter_exception_frame / idle_loop_arm64 /
+// EL0 dispatch site sequences (see docs/planning/cpu0-user-guard-autopsy/
+// README.md for why they are shaped the way they are) untouched, never
+// instrumenting inside those regions. Strictly lock-free atomics, last-wins per CPU; record-and-
 // continue only, no behavior change.
 static ERET_ANOMALY_SEEN: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_CPUS] =
     [const { AtomicU64::new(0) }; crate::arch_impl::aarch64::constants::MAX_CPUS];
@@ -1491,9 +1485,9 @@ static ERET_ANOMALY_SPSR: [AtomicU64; crate::arch_impl::aarch64::constants::MAX_
 /// `record_dispatch_mismatch_if_needed` (kernel-context-restore and
 /// userspace-dispatch branches). A parallel per-CPU atomic rather than a
 /// field inside `Aarch64ExceptionFrame` itself -- the frame's layout is
-/// consumed by the frozen assembly in `aarch64_enter_exception_frame` at
-/// fixed offsets, so adding a live field there would require re-deriving
-/// every offset used by that gold-master code. Read (not written) by the
+/// consumed by the hand-written assembly in `aarch64_enter_exception_frame`
+/// at fixed offsets, so adding a live field there would require re-deriving
+/// every offset used by that code. Read (not written) by the
 /// ERET_ANOMALY consumer sites so the postmortem can show whether the tid
 /// about to be ERET'd/resumed actually matches the last tid a frame was
 /// finalized for on this CPU, or whether an intervening dispatch path
@@ -3258,11 +3252,10 @@ fn dispatch_thread_locked(
                 );
             }
         }
-        // ═══════════════════════════════════════════════════════════════════
-        // 🔒 GOLD-MASTER REGION — DO NOT ADD A CPU0-SPECIFIC EL0 DISPATCH GUARD
-        // ═══════════════════════════════════════════════════════════════════
+        // No CPU0-specific EL0 dispatch guard here — CPU0 dispatches EL0
+        // threads IDENTICALLY to CPUs 1-7.
         //
-        // Frozen by PR #334 (commit 9da897f4, 2026-04-22) after a one-week
+        // History (PR #334, commit 9da897f4, 2026-04-22): a one-week
         // investigation attributed CPU0 "timer death" to an HVF vtimer issue.
         // The real bug was a CPU0-specific guard here that redirected every
         // EL0 candidate, then called `requeue_thread_after_save(thread_id)`
@@ -3271,27 +3264,20 @@ fn dispatch_thread_locked(
         // same thread, hit the guard, requeued, looped at ~24 kHz,
         // indefinitely, never reaching userspace.
         //
-        // RULE: CPU0 dispatches EL0 threads IDENTICALLY to CPUs 1-7. Do not
-        // add any CPU-specific branch here.
-        //
-        // IF YOU BELIEVE CPU0 NEEDS SPECIAL HANDLING, DO ALL OF:
-        //   1. Read docs/planning/cpu0-user-guard-autopsy/README.md first.
-        //   2. Reproduce the problem with cpu0-trace-dump-probe evidence,
-        //      specifically per-CPU tick_count parity at 30s uptime.
-        //   3. Verify on the Linux probe VM (10.211.55.3) that Linux needs
-        //      the behavior you're proposing. If Linux works without it,
-        //      Breenix can work without it.
-        //   4. Ensure any requeue you add demonstrably routes to a NON-CPU0
-        //      ready queue (NOT requeue_thread_after_save which re-enqueues
-        //      on the current CPU).
-        //   5. Obtain PR signoff from the project owner.
+        // So: don't add a CPU-specific branch here without strong evidence.
+        // If you think CPU0 genuinely needs special handling, reproduce the
+        // problem first (per-CPU tick_count parity at 30s uptime via the
+        // cpu0-trace-dump-probe), confirm on the Linux probe VM (10.211.55.3)
+        // that Linux needs the behavior — if Linux works without it, Breenix
+        // can too — and make sure any requeue you add demonstrably routes to a
+        // NON-CPU0 ready queue (NOT requeue_thread_after_save, which
+        // re-enqueues on the current CPU).
         //
         // The boot-time regression alarm in timer_interrupt.rs (panics if
-        // CPU0 tick_count < 10% of max peer at 30s) will catch you if any
-        // change to this region reintroduces the loop.
+        // CPU0 tick_count < 10% of max peer at 30s) will catch a change here
+        // that reintroduces the loop.
         //
-        // DO NOT REMOVE OR RELAX THIS COMMENT BLOCK.
-        // ═══════════════════════════════════════════════════════════════════
+        // Background: docs/planning/cpu0-user-guard-autopsy/README.md.
 
         if !has_started {
             if let Some(thread) = sched.get_thread_mut(thread_id) {
@@ -4900,32 +4886,28 @@ fn idle_enter_scheduler_if_needed() -> bool {
 
 /// ARM64 idle loop - wait for interrupts.
 #[no_mangle]
-// ═══════════════════════════════════════════════════════════════════════════
-// 🔒 GOLD-MASTER REGION — idle_loop_arm64
-// ═══════════════════════════════════════════════════════════════════════════
+// idle_loop_arm64 — the (daifset → gate check → dsb sy → wfi → daifclr)
+// sequence in this loop is load-bearing.
 //
-// Frozen by PR #334 (commit 9da897f4, 2026-04-22). The (daifset → gate check
-// → dsb sy → wfi → daifclr) sequence in this loop is the result of F20e
-// (bff1d92a), F32j's sleep gate (part of PR #328), and the empirical
-// finding that Linux runs the same pattern on the same Parallels
-// hypervisor without issue.
+// Shaped by PR #334 (commit 9da897f4, 2026-04-22), F20e (bff1d92a), F32j's
+// sleep gate (part of PR #328), and the empirical finding that Linux runs the
+// same pattern on the same Parallels hypervisor without issue.
 //
 // In particular:
 //   - `dsb sy` BEFORE wfi matches Linux's `arch/arm64/kernel/process.c::cpu_do_idle`
 //   - WFI runs with IRQs masked; masked IRQs still wake WFI per ARM spec
 //   - `daifclr` after WFI unmasks to take the pending IRQ
 //
-// DO NOT:
-//   - Re-add the idle-loop `rearm_timer()` that F20e removed (handler-level
-//     re-arm from e4e16b68 covers this)
-//   - Change the DAIF mask width without citing Linux arch_local_irq_disable
-//   - Add a CPU0-specific branch here (the previous guard was what caused
-//     the week-long "CPU0 regression" — see
+// When changing this loop, keep those invariants in mind:
+//   - Don't re-add the idle-loop `rearm_timer()` that F20e removed (handler-
+//     level re-arm from e4e16b68 covers this)
+//   - Don't change the DAIF mask width without citing Linux arch_local_irq_disable
+//   - Don't add a CPU0-specific branch here (the previous guard was what
+//     caused the week-long "CPU0 regression" — see
 //     docs/planning/cpu0-user-guard-autopsy/README.md)
 //
 // The regression alarm in timer_interrupt.rs fires if CPU0 tick_count
 // diverges from peer CPUs at 30s uptime.
-// ═══════════════════════════════════════════════════════════════════════════
 pub extern "C" fn idle_loop_arm64() -> ! {
     // Get CPU ID once (cheap MRS).
     let cpu_id = crate::arch_impl::aarch64::percpu::Aarch64PerCpu::cpu_id() as usize;

--- a/kernel/src/arch_impl/aarch64/gic.rs
+++ b/kernel/src/arch_impl/aarch64/gic.rs
@@ -1613,11 +1613,9 @@ fn init_gicv3_redistributor(cpu_id: usize) {
     gicr_write_at_rd_base(rd_base, GICR_SGI_OFFSET + GICR_ICFGR0, 0); // SGIs: always edge
     gicr_write_at_rd_base(rd_base, GICR_SGI_OFFSET + GICR_ICFGR0 + 4, 0); // PPIs: level-triggered
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // 🔒 GOLD-MASTER REGION — SGI admission enable
-    // ═══════════════════════════════════════════════════════════════════════
+    // SGI admission enable — load-bearing.
     //
-    // Frozen by F32j (commit 946b2812, PR #328) and retained by PR #334.
+    // Added by F32j (commit 946b2812, PR #328), retained by PR #334.
     // Without enabling the SGIs Breenix actually uses (SGI_RESCHEDULE and
     // SGI_TIMER_REARM) in each CPU's GICR_ISENABLER0, the SGIs can latch
     // in GICR_ISPENDR0 but never be admitted by the CPU interface —
@@ -1626,14 +1624,13 @@ fn init_gicv3_redistributor(cpu_id: usize) {
     // (20/20 Linux wakes of idle CPU0 in 14-54µs on same Parallels hypervisor).
     // Linux parity: /tmp/linux-v6.8/drivers/irqchip/irq-gic-v3.c::gic_cpu_config.
     //
-    // DO NOT remove or relax this ISENABLER write. Any future SGI Breenix
-    // introduces (beyond SGI 0 and 1) must also be OR'd into this mask.
-    // The `dsb sy; isb` after the write ensures the CPU interface sees
-    // the enable before any subsequent SGI send.
+    // Keep this ISENABLER write: any future SGI Breenix introduces (beyond
+    // SGI 0 and 1) must also be OR'd into this mask. The `dsb sy; isb` after
+    // the write ensures the CPU interface sees the enable before any
+    // subsequent SGI send.
     //
-    // See docs/planning/cpu0-user-guard-autopsy/README.md for the forensic
-    // record of the CPU0 regression this fix was part of addressing.
-    // ═══════════════════════════════════════════════════════════════════════
+    // Background: docs/planning/cpu0-user-guard-autopsy/README.md records the
+    // CPU0 regression this fix was part of addressing.
     let sgi_enable_mask =
         (1u32 << super::constants::SGI_RESCHEDULE) | (1u32 << super::constants::SGI_TIMER_REARM);
     gicr_write_at_rd_base(rd_base, GICR_SGI_OFFSET + GICR_ISENABLER0, sgi_enable_mask);
@@ -1641,7 +1638,6 @@ fn init_gicv3_redistributor(cpu_id: usize) {
         core::arch::asm!("dsb sy", options(nomem, nostack));
         core::arch::asm!("isb", options(nomem, nostack));
     }
-    // ═══════════════════════════════════════════════════════════════════════
 }
 
 /// Initialize GICv3 CPU Interface via ICC system registers.

--- a/kernel/src/arch_impl/aarch64/timer_interrupt.rs
+++ b/kernel/src/arch_impl/aarch64/timer_interrupt.rs
@@ -527,9 +527,7 @@ pub extern "C" fn timer_interrupt_handler(frame: *const Aarch64ExceptionFrame) {
         }
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // 🔒 GOLD-MASTER REGION — CPU0 divergence regression alarm
-    // ═══════════════════════════════════════════════════════════════════════
+    // CPU0 divergence regression alarm.
     //
     // Installed by PR #334 (2026-04-22) after the CPU0 user-guard dispatch
     // loop cost ~1 week to diagnose. The alarm fires a `panic!` at 30s
@@ -544,8 +542,7 @@ pub extern "C" fn timer_interrupt_handler(frame: *const Aarch64ExceptionFrame) {
     // A panic is intentionally loud: this regression SHOULD make the
     // system unbootable because silent degradation was the whole problem.
     //
-    // See docs/planning/cpu0-user-guard-autopsy/README.md.
-    // ═══════════════════════════════════════════════════════════════════════
+    // Background: docs/planning/cpu0-user-guard-autopsy/README.md.
     if cpu_id >= 1 && cpu_id < 8 {
         let this_cpu_ticks = TIMER_TICK_COUNT[cpu_id].load(Ordering::Relaxed);
         if this_cpu_ticks == 30000 {
@@ -604,7 +601,6 @@ pub extern "C" fn timer_interrupt_handler(frame: *const Aarch64ExceptionFrame) {
             }
         }
     }
-    // ═══════════════════════════════════════════════════════════════════════
 
     // Mask the timer interrupt at the source (set IMASK=1, keep ENABLE=1).
     // This de-asserts the PPI line, which signals the hypervisor (Parallels/HVF)
@@ -631,11 +627,10 @@ pub extern "C" fn timer_interrupt_handler(frame: *const Aarch64ExceptionFrame) {
         }
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // 🔒 GOLD-MASTER REGION — arm_timer at TOP of handler
-    // ═══════════════════════════════════════════════════════════════════════
+    // arm_timer at the TOP of the handler — unconditional re-arm before any
+    // handler work, to prevent IMASK death if the handler hangs.
     //
-    // Frozen by PR #336 after review. Original fix in commit e4e16b68
+    // Added in PR #336 after review; original fix in commit e4e16b68
     // (2026-03-29): "move arm_timer to top of handler — prevents IMASK death
     // when handler work hangs".
     //
@@ -647,19 +642,17 @@ pub extern "C" fn timer_interrupt_handler(frame: *const Aarch64ExceptionFrame) {
     // the timer is already re-armed with IMASK=0 so the CPU's vtimer keeps
     // ticking instead of dying permanently.
     //
-    // DO NOT:
-    //   - Move this re-arm later in the handler ("just a quick poll first,
-    //     then arm" has been tried and regresses to IMASK-death).
-    //   - Gate it on any condition — every timer-handler entry re-arms,
-    //     unconditionally, even if the previous arm happened 1µs ago.
-    //   - Replace the direct CNTV_CTL=1 + CVAL write with an arm function
-    //     that could take a lock.
+    // So keep the re-arm here: don't move it later in the handler ("just a
+    // quick poll first, then arm" has been tried and regresses to
+    // IMASK-death), don't gate it on any condition (every timer-handler entry
+    // re-arms, unconditionally, even if the previous arm happened 1µs ago),
+    // and don't replace the direct CNTV_CTL=1 + CVAL write with an arm
+    // function that could take a lock.
     //
     // Diagnostic proof of the IMASK-death class is in the e4e16b68 commit
     // message: `timer_ctl[0]=0x7 (ENABLE=1, IMASK=1, ISTATUS=1)` on a dead
     // CPU0 before the fix. See also docs/planning/cpu0-user-guard-autopsy
     // for the broader CPU0-liveness story.
-    // ═══════════════════════════════════════════════════════════════════════
     let ticks = TICKS_PER_INTERRUPT.load(Ordering::Relaxed);
     if crate::platform_config::is_vmware() {
         // VMware: re-arm both timers using CVAL (absolute compare value)


### PR DESCRIPTION
## Why

The `🔒 GOLD-MASTER REGIONS — FROZEN` framing was a **discipline gate** against undisciplined change — **not a correctness claim** about the code. In practice the freeze was causing *avoidance-hacks*: agents routed around these regions (extra indirection, parallel probes, "never touch" reasoning) rather than changing them with discipline when the code genuinely needed it.

This PR removes the *gate* while **preserving the engineering *rationale*** so future work still understands why each region is shaped the way it is and does not regress a hard-won fix.

## What

- **CLAUDE.md**: deletes the entire `## 🔒 GOLD-MASTER REGIONS — FROZEN 🔒` section (intro prose + table + CPU0-regression paragraph).
- **Inline markers** (`context_switch.rs`, `gic.rs`, `timer_interrupt.rs`): the `🔒 GOLD-MASTER` / `FROZEN` / `do-not-modify-without-signoff` / `read-the-autopsy-first` banners are converted to **plain comments** that keep the technical WHY:
  - ISB before dispatch ERET, and why *not* at the other ERET sites
  - `idle_loop_arm64` `dsb sy; wfi; daifclr` sequence
  - GICR SGI admission enable (`SGI_RESCHEDULE` + `SGI_TIMER_REARM`)
  - unconditional timer re-arm at the *top* of the handler (prevents IMASK death if the handler hangs)
  - CPU0 divergence regression alarm (panic at 30s if CPU0 tick_count < 10% of max peer)
  - **These edits are comment-only — no code lines changed.**
- **`docs/planning/cpu0-user-guard-autopsy/README.md`**: kept as the forensic postmortem (valuable history), but the "frozen / requires signoff / do not modify" framing is softened to explain *why the code is shaped this way* rather than forbid changing it.

## Left intact

The interrupt/syscall **hot-path no-logging hygiene** (Tier-1/Tier-2 `PROHIBITED CODE SECTIONS` and the "Interrupt and Syscall Development" timing rules) is a **timing concern, not a freeze**, and is deliberately untouched.

## Verification

- aarch64 kernel builds clean (zero warnings) in **both** configs: standard and `--features boot_tests`.
- `.rs` diffs confirmed **comment-only** (no code lines added/removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)