### PR TITLE
fix(tests): timer_delay starved-boot false-FAIL — counter-verified host-stall crediting

### DIFF
--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -1242,10 +1242,16 @@ fn test_timer_ticks() -> TestResult {
 ///
 /// Attempts to delay for approximately 10ms and checks that the elapsed
 /// time is within the MIN_MS..=MAX_MS band. This accounts for timer resolution
-/// and scheduling variance. On ARM64 the measurement window is additionally
-/// screened for intervals where wall-clock time advanced while the test thread
-/// made no progress. Such windows are re-measured without widening the scored
-/// bounds (see the detector comment in the aarch64 branch).
+/// and scheduling variance. On ARM64 the busy-wait additionally proves, from
+/// inside the guest, whether wall-clock time advanced while this vCPU executed
+/// nothing at all; only those windows are re-measured, and the scored bounds
+/// never move (see the attribution comment in the aarch64 branch).
+///
+/// The x86_64 branch keeps the single unscreened measurement it has always
+/// had. The starved-boot gate this screen exists for runs ARM64 only, and the
+/// PIT path has no per-CPU interrupt counter with which to prove the premise
+/// the ARM64 attribution rests on; it is a knowingly unscreened measurement
+/// rather than an oversight.
 fn test_timer_delay() -> TestResult {
     // Target delay in milliseconds
     const TARGET_MS: u64 = 10;
@@ -1281,50 +1287,64 @@ fn test_timer_delay() -> TestResult {
     {
         use crate::arch_impl::aarch64::timer;
 
-        // ---- Measurement-contamination detector (test harness only) ---------
+        // ---- Host-starvation attribution (test harness only) ----------------
         //
-        // The busy-wait below is measured with CNTVCT_EL0, which under QEMU TCG
-        // advances with host wall-clock time rather than guest execution
-        // progress. The preempt guard suppresses guest thread preemption, but
-        // interrupts remain enabled. A large inter-sample gap therefore proves
-        // only that wall-clock time advanced while this thread made no progress;
-        // it may include time in this CPU's interrupt handlers as well as time
-        // when the host descheduled the vCPU.
+        // CNTVCT_EL0 measures host wall-clock under QEMU TCG, so an overrunning
+        // window has two unrelated explanations: this CPU spent the time in its
+        // own kernel code (a real defect this test must report), or the host
+        // descheduled the vCPU thread and the guest executed nothing at all.
+        // Counting "wall-clock advanced while the loop made no progress" cannot
+        // tell those apart, so the window is built to make them distinguishable
+        // instead of guessing between them.
         //
-        // This conservative accounting is acceptable because it only causes a
-        // bounded re-measurement. A defect that deterministically steals the
-        // window contaminates every attempt and still FAILs on exhaustion. Only
-        // busy-wait gaps strictly between the two scored timestamp reads accrue
-        // stall_ticks. Excess in the boundary gaps is unattributable because the
-        // gaps straddle those reads. A long window is unmeasurable only when
-        // crediting both the observed stall and the whole-millisecond bracket
-        // loss brings the reading back to MAX_MS or less. The bracket conversion
-        // deliberately truncates because under-crediting unattributable time is
-        // the strict direction. A fault-injection control with a 4x-too-long wait
-        // and only 44us of bracket loss demonstrated why bracket loss alone must
-        // not force a retry.
+        // The busy-wait runs in slices with IRQ+FIQ masked. Inside a slice the
+        // only code this CPU can execute is the loop below, and each slice
+        // checks that premise rather than assuming it: it compares the per-CPU
+        // interrupt counter (IRQ_TOTAL, incremented at the top of handle_irq,
+        // which both the IRQ and the FIQ vector enter) and the per-CPU
+        // synchronous-exception counter across the slice. A gap inside a slice
+        // whose premise held is therefore proof that the vCPU itself was not
+        // running: no in-guest defect can manufacture one. Only that time is
+        // credited as host starvation, and only credited time can send a window
+        // back to be measured again.
         //
-        // A lack of thread progress can only ever lengthen a wall-clock
-        // measurement, so a short reading is always the kernel timer's fault
-        // and FAILs at once. A measurable long reading is contaminated only
-        // when at least
-        // CONTAMINATION_STALL_MILLISECONDS of stall was observed AND removing
-        // exactly that observed stall brings the reading back to MAX_MS or
-        // less. Re-measurement is bounded by both attempt count and CNTVCT wall
-        // time. A clean window whose overrun the observed stalls do not fully
-        // explain FAILs against the unchanged bounds. The test never passes
-        // without observing an in-band scored window.
-        const STALL_SAMPLE_MICROSECONDS: u64 = 10;
+        // Guest interrupt work stays inside the measurement on purpose: between
+        // slices the mask is opened so pending interrupts are taken, and what
+        // that costs lands in elapsed_ms with no credit. A handler that runs
+        // long, an interrupt storm, or any other in-guest theft of this CPU
+        // therefore still FAILs with "delay too long on ARM64" on the very
+        // first window, exactly as it did before this screen existed, and just
+        // as reliably when the defect is intermittent, because such a window is
+        // never retried. A slice whose premise failed is credited to nobody,
+        // which is the strict direction. Slices are short enough (250us) that
+        // no timer tick is lost, only deferred.
+        //
+        // Known residue, stated rather than hidden: a host outage landing
+        // wholly inside one of the brief open-mask windows is attributed to the
+        // guest and FAILs. That is the verdict main gives today for every
+        // outage, and the open windows are a small fraction of the measurement.
+        //
+        // Lost thread progress can only lengthen a wall-clock reading, so a
+        // short reading is always the kernel timer's fault and FAILs at once
+        // with no retry. Re-measurement is bounded by attempt count and by
+        // CNTVCT wall time (checked between attempts, so the bound is that
+        // budget plus at most one window), and exhausting it is a distinct
+        // FAIL. The test never passes without an in-band scored window.
+        const STALL_SAMPLE_MICROSECONDS: u64 = 5;
+        const SLICE_MICROSECONDS: u64 = 250;
         const CONTAMINATION_STALL_MILLISECONDS: u64 = 1;
-        const MAX_MEASUREMENT_ATTEMPTS: u32 = 16;
-        const MEASUREMENT_BUDGET_MS: u64 = 5_000;
-        const MIN_SCREENABLE_FREQUENCY_HZ: u64 = 100_000;
+        const MAX_MEASUREMENT_ATTEMPTS: u32 = 4;
+        const MEASUREMENT_BUDGET_MS: u64 = 400;
+        const MIN_SCREENABLE_FREQUENCY_HZ: u64 = 1_000_000;
 
         struct TimerDelayMeasurement {
             elapsed_ms: u64,
-            stall_ticks: u64,
-            unattributed_bracket_ticks: u64,
+            host_stall_ticks: u64,
             max_gap_ticks: u64,
+            open_window_ticks: u64,
+            irqs_taken: u64,
+            forfeited_slices: u64,
+            slices: u64,
             samples: u64,
         }
 
@@ -1343,121 +1363,223 @@ fn test_timer_delay() -> TestResult {
             }
         }
 
+        /// Masks IRQ+FIQ for the scored window and restores DAIF exactly.
+        struct TimerDelayMaskGuard(u64);
+
+        impl TimerDelayMaskGuard {
+            fn enter() -> Self {
+                let daif: u64;
+                unsafe {
+                    core::arch::asm!("mrs {}, daif", out(reg) daif, options(nomem, nostack));
+                    core::arch::asm!("msr daifset, #3", "isb", options(nomem, nostack));
+                }
+                Self(daif)
+            }
+
+            /// DAIF I bit (bit 7) clear means interrupts were live on entry.
+            fn interrupts_were_enabled(&self) -> bool {
+                (self.0 & (1 << 7)) == 0
+            }
+        }
+
+        impl Drop for TimerDelayMaskGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    core::arch::asm!("msr daif, {}", "isb", in(reg) self.0, options(nomem, nostack));
+                }
+            }
+        }
+
+        /// Give pending interrupts an architectural window in which to be taken.
+        fn open_interrupt_window() {
+            unsafe {
+                core::arch::asm!(
+                    "msr daifclr, #3",
+                    "isb",
+                    "msr daifset, #3",
+                    "isb",
+                    options(nomem, nostack)
+                );
+            }
+        }
+
         // Get frequency for nanosecond calculations
         let freq = timer::frequency_hz();
         if freq == 0 {
             return TestResult::Fail("timer frequency is 0");
         }
-        if freq < MIN_SCREENABLE_FREQUENCY_HZ {
-            return TestResult::Fail("timer frequency below 100 kHz; cannot screen delay on ARM64");
-        }
+        // Below this frequency a 5us gap is not representable in whole ticks, so
+        // the screen is switched off and the measurement is scored exactly as it
+        // was before this screen existed - one window, no retry.
+        let screened = freq >= MIN_SCREENABLE_FREQUENCY_HZ;
 
         // Calculate ticks for TARGET_MS milliseconds
         let ticks_for_target = timer::milliseconds_to_ticks(freq, TARGET_MS);
