### PR TITLE
fix: Parallels init DATA_ABORT boot regression (near-null deref after bsshd spawn)

### DIFF
--- a/kernel/src/arch_impl/aarch64/constants.rs
+++ b/kernel/src/arch_impl/aarch64/constants.rs
@@ -149,6 +149,12 @@ pub const PERCPU_EXCEPTION_CLEANUP_CONTEXT_OFFSET: usize = 88;
 /// Used by assembly ERET paths to save/restore one register across SP switches.
 pub const PERCPU_ERET_SCRATCH_OFFSET: usize = 96;
 
+/// Offset of the second ERET scratch register save area in PerCpuData.
+/// Holds `frame.x17` for the dispatch ERET path in `aarch64_enter_exception_frame`,
+/// which needs a second scratch register after its SP switch has made the
+/// exception frame unaddressable.
+pub const PERCPU_ERET_SCRATCH2_OFFSET: usize = 144;
+
 /// Offset of dispatch ELR in PerCpuData.
 /// Written by context switch Rust code, read by assembly ERET path.
 /// Immune to cross-CPU frame overwrite race (per-CPU, not on shared stack).

--- a/kernel/src/arch_impl/aarch64/context_switch.rs
+++ b/kernel/src/arch_impl/aarch64/context_switch.rs
@@ -688,10 +688,16 @@ aarch64_enter_exception_frame:
     ldp x28, x29, [sp, #224]
     ldr x30, [sp, #240]
 
+    // Park frame.x16 and frame.x17 in per-CPU scratch before the SP switch
+    // below makes the exception frame unaddressable. Both are re-loaded
+    // immediately before the ERET: the CPU0 breadcrumb blocks after the SP
+    // switch use x16 and x17 as their only available scratch registers, so
+    // neither can hold its final architectural value across them.
     mrs x16, tpidr_el1
     ldr x17, [sp, #128]
-    str x17, [x16, #96]
+    str x17, [x16, #96]      // percpu.eret_scratch  = frame.x16
     ldr x17, [sp, #136]
+    str x17, [x16, #144]     // percpu.eret_scratch2 = frame.x17
 
     mrs x16, spsr_el1
     and x16, x16, #0xF
@@ -757,7 +763,8 @@ aarch64_enter_exception_frame:
 6:
 
     mrs x16, tpidr_el1
-    ldr x16, [x16, #96]
+    ldr x17, [x16, #144]     // x17 = saved frame.x17
+    ldr x16, [x16, #96]      // x16 = saved frame.x16
     eret
 "#
 );

--- a/kernel/src/per_cpu_aarch64.rs
+++ b/kernel/src/per_cpu_aarch64.rs
@@ -65,8 +65,11 @@ pub struct PerCpuData {
     pub eret_guard_spsr: u64,
     /// Guard source tag, written last to publish the record (offset 136).
     pub eret_guard_source: u64,
+    /// Second scratch slot used by the assembly dispatch ERET path to carry
+    /// `frame.x17` across the SP switch (offset 144).
+    pub eret_scratch2: u64,
     /// Padding to match the fixed 192-byte per-CPU layout.
-    _pad3: [u8; 48],
+    _pad3: [u8; 40],
 }
 
 const _: () = assert!(
@@ -100,7 +103,8 @@ impl PerCpuData {
             eret_guard_elr: 0,
             eret_guard_spsr: 0,
             eret_guard_source: 0,
-            _pad3: [0; 48],
+            eret_scratch2: 0,
+            _pad3: [0; 40],
         }
     }
 }
@@ -116,6 +120,10 @@ const _: () = assert!(
 const _: () = assert!(
     core::mem::offset_of!(PerCpuData, eret_guard_source)
         == crate::arch_impl::aarch64::constants::PERCPU_ERET_GUARD_SOURCE_OFFSET
+);
+const _: () = assert!(
+    core::mem::offset_of!(PerCpuData, eret_scratch2)
+        == crate::arch_impl::aarch64::constants::PERCPU_ERET_SCRATCH2_OFFSET
 );
 
 /// Per-CPU data for all CPUs (up to MAX_CPUS).


### PR DESCRIPTION
## RCA

**Culprit merge**: `308c281b` — PR #504 `feat/teardown-p1-retirement-fence`
**Last green sha**: `7ae22124` — PR #503 `feat/teardown-p0-observability` (0/3 boots faulted)
**Underlying defect**: pre-existing latent bug in the `aarch64_enter_exception_frame` `global_asm!` stub (`kernel/src/arch_impl/aarch64/context_switch.rs`), present verbatim in the green shas.

The failure is a **register-restore bug on the CPU0 ERET dispatch path**: the stub restores `x0`-`x30` from the exception frame, then does `mov sp, x16`, making the frame unaddressable. It therefore parks `frame.x16` in per-CPU scratch (offset 96) and re-loads it right before `eret`. Two CPU0-only breadcrumb blocks (labels `5:` and `6:`, ids 109/110) run **after** that SP switch; each does `mov x17,#109/#110` then `mrs x17, cntv_ctl_el0`. `x17` had no rescue slot, so on CPU0 any thread preempted on the dispatch path resumes with `x17 = CNTV_CTL_EL0` (== 1, the common post-rearm timer state) instead of its true value — a near-null pointer.

The bug was latent in every prior sha (the assembly is byte-identical across `4f372ee0`, `7ae22124`, `308c281b`, `7ad21766`). PR #504's `RetirementSnapshot::capture()` (`kernel/src/task/scheduler.rs:646`) is what made it *reachable and fatal*: LLVM fully unrolls the 8-iteration `MAX_CPUS` loop, runs out of allocatable registers, and parks the `SCHEDULING_EPOCHS`/`CPU_ONLINE` base pointers in `x17`/`x18` — keeping `x17` live across ~50 interleaved `ldar`/`ldarb` instructions. That created a wide, hot, CPU0-reachable preemption window inlined into `reclaim_deferred_process_resources`, where a corrupted `x17` produces a `DATA_ABORT` at `FAR ∈ {0x1, 0x11, 0x21}` (`ESR=0x96000005`, `DFSC=0x5`).

Full RCA: `/private/tmp/claude-501/-Users-wrb-fun-code-breenix/22d1287c-465b-406a-9052-719b2b991adc/scratchpad/519-fix/parallels-regression-rca.md`

## Fix

FIXED. Branch `fix/parallels-init-data-abort` @ `7a0cc2e14cfa60e9b115429ba2e3f835d05e9a2f`, pushed.

MECHANISM (confirmed against source, exactly as the RCA states): the `aarch64_enter_exception_frame` `global_asm!` stub restores x0-x30 from the exception frame, then does `mov sp, x16`, which makes the frame unaddressable. It therefore parks `frame.x16` in per-CPU scratch (offset 96) and re-loads it right before the `eret`. Two CPU0-only breadcrumb blocks (labels 5: and 6:, ids 109/110) run AFTER that SP switch; each does `mov x17,#109/#110` then `mrs x17, cntv_ctl_el0`. x17 had no rescue slot, so on CPU0 the resumed thread's x17 was silently corrupted with the timer control register value across the ERET dispatch path.

The fix rescues `x17` the same way `x16` is already rescued: stash it into per-CPU scratch before the breadcrumb blocks clobber it, and reload it right before `eret`.

## Proof

- QEMU: clean 0/20 faults, starved 0/20 faults
- Parallels: 3 consecutive green boots
- Review-clean

Discovered by the #519 conclusive post-merge demonstration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)