-        // On QEMU TCG aarch64 at CNTFRQ_EL0=24MHz, a clean window retires about
-        // 14k samples/ms (~70ns/sample), roughly 140x below this 10us threshold.
-        let stall_sample_ticks =
-            (freq.saturating_mul(STALL_SAMPLE_MICROSECONDS) / 1_000_000).max(1);
+        let microseconds_to_ticks =
+            |microseconds: u64| (freq.saturating_mul(microseconds) / 1_000_000).max(1);
+        // On QEMU TCG aarch64 a masked slice retires a sample every ~70ns,
+        // roughly 70x below this threshold.
+        let stall_sample_ticks = microseconds_to_ticks(STALL_SAMPLE_MICROSECONDS);
+        let slice_ticks = microseconds_to_ticks(SLICE_MICROSECONDS);
         let contamination_stall_ticks =
             timer::milliseconds_to_ticks(freq, CONTAMINATION_STALL_MILLISECONDS);
         let measurement_budget_ticks = timer::milliseconds_to_ticks(freq, MEASUREMENT_BUDGET_MS);
         let stall_excess = |gap: u64| gap.saturating_sub(stall_sample_ticks);
         let ticks_to_microseconds = |ticks: u64| ticks.saturating_mul(1_000_000) / freq;
+        let ticks_to_milliseconds = |ticks: u64| ticks.saturating_mul(1_000) / freq;
+
+        let cpu = crate::arch_impl::current::percpu::Aarch64PerCpu::cpu_id() as usize;
+        let irq_count = || crate::tracing::providers::counters::IRQ_TOTAL.get_cpu(cpu);
+        let sync_count = || {
+            crate::arch_impl::aarch64::exception::SYNC_EXCEPTION_COUNT
+                .get(cpu)
+                .map(|counter| counter.load(core::sync::atomic::Ordering::Relaxed))
+                .unwrap_or(0)
+        };
 
         let measure_window = || {
             let _preempt_guard = TimerDelayPreemptGuard::enter();
+            let mask_guard = TimerDelayMaskGuard::enter();
+            let may_open_windows = mask_guard.interrupts_were_enabled();
+
+            let window_irq_start = irq_count();
+            let mut slice_irq = window_irq_start;
+            let mut slice_sync = sync_count();
+            let mut slice_stall_ticks = 0u64;
+
+            let mut host_stall_ticks = 0u64;
+            let mut max_gap_ticks = 0u64;
+            let mut open_window_ticks = 0u64;
+            let mut forfeited_slices = 0u64;
+            let mut slices = 1u64;
 
             let pre_start_counter = timer::rdtsc();
             let start_ns = timer::nanoseconds_since_base().unwrap_or(0);
             let start_counter = timer::rdtsc();
-            let target_counter = start_counter.saturating_add(ticks_for_target);
+            let mut samples = 2u64;
+            let mut previous_sample = start_counter;
+            let mut slice_start = start_counter;
 
             let opening_gap = timer::elapsed_ticks(start_counter, pre_start_counter);
-            let mut unattributed_bracket_ticks = stall_excess(opening_gap);
-            let mut max_gap_ticks = opening_gap;
-            let mut stall_ticks = 0u64;
-            let mut previous_sample = start_counter;
-            let mut samples = 1u64;
+            slice_stall_ticks = slice_stall_ticks.saturating_add(stall_excess(opening_gap));
+            max_gap_ticks = max_gap_ticks.max(opening_gap);
 
             loop {
                 let sample = timer::rdtsc();
                 let gap = timer::elapsed_ticks(sample, previous_sample);
+                slice_stall_ticks = slice_stall_ticks.saturating_add(stall_excess(gap));
                 max_gap_ticks = max_gap_ticks.max(gap);
-                stall_ticks = stall_ticks.saturating_add(stall_excess(gap));
                 samples = samples.saturating_add(1);
                 previous_sample = sample;
-                if sample >= target_counter {
+
+                if timer::elapsed_ticks(sample, start_counter) >= ticks_for_target {
                     break;
                 }
+
+                if timer::elapsed_ticks(sample, slice_start) >= slice_ticks {
+                    // Credit this slice only if nothing but this loop ran on
+                    // this CPU for the whole of it.
+                    if irq_count() == slice_irq && sync_count() == slice_sync {
+                        host_stall_ticks = host_stall_ticks.saturating_add(slice_stall_ticks);
+                    } else {
+                        forfeited_slices = forfeited_slices.saturating_add(1);
+                    }
+                    slice_stall_ticks = 0;
+
+                    let open_start = timer::rdtsc();
+                    if may_open_windows {
+                        open_interrupt_window();
+                    }
+                    let open_end = timer::rdtsc();
+                    open_window_ticks = open_window_ticks
+                        .saturating_add(timer::elapsed_ticks(open_end, open_start));
+
+                    slice_irq = irq_count();
+                    slice_sync = sync_count();
+                    slices = slices.saturating_add(1);
+                    previous_sample = timer::rdtsc();
+                    slice_start = previous_sample;
+                    samples = samples.saturating_add(3);
+                }
+
                 core::hint::spin_loop();
             }
 
             let end_ns = timer::nanoseconds_since_base().unwrap_or(0);
             let post_end_counter = timer::rdtsc();
+            samples = samples.saturating_add(2);
             let closing_gap = timer::elapsed_ticks(post_end_counter, previous_sample);
+            slice_stall_ticks = slice_stall_ticks.saturating_add(stall_excess(closing_gap));
             max_gap_ticks = max_gap_ticks.max(closing_gap);
-            unattributed_bracket_ticks =
-                unattributed_bracket_ticks.saturating_add(stall_excess(closing_gap));
-            samples = samples.saturating_add(1);
+
+            let window_irq_end = irq_count();
+            if window_irq_end == slice_irq && sync_count() == slice_sync {
+                host_stall_ticks = host_stall_ticks.saturating_add(slice_stall_ticks);
+            } else {
+                forfeited_slices = forfeited_slices.saturating_add(1);
+            }
 
             TimerDelayMeasurement {
                 elapsed_ms: end_ns.saturating_sub(start_ns) / 1_000_000,
-                stall_ticks,
-                unattributed_bracket_ticks,
+                host_stall_ticks,
                 max_gap_ticks,
+                open_window_ticks,
+                irqs_taken: window_irq_end.wrapping_sub(window_irq_start),
+                forfeited_slices,
+                slices,
                 samples,
             }
         };
 
         let measurement_budget_start = timer::rdtsc();
+        let max_attempts = if screened {
+            MAX_MEASUREMENT_ATTEMPTS
+        } else {
+            1
+        };
         let mut attempt: u32 = 0;
         loop {
-            if attempt >= MAX_MEASUREMENT_ATTEMPTS
+            if attempt >= max_attempts
                 || timer::elapsed_ticks(timer::rdtsc(), measurement_budget_start)
                     >= measurement_budget_ticks
             {
-                return TestResult::Fail(
-                    "timer delay never observed an uncontaminated window on ARM64",
-                );
+                return TestResult::Fail("timer delay never observed an unstarved window on ARM64");
             }
             attempt += 1;
 
             let measurement = measure_window();
             let in_band = measurement.elapsed_ms >= MIN_MS && measurement.elapsed_ms <= MAX_MS;
-            let stall_ms = measurement.stall_ticks.saturating_mul(1_000) / freq;
-            let bracket_loss_ms =
-                measurement.unattributed_bracket_ticks.saturating_mul(1_000) / freq;
-            let unmeasurable = measurement.elapsed_ms > MAX_MS
-                && measurement.unattributed_bracket_ticks != 0
-                && measurement
-                    .elapsed_ms
-                    .saturating_sub(stall_ms)
-                    .saturating_sub(bracket_loss_ms)
-                    <= MAX_MS;
-            let contaminated = measurement.elapsed_ms > MAX_MS
-                && !unmeasurable
-                && measurement.stall_ticks >= contamination_stall_ticks
-                && measurement.elapsed_ms.saturating_sub(stall_ms) <= MAX_MS;
+            let host_stall_ms = ticks_to_milliseconds(measurement.host_stall_ticks);
+            let host_starved = screened
+                && measurement.elapsed_ms > MAX_MS
+                && measurement.host_stall_ticks >= contamination_stall_ticks
+                && measurement.elapsed_ms.saturating_sub(host_stall_ms) <= MAX_MS;
             let verdict = if in_band {
                 "in-band"
-            } else if unmeasurable {
-                "unmeasurable"
-            } else if contaminated {
-                "contaminated"
+            } else if host_starved {
+                "host-starved"
             } else {
                 "out-of-band"
             };
 
-            if !in_band || attempt != 1 {
-                // Serial is required because boot-test capture does not include log::* output.
+            // Serial matches the framework's own [TEST:...] marker channel.
+            // Printed for every window that was not a clean first-attempt pass,
+            // and for a passing window that nonetheless saw a credited stall, so
+            // starvation that pulled a short delay up into the band leaves
+            // evidence instead of passing silently.
+            if !in_band || attempt > 1 || measurement.host_stall_ticks >= contamination_stall_ticks
+            {
                 crate::serial_println!(
-                    "[timer_delay] attempt={} verdict={} elapsed_ms={} stall_ms={} bracket_loss_us={} max_gap_us={} samples={}",
+                    "[timer_delay] attempt={} verdict={} elapsed_ms={} host_stall_ms={} max_gap_us={} open_window_us={} irqs={} slices={} forfeited={} samples={}",
                     attempt,
                     verdict,
                     measurement.elapsed_ms,
-                    stall_ms,
-                    ticks_to_microseconds(measurement.unattributed_bracket_ticks),
+                    host_stall_ms,
                     ticks_to_microseconds(measurement.max_gap_ticks),
+                    ticks_to_microseconds(measurement.open_window_ticks),
+                    measurement.irqs_taken,
+                    measurement.slices,
+                    measurement.forfeited_slices,
                     measurement.samples,
                 );
             }
@@ -1468,7 +1590,7 @@ fn test_timer_delay() -> TestResult {
             if measurement.elapsed_ms < MIN_MS {
                 return TestResult::Fail("delay too short on ARM64");
             }
-            if !unmeasurable && !contaminated {
+            if !host_starved {
                 return TestResult::Fail("delay too long on ARM64");
             }
         }

--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -1296,8 +1296,13 @@ fn test_timer_delay() -> TestResult {
         // window contaminates every attempt and still FAILs on exhaustion. Only
         // busy-wait gaps strictly between the two scored timestamp reads accrue
         // stall_ticks. Excess in the boundary gaps is unattributable because the
-        // gaps straddle those reads; a long window with any such excess is
-        // unmeasurable and must be retried rather than excused or scored.
+        // gaps straddle those reads. A long window is unmeasurable only when
+        // crediting both the observed stall and the whole-millisecond bracket
+        // loss brings the reading back to MAX_MS or less. The bracket conversion
+        // deliberately truncates because under-crediting unattributable time is
+        // the strict direction. A fault-injection control with a 4x-too-long wait
+        // and only 44us of bracket loss demonstrated why bracket loss alone must
+        // not force a retry.
         //
         // A lack of thread progress can only ever lengthen a wall-clock
         // measurement, so a short reading is always the kernel timer's fault
@@ -1420,8 +1425,15 @@ fn test_timer_delay() -> TestResult {
             let measurement = measure_window();
             let in_band = measurement.elapsed_ms >= MIN_MS && measurement.elapsed_ms <= MAX_MS;
             let stall_ms = measurement.stall_ticks.saturating_mul(1_000) / freq;
-            let unmeasurable =
-                measurement.elapsed_ms > MAX_MS && measurement.unattributed_bracket_ticks != 0;
+            let bracket_loss_ms =
+                measurement.unattributed_bracket_ticks.saturating_mul(1_000) / freq;
+            let unmeasurable = measurement.elapsed_ms > MAX_MS
+                && measurement.unattributed_bracket_ticks != 0
+                && measurement
+                    .elapsed_ms
+                    .saturating_sub(stall_ms)
+                    .saturating_sub(bracket_loss_ms)
+                    <= MAX_MS;
             let contaminated = measurement.elapsed_ms > MAX_MS
                 && !unmeasurable
                 && measurement.stall_ticks >= contamination_stall_ticks

--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -1243,9 +1243,9 @@ fn test_timer_ticks() -> TestResult {
 /// Attempts to delay for approximately 10ms and checks that the elapsed
 /// time is within the MIN_MS..=MAX_MS band. This accounts for timer resolution
 /// and scheduling variance. On ARM64 the measurement window is additionally
-/// screened for host-starvation contamination and re-measured when the window
-/// itself, not the kernel timer, was what went wrong (see the detector comment
-/// in the aarch64 branch). The scored bounds are never widened.
+/// screened for intervals where wall-clock time advanced while the test thread
+/// made no progress. Such windows are re-measured without widening the scored
+/// bounds (see the detector comment in the aarch64 branch).
 fn test_timer_delay() -> TestResult {
     // Target delay in milliseconds
     const TARGET_MS: u64 = 10;
@@ -1284,41 +1284,44 @@ fn test_timer_delay() -> TestResult {
         // ---- Measurement-contamination detector (test harness only) ---------
         //
         // The busy-wait below is measured with CNTVCT_EL0, which under QEMU TCG
-        // advances with host wall-clock time rather than with guest execution
-        // progress. The preempt guard below suppresses *guest* preemption of
-        // this thread, but nothing inside the guest can stop the host scheduler
-        // from descheduling the whole vCPU thread mid-window. When that
-        // happens, the next counter read jumps forward by the entire host
-        // stall, so elapsed_ms reports the host outage instead of the kernel's
-        // delay accuracy and lands past MAX_MS even when the timer is exact.
+        // advances with host wall-clock time rather than guest execution
+        // progress. The preempt guard suppresses guest thread preemption, but
+        // interrupts remain enabled. A large inter-sample gap therefore proves
+        // only that wall-clock time advanced while this thread made no progress;
+        // it may include time in this CPU's interrupt handlers as well as time
+        // when the host descheduled the vCPU.
         //
-        // The window is therefore self-instrumented. Every spin iteration, plus
-        // both measurement boundaries, records the counter delta since the
-        // previous counter read; the whole interval that elapsed_ms covers is
-        // sampled with no gaps. One spin_loop() plus one counter read cannot
-        // legitimately consume STALL_SAMPLE_MICROSECONDS of wall clock (a clean
-        // window executes tens of thousands of iterations per millisecond), so
-        // any larger delta is direct guest-observable evidence that wall-clock
-        // time outran guest progress, i.e. the vCPU lost its host CPU. The
-        // excess of every such delta accumulates into stall_ticks.
+        // This conservative accounting is acceptable because it only causes a
+        // bounded re-measurement. A defect that deterministically steals the
+        // window contaminates every attempt and still FAILs on exhaustion. Only
+        // busy-wait gaps strictly between the two scored timestamp reads accrue
+        // stall_ticks. Excess in the boundary gaps is unattributable because the
+        // gaps straddle those reads; a long window with any such excess is
+        // unmeasurable and must be retried rather than excused or scored.
         //
-        // A host stall can only ever *lengthen* a wall-clock measurement, so a
-        // short reading is always the kernel timer's fault and FAILs at once. A
-        // long reading is treated as contaminated only when at least
+        // A lack of thread progress can only ever lengthen a wall-clock
+        // measurement, so a short reading is always the kernel timer's fault
+        // and FAILs at once. A measurable long reading is contaminated only
+        // when at least
         // CONTAMINATION_STALL_MILLISECONDS of stall was observed AND removing
         // exactly that observed stall brings the reading back to MAX_MS or
-        // less - that is, the observed loss of CPU fully explains the overrun.
-        // Contaminated windows are re-measured (bounded by
-        // MAX_MEASUREMENT_ATTEMPTS) instead of being scored. A clean window, or
-        // one whose overrun the observed stalls do not explain (which is what a
-        // genuinely broken or inaccurate kernel timer produces), is scored
-        // against the unchanged MIN_MS/MAX_MS bounds and FAILs exactly as
-        // before. If no uncontaminated window is ever obtained the test FAILs
-        // with its own distinct message; it never passes by default and the
-        // asserted property is unchanged.
+        // less. Re-measurement is bounded by both attempt count and CNTVCT wall
+        // time. A clean window whose overrun the observed stalls do not fully
+        // explain FAILs against the unchanged bounds. The test never passes
+        // without observing an in-band scored window.
         const STALL_SAMPLE_MICROSECONDS: u64 = 10;
         const CONTAMINATION_STALL_MILLISECONDS: u64 = 1;
         const MAX_MEASUREMENT_ATTEMPTS: u32 = 16;
+        const MEASUREMENT_BUDGET_MS: u64 = 5_000;
+        const MIN_SCREENABLE_FREQUENCY_HZ: u64 = 100_000;
+
+        struct TimerDelayMeasurement {
+            elapsed_ms: u64,
+            stall_ticks: u64,
+            unattributed_bracket_ticks: u64,
+            max_gap_ticks: u64,
+            samples: u64,
+        }
 
         struct TimerDelayPreemptGuard;
 
@@ -1340,103 +1343,121 @@ fn test_timer_delay() -> TestResult {
         if freq == 0 {
             return TestResult::Fail("timer frequency is 0");
         }
+        if freq < MIN_SCREENABLE_FREQUENCY_HZ {
+            return TestResult::Fail("timer frequency below 100 kHz; cannot screen delay on ARM64");
+        }
 
         // Calculate ticks for TARGET_MS milliseconds
-        let ticks_for_target = (freq * TARGET_MS) / 1000;
-        // Per-sample wall-clock cost above which a single loop iteration can
-        // only be explained by the vCPU having lost its host CPU.
+        let ticks_for_target = timer::milliseconds_to_ticks(freq, TARGET_MS);
+        // On QEMU TCG aarch64 at CNTFRQ_EL0=24MHz, a clean window retires about
+        // 14k samples/ms (~70ns/sample), roughly 140x below this 10us threshold.
         let stall_sample_ticks =
             (freq.saturating_mul(STALL_SAMPLE_MICROSECONDS) / 1_000_000).max(1);
         let contamination_stall_ticks =
             timer::milliseconds_to_ticks(freq, CONTAMINATION_STALL_MILLISECONDS);
+        let measurement_budget_ticks = timer::milliseconds_to_ticks(freq, MEASUREMENT_BUDGET_MS);
         let stall_excess = |gap: u64| gap.saturating_sub(stall_sample_ticks);
         let ticks_to_microseconds = |ticks: u64| ticks.saturating_mul(1_000_000) / freq;
 
+        let measure_window = || {
+            let _preempt_guard = TimerDelayPreemptGuard::enter();
+
+            let pre_start_counter = timer::rdtsc();
+            let start_ns = timer::nanoseconds_since_base().unwrap_or(0);
+            let start_counter = timer::rdtsc();
+            let target_counter = start_counter.saturating_add(ticks_for_target);
+
+            let opening_gap = timer::elapsed_ticks(start_counter, pre_start_counter);
+            let mut unattributed_bracket_ticks = stall_excess(opening_gap);
+            let mut max_gap_ticks = opening_gap;
+            let mut stall_ticks = 0u64;
+            let mut previous_sample = start_counter;
+            let mut samples = 1u64;
+
+            loop {
+                let sample = timer::rdtsc();
+                let gap = timer::elapsed_ticks(sample, previous_sample);
+                max_gap_ticks = max_gap_ticks.max(gap);
+                stall_ticks = stall_ticks.saturating_add(stall_excess(gap));
+                samples = samples.saturating_add(1);
+                previous_sample = sample;
+                if sample >= target_counter {
+                    break;
+                }
+                core::hint::spin_loop();
+            }
+
+            let end_ns = timer::nanoseconds_since_base().unwrap_or(0);
+            let post_end_counter = timer::rdtsc();
+            let closing_gap = timer::elapsed_ticks(post_end_counter, previous_sample);
+            max_gap_ticks = max_gap_ticks.max(closing_gap);
+            unattributed_bracket_ticks =
+                unattributed_bracket_ticks.saturating_add(stall_excess(closing_gap));
+            samples = samples.saturating_add(1);
+
+            TimerDelayMeasurement {
+                elapsed_ms: end_ns.saturating_sub(start_ns) / 1_000_000,
+                stall_ticks,
+                unattributed_bracket_ticks,
+                max_gap_ticks,
+                samples,
+            }
+        };
+
+        let measurement_budget_start = timer::rdtsc();
         let mut attempt: u32 = 0;
         loop {
-            attempt += 1;
-
-            let (elapsed_ms, stall_ticks, max_gap_ticks, samples) = {
-                let _preempt_guard = TimerDelayPreemptGuard::enter();
-
-                // Bracket the opening timestamp so a host stall between these
-                // two reads is attributed as stall, not as delay error.
-                let pre_start_counter = timer::rdtsc();
-                let start_ns = timer::nanoseconds_since_base().unwrap_or(0);
-                let start_counter = timer::rdtsc();
-                let target_counter = start_counter + ticks_for_target;
-
-                let mut max_gap_ticks = timer::elapsed_ticks(start_counter, pre_start_counter);
-                let mut stall_ticks = stall_excess(max_gap_ticks);
-                let mut previous_sample = start_counter;
-                let mut samples: u64 = 1;
-
-                // Busy-wait until we reach target, sampling host-stall evidence
-                loop {
-                    let sample = timer::rdtsc();
-                    let gap = timer::elapsed_ticks(sample, previous_sample);
-                    if gap > max_gap_ticks {
-                        max_gap_ticks = gap;
-                    }
-                    stall_ticks = stall_ticks.saturating_add(stall_excess(gap));
-                    samples = samples.saturating_add(1);
-                    previous_sample = sample;
-                    if sample >= target_counter {
-                        break;
-                    }
-                    core::hint::spin_loop();
-                }
-
-                let end_ns = timer::nanoseconds_since_base().unwrap_or(0);
-                let post_end_counter = timer::rdtsc();
-                let tail_gap = timer::elapsed_ticks(post_end_counter, previous_sample);
-                if tail_gap > max_gap_ticks {
-                    max_gap_ticks = tail_gap;
-                }
-                stall_ticks = stall_ticks.saturating_add(stall_excess(tail_gap));
-                samples = samples.saturating_add(1);
-
-                (
-                    (end_ns.saturating_sub(start_ns)) / 1_000_000,
-                    stall_ticks,
-                    max_gap_ticks,
-                    samples,
-                )
-            };
-
-            if elapsed_ms >= MIN_MS && elapsed_ms <= MAX_MS {
-                return TestResult::Pass;
-            }
-
-            // Out of band: decide whether the measurement window was
-            // contaminated by host starvation or the kernel timer is wrong.
-            let stall_ms = stall_ticks.saturating_mul(1_000) / freq;
-            let contaminated = elapsed_ms > MAX_MS
-                && stall_ticks >= contamination_stall_ticks
-                && elapsed_ms.saturating_sub(stall_ms) <= MAX_MS;
-
-            crate::serial_println!(
-                "[timer_delay] attempt={} contaminated={} elapsed_ms={} stall_ms={} max_gap_us={} samples={}",
-                attempt,
-                contaminated as u8,
-                elapsed_ms,
-                stall_ms,
-                ticks_to_microseconds(max_gap_ticks),
-                samples,
-            );
-
-            if !contaminated {
-                return if elapsed_ms < MIN_MS {
-                    TestResult::Fail("delay too short on ARM64")
-                } else {
-                    TestResult::Fail("delay too long on ARM64")
-                };
-            }
-
-            if attempt >= MAX_MEASUREMENT_ATTEMPTS {
+            if attempt >= MAX_MEASUREMENT_ATTEMPTS
+                || timer::elapsed_ticks(timer::rdtsc(), measurement_budget_start)
+                    >= measurement_budget_ticks
+            {
                 return TestResult::Fail(
                     "timer delay never observed an uncontaminated window on ARM64",
                 );
+            }
+            attempt += 1;
+
+            let measurement = measure_window();
+            let in_band = measurement.elapsed_ms >= MIN_MS && measurement.elapsed_ms <= MAX_MS;
+            let stall_ms = measurement.stall_ticks.saturating_mul(1_000) / freq;
+            let unmeasurable =
+                measurement.elapsed_ms > MAX_MS && measurement.unattributed_bracket_ticks != 0;
+            let contaminated = measurement.elapsed_ms > MAX_MS
+                && !unmeasurable
+                && measurement.stall_ticks >= contamination_stall_ticks
+                && measurement.elapsed_ms.saturating_sub(stall_ms) <= MAX_MS;
+            let verdict = if in_band {
+                "in-band"
+            } else if unmeasurable {
+                "unmeasurable"
+            } else if contaminated {
+                "contaminated"
+            } else {
+                "out-of-band"
+            };
+
+            if !in_band || attempt != 1 {
+                // Serial is required because boot-test capture does not include log::* output.
+                crate::serial_println!(
+                    "[timer_delay] attempt={} verdict={} elapsed_ms={} stall_ms={} bracket_loss_us={} max_gap_us={} samples={}",
+                    attempt,
+                    verdict,
+                    measurement.elapsed_ms,
+                    stall_ms,
+                    ticks_to_microseconds(measurement.unattributed_bracket_ticks),
+                    ticks_to_microseconds(measurement.max_gap_ticks),
+                    measurement.samples,
+                );
+            }
+
+            if in_band {
+                return TestResult::Pass;
+            }
+            if measurement.elapsed_ms < MIN_MS {
+                return TestResult::Fail("delay too short on ARM64");
+            }
+            if !unmeasurable && !contaminated {
+                return TestResult::Fail("delay too long on ARM64");
             }
         }
     }

--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -1285,7 +1285,9 @@ fn test_timer_delay() -> TestResult {
 
     #[cfg(target_arch = "aarch64")]
     {
+        use crate::arch_impl::aarch64::exception::SYNC_EXCEPTION_COUNT;
         use crate::arch_impl::aarch64::timer;
+        use crate::tracing::providers::counters::IRQ_TOTAL;
 
         // ---- Host-starvation attribution (test harness only) ----------------
         //
@@ -1297,32 +1299,31 @@ fn test_timer_delay() -> TestResult {
         // tell those apart, so the window is built to make them distinguishable
         // instead of guessing between them.
         //
-        // The busy-wait runs in slices with IRQ+FIQ masked. Inside a slice the
-        // only code this CPU can execute is the loop below, and each slice
-        // checks that premise rather than assuming it: it compares the per-CPU
-        // interrupt counter (IRQ_TOTAL, incremented at the top of handle_irq,
-        // which both the IRQ and the FIQ vector enter) and the per-CPU
-        // synchronous-exception counter across the slice. A gap inside a slice
-        // whose premise held is therefore proof that the vCPU itself was not
-        // running: no in-guest defect can manufacture one. Only that time is
-        // credited as host starvation, and only credited time can send a window
-        // back to be measured again.
+        // The three measurement paths catch different defect classes. A 100us
+        // IRQ+FIQ-masked slice catches a contiguous host deschedule: a >5us gap
+        // between two CNTVCT samples strictly inside the scored timestamps is
+        // credited only when the per-CPU IRQ and synchronous-exception counters
+        // prove that no other guest code ran. An open drain window catches
+        // deferred or immediately reasserting IRQ/FIQ work: both counters must
+        // remain quiet for 5us (with 1ms polling cap) before the mask closes, and
+        // all drain time is inside elapsed_ms and receives no starvation credit.
+        // The final partial slice is checked while still masked, then one final
+        // drain runs before the closing timestamp so pending work cannot escape
+        // the reading. A failed or unindexable premise forfeits its whole slice.
         //
-        // Guest interrupt work stays inside the measurement on purpose: between
-        // slices the mask is opened so pending interrupts are taken, and what
-        // that costs lands in elapsed_ms with no credit. A handler that runs
-        // long, an interrupt storm, or any other in-guest theft of this CPU
-        // therefore still FAILs with "delay too long on ARM64" on the very
-        // first window, exactly as it did before this screen existed, and just
-        // as reliably when the defect is intermittent, because such a window is
-        // never retried. A slice whose premise failed is credited to nobody,
-        // which is the strict direction. Slices are short enough (250us) that
-        // no timer tick is lost, only deferred.
+        // The timestamp boundary brackets catch no starvation class. They
+        // straddle the scored interval, so they are deliberately credited to
+        // nobody; this prevents time outside the reading from excusing a real
+        // in-guest overrun. Likewise, a host outage landing wholly inside a
+        // drain window is blamed on the guest and FAILs. This strict-direction
+        // residue is intentionally preserved and disclosed.
         //
-        // Known residue, stated rather than hidden: a host outage landing
-        // wholly inside one of the brief open-mask windows is attributed to the
-        // guest and FAILs. That is the verdict main gives today for every
-        // outage, and the open windows are a small fraction of the measurement.
+        // The wait terminates when CNTVCT reaches its target. Consequently this
+        // screen detects contiguous stolen time that opens a large sample gap;
+        // it does not detect a steady fractional CPU tax that never opens one.
+        // Such a tax has never lengthened this wall-clock reading, with or
+        // without masking. A contiguous in-guest handler which carries the
+        // reading beyond MAX_MS remains uncredited and FAILs on that attempt.
         //
         // Lost thread progress can only lengthen a wall-clock reading, so a
         // short reading is always the kernel timer's fault and FAILs at once
@@ -1331,7 +1332,9 @@ fn test_timer_delay() -> TestResult {
         // budget plus at most one window), and exhausting it is a distinct
         // FAIL. The test never passes without an in-band scored window.
         const STALL_SAMPLE_MICROSECONDS: u64 = 5;
-        const SLICE_MICROSECONDS: u64 = 250;
+        const SLICE_MICROSECONDS: u64 = 100;
+        const DRAIN_QUIET_MICROSECONDS: u64 = 5;
+        const DRAIN_CAP_MICROSECONDS: u64 = 1_000;
         const CONTAMINATION_STALL_MILLISECONDS: u64 = 1;
         const MAX_MEASUREMENT_ATTEMPTS: u32 = 4;
         const MEASUREMENT_BUDGET_MS: u64 = 400;
@@ -1346,6 +1349,18 @@ fn test_timer_delay() -> TestResult {
             forfeited_slices: u64,
             slices: u64,
             samples: u64,
+        }
+
+        #[derive(Clone, Copy)]
+        struct TimerDelayCounterSnapshot {
+            irq: u64,
+            sync: u64,
+        }
+
+        struct TimerDelayDrain {
+            counters: Option<TimerDelayCounterSnapshot>,
+            end_counter: u64,
+            elapsed_ticks: u64,
         }
 
         struct TimerDelayPreemptGuard;
@@ -1390,16 +1405,81 @@ fn test_timer_delay() -> TestResult {
             }
         }
 
-        /// Give pending interrupts an architectural window in which to be taken.
-        fn open_interrupt_window() {
-            unsafe {
-                core::arch::asm!(
-                    "msr daifclr, #3",
-                    "isb",
-                    "msr daifset, #3",
-                    "isb",
-                    options(nomem, nostack)
-                );
+        fn sample_counter(samples: &mut u64) -> u64 {
+            *samples = samples.saturating_add(1);
+            timer::rdtsc()
+        }
+
+        fn counter_snapshot(cpu: usize) -> Option<TimerDelayCounterSnapshot> {
+            let Some(irq) = IRQ_TOTAL.per_cpu.get(cpu) else {
+                return None;
+            };
+            let Some(sync) = SYNC_EXCEPTION_COUNT.get(cpu) else {
+                return None;
+            };
+            Some(TimerDelayCounterSnapshot {
+                irq: irq.value.load(core::sync::atomic::Ordering::Relaxed),
+                sync: sync.load(core::sync::atomic::Ordering::Relaxed),
+            })
+        }
+
+        fn counters_unchanged(
+            start: Option<TimerDelayCounterSnapshot>,
+            end: Option<TimerDelayCounterSnapshot>,
+        ) -> bool {
+            match (start, end) {
+                (Some(start), Some(end)) => start.irq == end.irq && start.sync == end.sync,
+                _ => false,
+            }
+        }
+
+        /// Open IRQ+FIQ delivery until both premise counters remain quiet.
+        fn drain_interrupts(
+            cpu: usize,
+            may_open_windows: bool,
+            quiet_ticks: u64,
+            cap_ticks: u64,
+            samples: &mut u64,
+        ) -> TimerDelayDrain {
+            let drain_start = sample_counter(samples);
+            let mut counters = counter_snapshot(cpu);
+
+            if may_open_windows {
+                unsafe {
+                    core::arch::asm!("msr daifclr, #3", "isb", options(nomem, nostack));
+                }
+
+                counters = counter_snapshot(cpu);
+                let mut quiet_start = sample_counter(samples);
+                loop {
+                    let current_counters = counter_snapshot(cpu);
+                    let now = sample_counter(samples);
+                    if counters_unchanged(counters, current_counters) {
+                        if timer::elapsed_ticks(now, quiet_start) >= quiet_ticks {
+                            break;
+                        }
+                    } else {
+                        counters = current_counters;
+                        quiet_start = now;
+                    }
+
+                    if timer::elapsed_ticks(now, drain_start) >= cap_ticks {
+                        break;
+                    }
+                    core::hint::spin_loop();
+                }
+
+                unsafe {
+                    core::arch::asm!("msr daifset, #3", "isb", options(nomem, nostack));
+                }
+                counters = counter_snapshot(cpu);
+            }
+
+            let drain_end = sample_counter(samples);
+            TimerDelayDrain {
+                counters,
+                end_counter: drain_end,
+                elapsed_ticks: timer::elapsed_ticks(drain_end, drain_start),
             }
         }
 
@@ -1421,6 +1501,8 @@ fn test_timer_delay() -> TestResult {
         // roughly 70x below this threshold.
         let stall_sample_ticks = microseconds_to_ticks(STALL_SAMPLE_MICROSECONDS);
         let slice_ticks = microseconds_to_ticks(SLICE_MICROSECONDS);
+        let drain_quiet_ticks = microseconds_to_ticks(DRAIN_QUIET_MICROSECONDS);
+        let drain_cap_ticks = microseconds_to_ticks(DRAIN_CAP_MICROSECONDS);
         let contamination_stall_ticks =
             timer::milliseconds_to_ticks(freq, CONTAMINATION_STALL_MILLISECONDS);
         let measurement_budget_ticks = timer::milliseconds_to_ticks(freq, MEASUREMENT_BUDGET_MS);
@@ -1428,48 +1510,32 @@ fn test_timer_delay() -> TestResult {
         let ticks_to_microseconds = |ticks: u64| ticks.saturating_mul(1_000_000) / freq;
         let ticks_to_milliseconds = |ticks: u64| ticks.saturating_mul(1_000) / freq;
 
-        let cpu = crate::arch_impl::current::percpu::Aarch64PerCpu::cpu_id() as usize;
-        let irq_count = || crate::tracing::providers::counters::IRQ_TOTAL.get_cpu(cpu);
-        let sync_count = || {
-            crate::arch_impl::aarch64::exception::SYNC_EXCEPTION_COUNT
-                .get(cpu)
-                .map(|counter| counter.load(core::sync::atomic::Ordering::Relaxed))
-                .unwrap_or(0)
-        };
-
         let measure_window = || {
             let _preempt_guard = TimerDelayPreemptGuard::enter();
+            let cpu = crate::arch_impl::current::percpu::Aarch64PerCpu::cpu_id() as usize;
             let mask_guard = TimerDelayMaskGuard::enter();
             let may_open_windows = mask_guard.interrupts_were_enabled();
-
-            let window_irq_start = irq_count();
-            let mut slice_irq = window_irq_start;
-            let mut slice_sync = sync_count();
-            let mut slice_stall_ticks = 0u64;
 
             let mut host_stall_ticks = 0u64;
             let mut max_gap_ticks = 0u64;
             let mut open_window_ticks = 0u64;
             let mut forfeited_slices = 0u64;
-            let mut slices = 1u64;
+            let mut slices = 0u64;
+            let mut samples = 0u64;
 
-            let pre_start_counter = timer::rdtsc();
             let start_ns = timer::nanoseconds_since_base().unwrap_or(0);
-            let start_counter = timer::rdtsc();
-            let mut samples = 2u64;
+            let start_counter = sample_counter(&mut samples);
+            let window_counters_start = counter_snapshot(cpu);
+            let mut slice_counters = window_counters_start;
+            let mut slice_stall_ticks = 0u64;
             let mut previous_sample = start_counter;
             let mut slice_start = start_counter;
 
-            let opening_gap = timer::elapsed_ticks(start_counter, pre_start_counter);
-            slice_stall_ticks = slice_stall_ticks.saturating_add(stall_excess(opening_gap));
-            max_gap_ticks = max_gap_ticks.max(opening_gap);
-
             loop {
-                let sample = timer::rdtsc();
+                let sample = sample_counter(&mut samples);
                 let gap = timer::elapsed_ticks(sample, previous_sample);
                 slice_stall_ticks = slice_stall_ticks.saturating_add(stall_excess(gap));
                 max_gap_ticks = max_gap_ticks.max(gap);
-                samples = samples.saturating_add(1);
                 previous_sample = sample;
 
                 if timer::elapsed_ticks(sample, start_counter) >= ticks_for_target {
@@ -1479,52 +1545,63 @@ fn test_timer_delay() -> TestResult {
                 if timer::elapsed_ticks(sample, slice_start) >= slice_ticks {
                     // Credit this slice only if nothing but this loop ran on
                     // this CPU for the whole of it.
-                    if irq_count() == slice_irq && sync_count() == slice_sync {
+                    let slice_end_counters = counter_snapshot(cpu);
+                    if counters_unchanged(slice_counters, slice_end_counters) {
                         host_stall_ticks = host_stall_ticks.saturating_add(slice_stall_ticks);
                     } else {
                         forfeited_slices = forfeited_slices.saturating_add(1);
                     }
+                    slices = slices.saturating_add(1);
                     slice_stall_ticks = 0;
 
-                    let open_start = timer::rdtsc();
-                    if may_open_windows {
-                        open_interrupt_window();
-                    }
-                    let open_end = timer::rdtsc();
-                    open_window_ticks = open_window_ticks
-                        .saturating_add(timer::elapsed_ticks(open_end, open_start));
-
-                    slice_irq = irq_count();
-                    slice_sync = sync_count();
-                    slices = slices.saturating_add(1);
-                    previous_sample = timer::rdtsc();
+                    let drain = drain_interrupts(
+                        cpu,
+                        may_open_windows,
+                        drain_quiet_ticks,
+                        drain_cap_ticks,
+                        &mut samples,
+                    );
+                    open_window_ticks = open_window_ticks.saturating_add(drain.elapsed_ticks);
+                    slice_counters = drain.counters;
+                    previous_sample = drain.end_counter;
                     slice_start = previous_sample;
-                    samples = samples.saturating_add(3);
                 }
 
                 core::hint::spin_loop();
             }
 
-            let end_ns = timer::nanoseconds_since_base().unwrap_or(0);
-            let post_end_counter = timer::rdtsc();
-            samples = samples.saturating_add(2);
-            let closing_gap = timer::elapsed_ticks(post_end_counter, previous_sample);
-            slice_stall_ticks = slice_stall_ticks.saturating_add(stall_excess(closing_gap));
-            max_gap_ticks = max_gap_ticks.max(closing_gap);
-
-            let window_irq_end = irq_count();
-            if window_irq_end == slice_irq && sync_count() == slice_sync {
+            // Decide the final partial slice before opening the mask. Interrupts
+            // serviced by the closing drain cannot revoke already-proven host
+            // stall, but their full cost remains inside the scored timestamp.
+            let final_slice_counters = counter_snapshot(cpu);
+            if counters_unchanged(slice_counters, final_slice_counters) {
                 host_stall_ticks = host_stall_ticks.saturating_add(slice_stall_ticks);
             } else {
                 forfeited_slices = forfeited_slices.saturating_add(1);
             }
+            slices = slices.saturating_add(1);
+
+            let final_drain = drain_interrupts(
+                cpu,
+                may_open_windows,
+                drain_quiet_ticks,
+                drain_cap_ticks,
+                &mut samples,
+            );
+            open_window_ticks = open_window_ticks.saturating_add(final_drain.elapsed_ticks);
+            let window_counters_end = final_drain.counters;
+            let end_ns = timer::nanoseconds_since_base().unwrap_or(0);
+            let irqs_taken = match (window_counters_start, window_counters_end) {
+                (Some(start), Some(end)) => end.irq.wrapping_sub(start.irq),
+                _ => 0,
+            };
 
             TimerDelayMeasurement {
                 elapsed_ms: end_ns.saturating_sub(start_ns) / 1_000_000,
                 host_stall_ticks,
                 max_gap_ticks,
                 open_window_ticks,
-                irqs_taken: window_irq_end.wrapping_sub(window_irq_start),
+                irqs_taken,
                 forfeited_slices,
                 slices,
                 samples,

--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -1241,12 +1241,15 @@ fn test_timer_ticks() -> TestResult {
 /// Test delay functionality - verify elapsed time is reasonable.
 ///
 /// Attempts to delay for approximately 10ms and checks that the elapsed
-/// time is within 50% tolerance (5-15ms). This accounts for timer resolution
-/// and scheduling variance.
+/// time is within the MIN_MS..=MAX_MS band. This accounts for timer resolution
+/// and scheduling variance. On ARM64 the measurement window is additionally
+/// screened for host-starvation contamination and re-measured when the window
+/// itself, not the kernel timer, was what went wrong (see the detector comment
+/// in the aarch64 branch). The scored bounds are never widened.
 fn test_timer_delay() -> TestResult {
     // Target delay in milliseconds
     const TARGET_MS: u64 = 10;
-    // Tolerance: 50% (allow 5-15ms for a 10ms delay)
+    // Tolerance band: MIN_MS = 5ms, MAX_MS = 20ms for a 10ms target
     const MIN_MS: u64 = TARGET_MS / 2;
     const MAX_MS: u64 = TARGET_MS * 2;
 
@@ -1278,6 +1281,45 @@ fn test_timer_delay() -> TestResult {
     {
         use crate::arch_impl::aarch64::timer;
 
+        // ---- Measurement-contamination detector (test harness only) ---------
+        //
+        // The busy-wait below is measured with CNTVCT_EL0, which under QEMU TCG
+        // advances with host wall-clock time rather than with guest execution
+        // progress. The preempt guard below suppresses *guest* preemption of
+        // this thread, but nothing inside the guest can stop the host scheduler
+        // from descheduling the whole vCPU thread mid-window. When that
+        // happens, the next counter read jumps forward by the entire host
+        // stall, so elapsed_ms reports the host outage instead of the kernel's
+        // delay accuracy and lands past MAX_MS even when the timer is exact.
+        //
+        // The window is therefore self-instrumented. Every spin iteration, plus
+        // both measurement boundaries, records the counter delta since the
+        // previous counter read; the whole interval that elapsed_ms covers is
+        // sampled with no gaps. One spin_loop() plus one counter read cannot
+        // legitimately consume STALL_SAMPLE_MICROSECONDS of wall clock (a clean
+        // window executes tens of thousands of iterations per millisecond), so
+        // any larger delta is direct guest-observable evidence that wall-clock
+        // time outran guest progress, i.e. the vCPU lost its host CPU. The
+        // excess of every such delta accumulates into stall_ticks.
+        //
+        // A host stall can only ever *lengthen* a wall-clock measurement, so a
+        // short reading is always the kernel timer's fault and FAILs at once. A
+        // long reading is treated as contaminated only when at least
+        // CONTAMINATION_STALL_MILLISECONDS of stall was observed AND removing
+        // exactly that observed stall brings the reading back to MAX_MS or
+        // less - that is, the observed loss of CPU fully explains the overrun.
+        // Contaminated windows are re-measured (bounded by
+        // MAX_MEASUREMENT_ATTEMPTS) instead of being scored. A clean window, or
+        // one whose overrun the observed stalls do not explain (which is what a
+        // genuinely broken or inaccurate kernel timer produces), is scored
+        // against the unchanged MIN_MS/MAX_MS bounds and FAILs exactly as
+        // before. If no uncontaminated window is ever obtained the test FAILs
+        // with its own distinct message; it never passes by default and the
+        // asserted property is unchanged.
+        const STALL_SAMPLE_MICROSECONDS: u64 = 10;
+        const CONTAMINATION_STALL_MILLISECONDS: u64 = 1;
+        const MAX_MEASUREMENT_ATTEMPTS: u32 = 16;
+
         struct TimerDelayPreemptGuard;
 
         impl TimerDelayPreemptGuard {
@@ -1293,36 +1335,109 @@ fn test_timer_delay() -> TestResult {
             }
         }
 
-        let _preempt_guard = TimerDelayPreemptGuard::enter();
-
         // Get frequency for nanosecond calculations
         let freq = timer::frequency_hz();
         if freq == 0 {
             return TestResult::Fail("timer frequency is 0");
         }
 
-        let start_ns = timer::nanoseconds_since_base().unwrap_or(0);
-
         // Calculate ticks for TARGET_MS milliseconds
         let ticks_for_target = (freq * TARGET_MS) / 1000;
+        // Per-sample wall-clock cost above which a single loop iteration can
+        // only be explained by the vCPU having lost its host CPU.
+        let stall_sample_ticks =
+            (freq.saturating_mul(STALL_SAMPLE_MICROSECONDS) / 1_000_000).max(1);
+        let contamination_stall_ticks =
+            timer::milliseconds_to_ticks(freq, CONTAMINATION_STALL_MILLISECONDS);
+        let stall_excess = |gap: u64| gap.saturating_sub(stall_sample_ticks);
+        let ticks_to_microseconds = |ticks: u64| ticks.saturating_mul(1_000_000) / freq;
 
-        let start_counter = timer::rdtsc();
-        let target_counter = start_counter + ticks_for_target;
+        let mut attempt: u32 = 0;
+        loop {
+            attempt += 1;
 
-        // Busy-wait until we reach target
-        while timer::rdtsc() < target_counter {
-            core::hint::spin_loop();
-        }
+            let (elapsed_ms, stall_ticks, max_gap_ticks, samples) = {
+                let _preempt_guard = TimerDelayPreemptGuard::enter();
 
-        let end_ns = timer::nanoseconds_since_base().unwrap_or(0);
-        let elapsed_ms = (end_ns.saturating_sub(start_ns)) / 1_000_000;
+                // Bracket the opening timestamp so a host stall between these
+                // two reads is attributed as stall, not as delay error.
+                let pre_start_counter = timer::rdtsc();
+                let start_ns = timer::nanoseconds_since_base().unwrap_or(0);
+                let start_counter = timer::rdtsc();
+                let target_counter = start_counter + ticks_for_target;
 
-        if elapsed_ms >= MIN_MS && elapsed_ms <= MAX_MS {
-            TestResult::Pass
-        } else if elapsed_ms < MIN_MS {
-            TestResult::Fail("delay too short on ARM64")
-        } else {
-            TestResult::Fail("delay too long on ARM64")
+                let mut max_gap_ticks = timer::elapsed_ticks(start_counter, pre_start_counter);
+                let mut stall_ticks = stall_excess(max_gap_ticks);
+                let mut previous_sample = start_counter;
+                let mut samples: u64 = 1;
+
+                // Busy-wait until we reach target, sampling host-stall evidence
+                loop {
+                    let sample = timer::rdtsc();
+                    let gap = timer::elapsed_ticks(sample, previous_sample);
+                    if gap > max_gap_ticks {
+                        max_gap_ticks = gap;
+                    }
+                    stall_ticks = stall_ticks.saturating_add(stall_excess(gap));
+                    samples = samples.saturating_add(1);
+                    previous_sample = sample;
+                    if sample >= target_counter {
+                        break;
+                    }
+                    core::hint::spin_loop();
+                }
+
+                let end_ns = timer::nanoseconds_since_base().unwrap_or(0);
+                let post_end_counter = timer::rdtsc();
+                let tail_gap = timer::elapsed_ticks(post_end_counter, previous_sample);
+                if tail_gap > max_gap_ticks {
+                    max_gap_ticks = tail_gap;
+                }
+                stall_ticks = stall_ticks.saturating_add(stall_excess(tail_gap));
+                samples = samples.saturating_add(1);
+
+                (
+                    (end_ns.saturating_sub(start_ns)) / 1_000_000,
+                    stall_ticks,
+                    max_gap_ticks,
+                    samples,
+                )
+            };
+
+            if elapsed_ms >= MIN_MS && elapsed_ms <= MAX_MS {
+                return TestResult::Pass;
+            }
+
+            // Out of band: decide whether the measurement window was
+            // contaminated by host starvation or the kernel timer is wrong.
+            let stall_ms = stall_ticks.saturating_mul(1_000) / freq;
+            let contaminated = elapsed_ms > MAX_MS
+                && stall_ticks >= contamination_stall_ticks
+                && elapsed_ms.saturating_sub(stall_ms) <= MAX_MS;
+
+            crate::serial_println!(
+                "[timer_delay] attempt={} contaminated={} elapsed_ms={} stall_ms={} max_gap_us={} samples={}",
+                attempt,
+                contaminated as u8,
+                elapsed_ms,
+                stall_ms,
+                ticks_to_microseconds(max_gap_ticks),
+                samples,
+            );
+
+            if !contaminated {
+                return if elapsed_ms < MIN_MS {
+                    TestResult::Fail("delay too short on ARM64")
+                } else {
+                    TestResult::Fail("delay too long on ARM64")
+                };
+            }
+
+            if attempt >= MAX_MEASUREMENT_ATTEMPTS {
+                return TestResult::Fail(
+                    "timer delay never observed an uncontaminated window on ARM64",
+                );
+            }
         }
     }
 }

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -1337,3 +1337,48 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         with_replaced_source(&sources, "kernel/src/task/scheduler.rs", broken_scheduler);
     assert!(validate_exit_sgi_is_teardown_only(&broken_sgi).is_err());
 }
+
+/// The ARM64 `timer_delay` re-measurement may only be granted on evidence that
+/// the vCPU itself stopped executing. This pins the leniency-granting predicates
+/// so a future edit cannot quietly turn the screen into a retry-until-green loop.
+#[test]
+fn timer_delay_retry_is_gated_on_proven_host_starvation() {
+    let registry = repo_text("kernel/src/test_framework/registry.rs");
+    let body = function_body(&registry, "test_timer_delay");
+
+    // Scored bounds and both original failure verdicts are untouched.
+    assert!(body.contains("const MIN_MS: u64 = TARGET_MS / 2;"));
+    assert!(body.contains("const MAX_MS: u64 = TARGET_MS * 2;"));
+    assert!(body.contains("TestResult::Fail(\"delay too short on ARM64\")"));
+    assert!(body.contains("TestResult::Fail(\"delay too long on ARM64\")"));
+    assert!(body.contains("if in_band {\n                return TestResult::Pass;"));
+
+    // The window is measured in IRQ+FIQ-masked slices, and interrupts are still
+    // taken between slices so in-guest interrupt cost stays inside the reading.
+    assert!(body.contains("msr daifset, #3"));
+    assert!(body.contains("msr daifclr, #3"));
+    assert!(body.contains("if may_open_windows {"));
+
+    // Stall time is credited only for a slice whose interrupt and synchronous
+    // exception counters prove no other guest code ran on this CPU.
+    assert!(body.contains("if irq_count() == slice_irq && sync_count() == slice_sync {"));
+    assert!(body.contains("host_stall_ticks = host_stall_ticks.saturating_add(slice_stall_ticks);"));
+    assert!(body.contains("forfeited_slices = forfeited_slices.saturating_add(1);"));
+
+    // Only credited stall, large enough to explain the overrun, sends a window
+    // back for re-measurement; everything else is a verdict on this attempt.
+    assert!(body.contains("let host_starved = screened"));
+    assert!(body.contains("&& measurement.host_stall_ticks >= contamination_stall_ticks"));
+    assert!(body.contains("&& measurement.elapsed_ms.saturating_sub(host_stall_ms) <= MAX_MS;"));
+    assert!(body.contains(
+        "if !host_starved {\n                return TestResult::Fail(\"delay too long on ARM64\");"
+    ));
+
+    // Re-measurement stays bounded by attempts and by wall clock, and running
+    // out of both is a distinct failure rather than a pass.
+    assert!(body.contains("const MAX_MEASUREMENT_ATTEMPTS: u32 = 4;"));
+    assert!(body.contains("const MEASUREMENT_BUDGET_MS: u64 = 400;"));
+    assert!(body.contains(
+        "return TestResult::Fail(\"timer delay never observed an unstarved window on ARM64\");"
+    ));
+}

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -1341,44 +1341,140 @@ fn deliberately_broken_variants_fail_the_ratchet() {
 /// The ARM64 `timer_delay` re-measurement may only be granted on evidence that
 /// the vCPU itself stopped executing. This pins the leniency-granting predicates
 /// so a future edit cannot quietly turn the screen into a retry-until-green loop.
+fn check_timer_delay_starvation_ratchet(body: &str) -> Result<(), String> {
+    let body = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    let require = |needle: &str| {
+        body.contains(needle)
+            .then_some(())
+            .ok_or_else(|| format!("missing timer_delay safety anchor: {needle}"))
+    };
+
+    // Pin the target and leniency threshold as well as the bound expressions.
+    require("const TARGET_MS: u64 = 10;")?;
+    require("const MIN_MS: u64 = TARGET_MS / 2;")?;
+    require("const MAX_MS: u64 = TARGET_MS * 2;")?;
+    require("const CONTAMINATION_STALL_MILLISECONDS: u64 = 1;")?;
+    require("TestResult::Fail(\"delay too short on ARM64\")")?;
+    require("TestResult::Fail(\"delay too long on ARM64\")")?;
+    require("if in_band { return TestResult::Pass;")?;
+
+    // The window uses short IRQ+FIQ-masked slices. Each open window remains
+    // open until both premise counters are quiet, subject to a hard cap.
+    require("const SLICE_MICROSECONDS: u64 = 100;")?;
+    require("const DRAIN_QUIET_MICROSECONDS: u64 = 5;")?;
+    require("const DRAIN_CAP_MICROSECONDS: u64 = 1_000;")?;
+    require("msr daifset, #3")?;
+    require("msr daifclr, #3")?;
+    require("if may_open_windows {")?;
+    require("timer::elapsed_ticks(now, quiet_start) >= quiet_ticks")?;
+    require("timer::elapsed_ticks(now, drain_start) >= cap_ticks")?;
+    require("open_window_ticks = open_window_ticks.saturating_add(drain.elapsed_ticks);")?;
+
+    // Counter lookup is per attempt, after preemption is disabled, and an
+    // unindexable IRQ or synchronous-exception counter fails closed.
+    let preempt = body
+        .find("let _preempt_guard = TimerDelayPreemptGuard::enter();")
+        .ok_or_else(|| "missing preemption guard".to_owned())?;
+    let cpu = body[preempt..]
+        .find("Aarch64PerCpu::cpu_id() as usize;")
+        .map(|offset| preempt + offset)
+        .ok_or_else(|| "CPU id is not sampled after preemption is disabled".to_owned())?;
+    if cpu <= preempt {
+        return Err("CPU id must be sampled inside the guarded window".to_owned());
+    }
+    require("let Some(irq) = IRQ_TOTAL.per_cpu.get(cpu) else { return None;")?;
+    require("let Some(sync) = SYNC_EXCEPTION_COUNT.get(cpu) else { return None;")?;
+    require("_ => false,")?;
+
+    // Only gaps between samples inside the timestamp reads can be credited.
+    // The boundary-bracket bookkeeping that caused the review hard-stop must
+    // not return under another accidental edit.
+    for forbidden in [
+        "pre_start_counter",
+        "post_end_counter",
+        "opening_gap",
+        "closing_gap",
+    ] {
+        if body.contains(forbidden) {
+            return Err(format!(
+                "timestamp boundary bracket must remain uncredited: {forbidden}"
+            ));
+        }
+    }
+    if body
+        .matches("host_stall_ticks = host_stall_ticks.saturating_add(slice_stall_ticks);")
+        .count()
+        != 2
+    {
+        return Err(
+            "host stall credit must come from exactly the completed and final masked slices"
+                .to_owned(),
+        );
+    }
+    require("fn sample_counter(samples: &mut u64) -> u64")?;
+    require("*samples = samples.saturating_add(1);")?;
+    if body.contains("samples = samples.saturating_add(2)")
+        || body.contains("samples = samples.saturating_add(3)")
+    {
+        return Err("sample diagnostics must count each CNTVCT sample at its call site".to_owned());
+    }
+
+    // The final partial slice is decided while masked, then pending work is
+    // drained before the closing scored timestamp.
+    let final_premise = body
+        .find("let final_slice_counters = counter_snapshot(cpu);")
+        .ok_or_else(|| "missing final masked-slice premise check".to_owned())?;
+    let final_drain = body[final_premise..]
+        .find("let final_drain = drain_interrupts(")
+        .map(|offset| final_premise + offset)
+        .ok_or_else(|| "missing final interrupt drain".to_owned())?;
+    let closing_timestamp = body[final_drain..]
+        .find("let end_ns = timer::nanoseconds_since_base().unwrap_or(0);")
+        .map(|offset| final_drain + offset)
+        .ok_or_else(|| "final drain must precede the closing timestamp".to_owned())?;
+    if !(final_premise < final_drain && final_drain < closing_timestamp) {
+        return Err("final premise, drain, and closing timestamp are out of order".to_owned());
+    }
+
+    // Only credited stall, large enough to explain the overrun, sends a window
+    // back for re-measurement; everything else is a verdict on this attempt.
+    require("let host_starved = screened")?;
+    require("&& measurement.host_stall_ticks >= contamination_stall_ticks")?;
+    require("&& measurement.elapsed_ms.saturating_sub(host_stall_ms) <= MAX_MS;")?;
+    require("if !host_starved { return TestResult::Fail(\"delay too long on ARM64\");")?;
+
+    // Re-measurement stays bounded by attempts and by wall clock, and running
+    // out of either is a distinct failure rather than a pass.
+    require("const MAX_MEASUREMENT_ATTEMPTS: u32 = 4;")?;
+    require("const MEASUREMENT_BUDGET_MS: u64 = 400;")?;
+    require("TestResult::Fail(\"timer delay never observed an unstarved window on ARM64\")")?;
+
+    Ok(())
+}
+
 #[test]
 fn timer_delay_retry_is_gated_on_proven_host_starvation() {
     let registry = repo_text("kernel/src/test_framework/registry.rs");
     let body = function_body(&registry, "test_timer_delay");
+    check_timer_delay_starvation_ratchet(body).expect("timer_delay starvation safety ratchet");
+}
 
-    // Scored bounds and both original failure verdicts are untouched.
-    assert!(body.contains("const MIN_MS: u64 = TARGET_MS / 2;"));
-    assert!(body.contains("const MAX_MS: u64 = TARGET_MS * 2;"));
-    assert!(body.contains("TestResult::Fail(\"delay too short on ARM64\")"));
-    assert!(body.contains("TestResult::Fail(\"delay too long on ARM64\")"));
-    assert!(body.contains("if in_band {\n                return TestResult::Pass;"));
+#[test]
+fn deliberately_broken_timer_delay_variants_fail_the_ratchet() {
+    let registry = repo_text("kernel/src/test_framework/registry.rs");
+    let body = function_body(&registry, "test_timer_delay");
 
-    // The window is measured in IRQ+FIQ-masked slices, and interrupts are still
-    // taken between slices so in-guest interrupt cost stays inside the reading.
-    assert!(body.contains("msr daifset, #3"));
-    assert!(body.contains("msr daifclr, #3"));
-    assert!(body.contains("if may_open_windows {"));
+    let widened_target = body.replacen(
+        "const TARGET_MS: u64 = 10;",
+        "const TARGET_MS: u64 = 40;",
+        1,
+    );
+    assert!(check_timer_delay_starvation_ratchet(&widened_target).is_err());
 
-    // Stall time is credited only for a slice whose interrupt and synchronous
-    // exception counters prove no other guest code ran on this CPU.
-    assert!(body.contains("if irq_count() == slice_irq && sync_count() == slice_sync {"));
-    assert!(body.contains("host_stall_ticks = host_stall_ticks.saturating_add(slice_stall_ticks);"));
-    assert!(body.contains("forfeited_slices = forfeited_slices.saturating_add(1);"));
-
-    // Only credited stall, large enough to explain the overrun, sends a window
-    // back for re-measurement; everything else is a verdict on this attempt.
-    assert!(body.contains("let host_starved = screened"));
-    assert!(body.contains("&& measurement.host_stall_ticks >= contamination_stall_ticks"));
-    assert!(body.contains("&& measurement.elapsed_ms.saturating_sub(host_stall_ms) <= MAX_MS;"));
-    assert!(body.contains(
-        "if !host_starved {\n                return TestResult::Fail(\"delay too long on ARM64\");"
-    ));
-
-    // Re-measurement stays bounded by attempts and by wall clock, and running
-    // out of both is a distinct failure rather than a pass.
-    assert!(body.contains("const MAX_MEASUREMENT_ATTEMPTS: u32 = 4;"));
-    assert!(body.contains("const MEASUREMENT_BUDGET_MS: u64 = 400;"));
-    assert!(body.contains(
-        "return TestResult::Fail(\"timer delay never observed an unstarved window on ARM64\");"
-    ));
+    let skipped_final_drain = body.replacen(
+        "let final_drain = drain_interrupts(",
+        "let final_drain = skip_interrupt_drain(",
+        1,
+    );
+    assert!(check_timer_delay_starvation_ratchet(&skipped_final_drain).is_err());
 }


### PR DESCRIPTION
## Mechanism (RCA)

`test_timer_delay` (ARM64, `kernel/src/test_framework/registry.rs`) measures
elapsed time via `CNTVCT_EL0` — QEMU's emulated ARM architectural counter,
which in TCG mode tracks real **host wall-clock time**, not guest execution
progress. The test busy-waits under a guest-only `preempt_disable()` guard
(`TimerDelayPreemptGuard`) that stops Breenix's own in-guest scheduler from
switching the test thread out, but has no way to prevent, detect, or
compensate for the **host OS** descheduling the QEMU vCPU thread itself —
that starvation happens entirely below the level `preempt_disable()` can
influence.

Under heavy host CPU contention (the 14-`yes`-hog starved-boot gate), a
host-scheduling gap during the spin loop lets `CNTVCT_EL0` jump forward by
the full stall duration between polls. `end_ns - start_ns` then reflects
real wall-clock elapsed time including the host-scheduling gap rather than
the guest's ~10ms busy-wait, easily exceeding `MAX_MS=20` and producing a
spurious `Fail("delay too long on ARM64")` — a false-FAIL of a
starved-host artifact, not a real in-guest timing defect. This was
confirmed against the `postmerge-starved/fail_001` evidence from #519 and
independently reproduced/characterized: `MIN_MS=5`/`MAX_MS=20`,
`TARGET_MS=10`, clock = `timer::rdtsc()` = `read_cntvct()`
(`kernel/src/arch_impl/aarch64/timer.rs:119-121`), and the existing
`preempt_disable()`/`preempt_enable()` guard is a guest-only per-CPU
counter (`kernel/src/per_cpu_aarch64.rs:420-435`) with no host-visible
effect — its own doc comment only ever covered guest-side scheduling
variance, not host-level starvation.

## Repair summary

Both hard stops repaired on the attempt-3 architecture (counter-verified
IRQ-masked slices, strict crediting kept); committed and pushed as
`ad1cfcf3` on `fix/timer-delay-starved-robustness`; all controls re-ran
post-repair and the 20-run starved smoke is 0/20.

**HARD STOP 1 (boundary-bracket crediting)** —
`kernel/src/test_framework/registry.rs`: `pre_start_counter`/
`post_end_counter` and the `opening_gap`/`closing_gap` bookkeeping are
gone. Only gaps between CNTVCT samples lying strictly between the two
`nanoseconds_since_base()` reads can reach `host_stall_ticks`; bracket
time is credited to nobody. The ratchet

Review-clean at `ad1cfcf3f349` with re-run fault-injection controls, 0/20
starved smoke; discovered by the #519/PR #521 post-merge demonstration.

## Evidence (from the commit)

```
Positive control (SIGSTOP/SIGCONT storm on the QEMU process):
  [timer_delay] attempt=1 verdict=host-starved elapsed_ms=40 host_stall_ms=38 max_gap_us=38740 open_window_us=275 irqs=1 slices=10 forfeited=0 samples=13059
  [timer_delay] attempt=2 verdict=in-band elapsed_ms=10 host_stall_ms=0 max_gap_us=168 open_window_us=692 irqs=6 slices=92 forfeited=0 samples=121080
  [TEST:timer:timer_delay:PASS]
Negative control A (30ms unmasked in-guest burn in the closing region, the
direct boundary-bracket regression test):
  [timer_delay] attempt=1 verdict=out-of-band elapsed_ms=40 host_stall_ms=0 max_gap_us=88 open_window_us=754 irqs=25 slices=92 forfeited=0 samples=154518
  [TEST:timer:timer_delay:FAIL:delay too long on ARM64]
Negative control A2 (same burn mid-window, at the 5ms mark):
  [timer_delay] attempt=1 verdict=out-of-band elapsed_ms=35 host_stall_ms=0 max_gap_us=30025 open_window_us=351 irqs=23 slices=47 forfeited=1 samples=78965
  [TEST:timer:timer_delay:FAIL:delay too long on ARM64]
Negative control B (4x-too-long busy-wait):
  [timer_delay] attempt=1 verdict=out-of-band elapsed_ms=40 host_stall_ms=2 max_gap_us=170 open_window_us=2668 irqs=24 slices=368 forfeited=0 samples=588183
  [TEST:timer:timer_delay:FAIL:delay too long on ARM64]
20/20 green under the 14-hog sequential starved gate; both aarch64 builds
warning-free; cargo test --test teardown_structure 9/9. All injection code
reverted, grep-confirmed clean before this commit.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
