### PR TITLE
feat(mm): process page-table custody record — every root drop classified and counted (#470 PR-1b)

### DIFF
--- a/docker/qemu/run-x86-boot-tests.sh
+++ b/docker/qemu/run-x86-boot-tests.sh
@@ -48,6 +48,10 @@ for i in $(seq 1 "$COUNT"); do
         if grep -q '\[TEST:process:frame_custody_refusal_gate:PASS\]' \
             "$OUTPUT_DIR"/serial_*.txt 2>/dev/null \
             && grep -qE '\[FRAME_CUSTODY_COUNTERS:x86:double=1:stale=1:never=1:untracked=1:duplicate=3:contended=[1-9][0-9]*\]' \
+                "$OUTPUT_DIR"/serial_*.txt 2>/dev/null \
+            && grep -q '\[TEST:process:page_table_custody_disposition_gate:PASS\]' \
+                "$OUTPUT_DIR"/serial_*.txt 2>/dev/null \
+            && grep -q '\[PT_CUSTODY_COUNTERS:x86:recorded=2:no_proof=0:no_arch=0:terminated=1:undecided=1:exec_unreturned=0\]' \
                 "$OUTPUT_DIR"/serial_*.txt 2>/dev/null; then
             passed=true
             break
@@ -68,9 +72,14 @@ for i in $(seq 1 "$COUNT"); do
     $passed
     test "$(grep -h -c '\[TEST:process:frame_custody_refusal_gate:PASS\]' \
         "$OUTPUT_DIR"/serial_*.txt | awk '{ total += $1 } END { print total + 0 }')" -eq 1
+    test "$(grep -h -c '\[TEST:process:page_table_custody_disposition_gate:PASS\]' \
+        "$OUTPUT_DIR"/serial_*.txt | awk '{ total += $1 } END { print total + 0 }')" -eq 1
     COUNTER_LINE=$(grep -hE '\[FRAME_CUSTODY_COUNTERS:x86:' \
         "$OUTPUT_DIR"/serial_*.txt | tail -1)
     echo "$COUNTER_LINE"
+    PT_COUNTER_LINE=$(grep -hE '\[PT_CUSTODY_COUNTERS:x86:' \
+        "$OUTPUT_DIR"/serial_*.txt | tail -1)
+    echo "$PT_COUNTER_LINE"
     if grep -qE '\[BOOT_TESTS:FAIL|KERNEL PANIC|panic!' \
         "$OUTPUT_DIR"/serial_*.txt; then
         exit 1

--- a/kernel/src/memory/frame_allocator.rs
+++ b/kernel/src/memory/frame_allocator.rs
@@ -131,10 +131,16 @@ static BOOTSTRAP_FREE_FRAMES: Mutex<BootstrapFreeFrames> = Mutex::new(BootstrapF
 
 /// Unforgeable authority to return one allocator-issued generation.
 #[derive(Clone, Copy)]
-struct FrameLease {
+pub(crate) struct FrameLease {
     frame: PhysFrame,
     index: u32,
     generation: u32,
+}
+
+impl FrameLease {
+    pub(crate) fn frame(self) -> PhysFrame {
+        self.frame
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -643,8 +649,7 @@ pub fn allocate_frame() -> Option<PhysFrame> {
     allocate_claimed().map(|(frame, _)| frame)
 }
 
-#[cfg(feature = "boot_tests")]
-fn allocate_frame_leased() -> Option<FrameLease> {
+pub(crate) fn allocate_frame_leased() -> Option<FrameLease> {
     assert!(FRAME_LEDGER.get().is_some(), "frame ledger not initialized");
     allocate_claimed().and_then(|(_, lease)| lease)
 }
@@ -771,7 +776,9 @@ mod boot_tests;
 #[cfg(all(feature = "boot_tests", target_arch = "x86_64"))]
 pub use boot_tests::run_x86_frame_custody_gate;
 #[cfg(feature = "boot_tests")]
-pub use boot_tests::{frame_custody_healthy_counters_test, frame_custody_refusal_gate_test};
+pub use boot_tests::{
+    frame_custody_healthy_counters_test, frame_custody_refusal_gate_test, free_list_len_for_gate,
+};
 
 /// Memory statistics for procfs reporting
 pub struct MemoryStats {

--- a/kernel/src/memory/frame_allocator_tests.rs
+++ b/kernel/src/memory/frame_allocator_tests.rs
@@ -42,6 +42,10 @@ fn free_frame_count(frame: PhysFrame) -> usize {
         .count()
 }
 
+pub fn free_list_len_for_gate() -> usize {
+    FREE_FRAMES.lock().len()
+}
+
 fn take_free_frame(frame: PhysFrame) -> Option<FrameLease> {
     let candidate = {
         let mut free = FREE_FRAMES.lock();

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -157,6 +157,8 @@ pub fn init(physical_memory_offset: VirtAddr, memory_regions: &'static MemoryReg
 
     #[cfg(all(target_arch = "x86_64", feature = "boot_tests"))]
     frame_allocator::run_x86_frame_custody_gate();
+    #[cfg(all(target_arch = "x86_64", feature = "boot_tests"))]
+    process_memory::run_x86_page_table_custody_gate();
 }
 
 /// Get the physical memory offset

--- a/kernel/src/memory/process_memory.rs
+++ b/kernel/src/memory/process_memory.rs
@@ -3,25 +3,25 @@
 //! This module provides per-process page tables and address space isolation.
 
 #[cfg(not(target_arch = "x86_64"))]
-use crate::memory::arch_stub::ThreadPrivilege;
-#[cfg(not(target_arch = "x86_64"))]
 use crate::memory::arch_stub::{
-    Cr3, Mapper, OffsetPageTable, Page, PageTable, PageTableEntry, PageTableFlags, PhysAddr,
+    Cr3, FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags, PhysAddr,
     PhysFrame, Size4KiB, Translate, VirtAddr,
 };
-use crate::memory::frame_allocator::{allocate_frame, GlobalFrameAllocator};
+#[cfg(target_arch = "aarch64")]
+use crate::memory::frame_allocator::allocate_frame;
+use crate::memory::frame_allocator::{allocate_frame_leased, FrameLease};
 use crate::memory::layout::USER_STACK_REGION_END;
-#[cfg(target_arch = "x86_64")]
-use crate::task::thread::ThreadPrivilege;
 #[cfg(target_arch = "x86_64")]
 use x86_64::{
     registers::control::Cr3,
     structures::paging::{
-        mapper::TranslateResult, page_table::PageTableEntry, Mapper, OffsetPageTable, Page,
-        PageTable, PageTableFlags, PhysFrame, Size4KiB, Translate,
+        mapper::TranslateResult, FrameAllocator, Mapper, OffsetPageTable, Page, PageTable,
+        PageTableFlags, PhysFrame, Size4KiB, Translate,
     },
     PhysAddr, VirtAddr,
 };
+
+use alloc::vec::Vec;
 
 // ============================================================================
 // Copy-on-Write (CoW) Support
@@ -82,210 +82,61 @@ pub struct ProcessPageTable {
     level_4_frame: PhysFrame,
     /// The mapper for this page table
     mapper: OffsetPageTable<'static>,
+    /// Allocator authority for the root. PR-1c consumes this after proving the
+    /// address space is no longer live; PR-1b intentionally never returns it.
+    #[allow(dead_code)]
+    root_lease: FrameLease,
+    /// Allocation-derived custody for every intermediate table we created.
+    tables: OwnedTableFrames,
+}
+
+struct OwnedTableFrames {
+    leases: Vec<FrameLease>,
+    disposition: Disposition,
+}
+
+impl OwnedTableFrames {
+    fn new() -> Self {
+        Self {
+            leases: Vec::new(),
+            disposition: Disposition::Undecided,
+        }
+    }
+
+    fn record(&mut self, lease: FrameLease) {
+        self.leases.push(lease);
+        crate::trace_count!(crate::tracing::providers::teardown::PT_TABLE_FRAMES_RECORDED);
+    }
+}
+
+struct TableRecorder<'a>(&'a mut OwnedTableFrames);
+
+unsafe impl FrameAllocator<Size4KiB> for TableRecorder<'_> {
+    fn allocate_frame(&mut self) -> Option<PhysFrame> {
+        let lease = allocate_frame_leased()?;
+        let frame = lease.frame();
+        self.0.record(lease);
+        Some(frame)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Disposition {
+    Undecided,
+    RetiredByExecWalk,
+    Abandoned(AbandonReason),
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum AbandonReason {
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+    NoProofPipeline,
+    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
+    NoArchPipeline,
+    AlreadyTerminated,
 }
 
 impl ProcessPageTable {
-    /// Deep copy a PML4 entry, creating independent L3/L2/L1 tables
-    ///
-    /// This creates a complete copy of the page table hierarchy below this L4 entry,
-    /// ensuring that each process has its own isolated page tables.
-    #[allow(dead_code)]
-    fn deep_copy_pml4_entry(
-        source_entry: &PageTableEntry,
-        entry_index: usize,
-        phys_offset: VirtAddr,
-    ) -> Result<PhysFrame, &'static str> {
-        log::debug!(
-            "Deep copying PML4 entry {} with L3 addr {:#x}",
-            entry_index,
-            source_entry.addr().as_u64()
-        );
-
-        // Allocate a new L3 table
-        let new_l3_frame = allocate_frame().ok_or("Failed to allocate frame for L3 table")?;
-
-        // Map the new L3 table
-        let new_l3_virt = phys_offset + new_l3_frame.start_address().as_u64();
-        let new_l3_table = unsafe { &mut *(new_l3_virt.as_mut_ptr() as *mut PageTable) };
-
-        // Clear the new L3 table
-        // Clear all entries properly (not using zero() which sets PRESENT | WRITABLE)
-        for i in 0..512 {
-            new_l3_table[i].set_unused();
-        }
-
-        // Map the source L3 table
-        let source_l3_virt = phys_offset + source_entry.addr().as_u64();
-        let source_l3_table = unsafe { &*(source_l3_virt.as_ptr() as *const PageTable) };
-
-        // Copy each L3 entry, deep copying L2 tables as needed
-        for i in 0..512 {
-            if !source_l3_table[i].is_unused() {
-                // Check if this is a huge page (1GB page at L3 level)
-                if source_l3_table[i]
-                    .flags()
-                    .contains(PageTableFlags::HUGE_PAGE)
-                {
-                    // Huge pages can be shared at the physical level
-                    new_l3_table[i] = source_l3_table[i].clone();
-                    log::trace!("Copied L3 huge page entry {}", i);
-                } else {
-                    // Regular L3 entry pointing to L2 table - deep copy the L2 table
-                    match Self::deep_copy_l3_entry(&source_l3_table[i], i, phys_offset) {
-                        Ok(new_l2_frame) => {
-                            let flags = source_l3_table[i].flags();
-                            new_l3_table[i].set_addr(new_l2_frame.start_address(), flags);
-                            log::trace!(
-                                "Deep copied L3 entry {} -> new L2 frame {:#x}",
-                                i,
-                                new_l2_frame.start_address().as_u64()
-                            );
-                        }
-                        Err(e) => {
-                            log::error!("Failed to deep copy L3 entry {}: {}", i, e);
-                            return Err("Failed to deep copy L3 entry");
-                        }
-                    }
-                }
-            }
-        }
-
-        log::debug!(
-            "Successfully deep copied PML4 entry {} to new L3 frame {:#x}",
-            entry_index,
-            new_l3_frame.start_address().as_u64()
-        );
-
-        Ok(new_l3_frame)
-    }
-
-    /// Deep copy an L3 entry, creating independent L2/L1 tables
-    #[allow(dead_code)]
-    fn deep_copy_l3_entry(
-        source_entry: &PageTableEntry,
-        entry_index: usize,
-        phys_offset: VirtAddr,
-    ) -> Result<PhysFrame, &'static str> {
-        // Allocate a new L2 table
-        let new_l2_frame = allocate_frame().ok_or("Failed to allocate frame for L2 table")?;
-
-        // Map the new L2 table
-        let new_l2_virt = phys_offset + new_l2_frame.start_address().as_u64();
-        let new_l2_table = unsafe { &mut *(new_l2_virt.as_mut_ptr() as *mut PageTable) };
-
-        // Clear the new L2 table
-        // Clear all entries properly (not using zero() which sets PRESENT | WRITABLE)
-        for i in 0..512 {
-            new_l2_table[i].set_unused();
-        }
-
-        // Map the source L2 table
-        let source_l2_virt = phys_offset + source_entry.addr().as_u64();
-        let source_l2_table = unsafe { &*(source_l2_virt.as_ptr() as *const PageTable) };
-
-        // Copy each L2 entry, deep copying L1 tables as needed
-        for i in 0..512 {
-            if !source_l2_table[i].is_unused() {
-                // Check if this is a huge page (2MB page at L2 level)
-                if source_l2_table[i]
-                    .flags()
-                    .contains(PageTableFlags::HUGE_PAGE)
-                {
-                    // Huge pages can be shared at the physical level for kernel code
-                    // Calculate the virtual address this L2 entry covers
-                    let l2_virt_addr = (entry_index as u64) * 0x40000000 + (i as u64) * 0x200000; // 1GB per L3, 2MB per L2
-
-                    if l2_virt_addr >= 0x800000000000 {
-                        // Kernel space - safe to share huge pages
-                        new_l2_table[i] = source_l2_table[i].clone();
-                        log::trace!(
-                            "Shared kernel L2 huge page entry {} (addr {:#x})",
-                            i,
-                            l2_virt_addr
-                        );
-                    } else {
-                        // User space - should not share, but for now we'll share kernel code pages
-                        // This needs refinement based on what's actually mapped
-                        new_l2_table[i] = source_l2_table[i].clone();
-                        // Don't spam logs with hundreds of huge page entries
-                        if i < 10 {
-                            log::trace!(
-                                "Shared user L2 huge page entry {} (addr {:#x}) - FIXME",
-                                i,
-                                l2_virt_addr
-                            );
-                        }
-                    }
-                } else {
-                    // Regular L2 entry pointing to L1 table - deep copy the L1 table
-                    match Self::deep_copy_l2_entry(&source_l2_table[i], i, phys_offset) {
-                        Ok(new_l1_frame) => {
-                            let flags = source_l2_table[i].flags();
-                            new_l2_table[i].set_addr(new_l1_frame.start_address(), flags);
-                            log::trace!(
-                                "Deep copied L2 entry {} -> new L1 frame {:#x}",
-                                i,
-                                new_l1_frame.start_address().as_u64()
-                            );
-                        }
-                        Err(e) => {
-                            log::error!("Failed to deep copy L2 entry {}: {}", i, e);
-                            return Err("Failed to deep copy L2 entry");
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(new_l2_frame)
-    }
-
-    /// Deep copy an L2 entry, creating independent L1 tables
-    #[allow(dead_code)]
-    fn deep_copy_l2_entry(
-        source_entry: &PageTableEntry,
-        _entry_index: usize,
-        phys_offset: VirtAddr,
-    ) -> Result<PhysFrame, &'static str> {
-        // Allocate a new L1 table
-        let new_l1_frame = allocate_frame().ok_or("Failed to allocate frame for L1 table")?;
-
-        // Map the new L1 table
-        let new_l1_virt = phys_offset + new_l1_frame.start_address().as_u64();
-        let new_l1_table = unsafe { &mut *(new_l1_virt.as_mut_ptr() as *mut PageTable) };
-
-        // Clear the new L1 table
-        // Clear all entries properly (not using zero() which sets PRESENT | WRITABLE)
-        for i in 0..512 {
-            new_l1_table[i].set_unused();
-        }
-
-        // Map the source L1 table
-        let source_l1_virt = phys_offset + source_entry.addr().as_u64();
-        let source_l1_table = unsafe { &*(source_l1_virt.as_ptr() as *const PageTable) };
-
-        // Copy L1 entries - these point to actual physical pages
-        // For now, we'll share all physical pages (kernel code should be read-only anyway)
-        // In a full copy-on-write implementation, we'd mark pages as read-only and copy on write
-        for i in 0..512 {
-            if !source_l1_table[i].is_unused() {
-                // Share the physical page but with independent page table entry
-                // This allows different processes to have different permissions/flags if needed
-                new_l1_table[i] = source_l1_table[i].clone();
-                // Don't spam logs with L1 entries
-                if i < 5 {
-                    log::trace!(
-                        "Copied L1 entry {} -> phys frame {:#x}",
-                        i,
-                        source_l1_table[i].addr().as_u64()
-                    );
-                }
-            }
-        }
-
-        Ok(new_l1_frame)
-    }
-
     /// Create a new page table for a process (ARM64 version)
     ///
     /// On ARM64, this is much simpler than x86_64 because:
@@ -300,19 +151,20 @@ impl ProcessPageTable {
         log::debug!("ProcessPageTable::new() [ARM64] - Creating userspace page table");
 
         // Allocate a frame for the L0 page table (TTBR0)
-        let l0_frame = match allocate_frame() {
-            Some(frame) => {
+        let root_lease = match allocate_frame_leased() {
+            Some(lease) => {
                 log::debug!(
                     "ARM64: Allocated L0 frame for TTBR0: {:#x}",
-                    frame.start_address().as_u64()
+                    lease.frame().start_address().as_u64()
                 );
-                frame
+                lease
             }
             None => {
                 log::error!("ARM64: Frame allocator returned None - out of memory?");
                 return Err("Failed to allocate frame for page table");
             }
         };
+        let l0_frame = root_lease.frame();
 
         // Get physical memory offset
         let phys_offset = crate::memory::physical_memory_offset();
@@ -344,6 +196,8 @@ impl ProcessPageTable {
         let page_table = ProcessPageTable {
             level_4_frame: l0_frame,
             mapper,
+            root_lease,
+            tables: OwnedTableFrames::new(),
         };
 
         log::debug!("ARM64: ProcessPageTable created successfully");
@@ -377,9 +231,9 @@ impl ProcessPageTable {
         log::debug!("ProcessPageTable::new() - About to allocate L4 frame");
 
         // Try to allocate with error handling
-        let level_4_frame = match allocate_frame() {
-            Some(frame) => {
-                let frame_addr = frame.start_address().as_u64();
+        let root_lease = match allocate_frame_leased() {
+            Some(lease) => {
+                let frame_addr = lease.frame().start_address().as_u64();
                 log::debug!("Successfully allocated frame: {:#x}", frame_addr);
 
                 // Check for problematic frames
@@ -389,13 +243,15 @@ impl ProcessPageTable {
                     );
                 }
 
-                frame
+                lease
             }
             None => {
                 log::error!("Frame allocator returned None - out of memory?");
                 return Err("Failed to allocate frame for page table");
             }
         };
+        let level_4_frame = root_lease.frame();
+        let mut tables = OwnedTableFrames::new();
 
         log::debug!(
             "Allocated L4 frame: {:#x}",
@@ -598,8 +454,10 @@ impl ProcessPageTable {
                 // CREATE a fresh PDPT for PML4[0] to enable userspace mappings
                 // PML4[0] covers 0x0 - 0x7FFFFFFFFF (512GB) - this is the userspace region
                 // Each process needs its own independent page table hierarchy here
-                let fresh_pdpt_frame =
-                    allocate_frame().ok_or("Failed to allocate PDPT for PML4[0]")?;
+                let fresh_pdpt_lease =
+                    allocate_frame_leased().ok_or("Failed to allocate PDPT for PML4[0]")?;
+                let fresh_pdpt_frame = fresh_pdpt_lease.frame();
+                tables.record(fresh_pdpt_lease);
 
                 // Map and zero out the fresh PDPT
                 let fresh_pdpt_virt = phys_offset + fresh_pdpt_frame.start_address().as_u64();
@@ -1067,6 +925,8 @@ impl ProcessPageTable {
         let new_page_table = ProcessPageTable {
             level_4_frame,
             mapper,
+            root_lease,
+            tables,
         };
 
         // With global kernel page tables, all kernel stacks are automatically visible
@@ -1248,12 +1108,13 @@ impl ProcessPageTable {
                 PageTableFlags::PRESENT | PageTableFlags::WRITABLE
             };
 
-            match self.mapper.map_to_with_table_flags(
+            let Self { mapper, tables, .. } = self;
+            match mapper.map_to_with_table_flags(
                 page,
                 frame,
                 flags,
                 table_flags,
-                &mut GlobalFrameAllocator,
+                &mut TableRecorder(tables),
             ) {
                 Ok(flush) => {
                     // CRITICAL: Do NOT flush TLB immediately!
@@ -1357,13 +1218,14 @@ impl ProcessPageTable {
         };
 
         unsafe {
-            self.mapper
+            let Self { mapper, tables, .. } = self;
+            mapper
                 .map_to_with_table_flags(
                     page,
                     frame,
                     new_flags,
                     table_flags,
-                    &mut GlobalFrameAllocator,
+                    &mut TableRecorder(tables),
                 )
                 .map_err(|_| "Failed to remap page with new flags")?
                 .ignore(); // Don't flush - caller will handle TLB
@@ -1560,22 +1422,6 @@ impl ProcessPageTable {
         result
     }
 
-    /// Get a reference to the mapper
-    #[allow(dead_code)]
-    pub fn mapper(&mut self) -> &mut OffsetPageTable<'static> {
-        &mut self.mapper
-    }
-
-    /// Allocate a stack in this process's page table
-    #[allow(dead_code)]
-    pub fn allocate_stack(
-        &mut self,
-        size: usize,
-        privilege: ThreadPrivilege,
-    ) -> Result<crate::memory::stack::GuardedStack, &'static str> {
-        crate::memory::stack::GuardedStack::new(size, &mut self.mapper, privilege)
-    }
-
     /// Clear specific userspace mappings before loading a new program
     ///
     /// WORKAROUND: Since we share L3 tables between processes, we need to
@@ -1676,6 +1522,27 @@ impl ProcessPageTable {
         Ok(())
     }
 
+    /// Classify an address space that this PR cannot reclaim. This method is
+    /// intentionally limited to disposition accounting and returns no frames.
+    pub(crate) fn abandon(mut self, reason: AbandonReason) {
+        self.tables.disposition = Disposition::Abandoned(reason);
+        match reason {
+            AbandonReason::NoProofPipeline => {
+                crate::trace_count!(
+                    crate::tracing::providers::teardown::PT_ROOT_ABANDONED_NO_PROOF
+                );
+            }
+            AbandonReason::NoArchPipeline => {
+                crate::trace_count!(crate::tracing::providers::teardown::PT_ROOT_ABANDONED_NO_ARCH);
+            }
+            AbandonReason::AlreadyTerminated => {
+                crate::trace_count!(
+                    crate::tracing::providers::teardown::PT_ROOT_ABANDONED_TERMINATED
+                );
+            }
+        }
+    }
+
     /// Clean up page table resources during exec()
     ///
     /// This walks the entire page table hierarchy and:
@@ -1686,10 +1553,16 @@ impl ProcessPageTable {
     ///
     /// Call this on the OLD page table after installing the new one during exec().
     #[cfg(target_arch = "x86_64")]
-    pub fn cleanup_for_exec(self) {
+    pub fn cleanup_for_exec(mut self) {
         use crate::memory::frame_allocator::deallocate_frame;
         use crate::memory::frame_metadata::frame_decref;
         use alloc::vec::Vec;
+
+        self.tables.disposition = Disposition::RetiredByExecWalk;
+        crate::trace_count_add!(
+            crate::tracing::providers::teardown::PT_EXEC_WALK_LEASES_UNRETURNED,
+            self.tables.leases.len() as u64
+        );
 
         let phys_offset = crate::memory::physical_memory_offset();
         let mut user_frames_freed = 0u64;
@@ -1858,10 +1731,16 @@ impl ProcessPageTable {
     ///
     /// ARM64 uses different page table naming (L0/L1/L2/L3) but same structure.
     #[cfg(target_arch = "aarch64")]
-    pub fn cleanup_for_exec(self) {
+    pub fn cleanup_for_exec(mut self) {
         use crate::memory::frame_allocator::deallocate_frame;
         use crate::memory::frame_metadata::frame_decref;
         use alloc::vec::Vec;
+
+        self.tables.disposition = Disposition::RetiredByExecWalk;
+        crate::trace_count_add!(
+            crate::tracing::providers::teardown::PT_EXEC_WALK_LEASES_UNRETURNED,
+            self.tables.leases.len() as u64
+        );
 
         let phys_offset = crate::memory::physical_memory_offset();
         let mut user_frames_freed = 0u64;
@@ -1994,6 +1873,99 @@ impl ProcessPageTable {
             table_frames_freed
         );
     }
+}
+
+impl Drop for ProcessPageTable {
+    fn drop(&mut self) {
+        match self.tables.disposition {
+            Disposition::Undecided => {
+                crate::trace_count!(crate::tracing::providers::teardown::PT_ROOT_DROPPED_UNDECIDED);
+            }
+            Disposition::RetiredByExecWalk => {}
+            Disposition::Abandoned(reason) => match reason {
+                AbandonReason::NoProofPipeline
+                | AbandonReason::NoArchPipeline
+                | AbandonReason::AlreadyTerminated => {}
+            },
+        }
+    }
+}
+
+#[cfg(feature = "boot_tests")]
+fn disposition_gate_counters() -> [u64; 6] {
+    use crate::tracing::providers::teardown;
+    [
+        teardown::PT_TABLE_FRAMES_RECORDED.aggregate(),
+        teardown::PT_ROOT_ABANDONED_NO_PROOF.aggregate(),
+        teardown::PT_ROOT_ABANDONED_NO_ARCH.aggregate(),
+        teardown::PT_ROOT_ABANDONED_TERMINATED.aggregate(),
+        teardown::PT_ROOT_DROPPED_UNDECIDED.aggregate(),
+        teardown::PT_EXEC_WALK_LEASES_UNRETURNED.aggregate(),
+    ]
+}
+
+/// O2/G-H: drive the real classified-abandon and non-freeing Drop paths.
+#[cfg(feature = "boot_tests")]
+pub fn page_table_custody_disposition_gate_test() -> crate::test_framework::registry::TestResult {
+    use crate::test_framework::registry::TestResult;
+
+    let start = disposition_gate_counters();
+
+    let terminated = match ProcessPageTable::new() {
+        Ok(page_table) => page_table,
+        Err(_) => return TestResult::Fail("G: page-table construction failed"),
+    };
+    let free_before_abandon = crate::memory::frame_allocator::free_list_len_for_gate();
+    terminated.abandon(AbandonReason::AlreadyTerminated);
+    let after_abandon = disposition_gate_counters();
+    if after_abandon[3] != start[3] + 1
+        || after_abandon[1] != start[1]
+        || after_abandon[2] != start[2]
+        || after_abandon[4] != start[4]
+        || after_abandon[5] != start[5]
+        || crate::memory::frame_allocator::free_list_len_for_gate() != free_before_abandon
+    {
+        return TestResult::Fail("G: terminated abandonment was not isolated and non-freeing");
+    }
+
+    let undecided = match ProcessPageTable::new() {
+        Ok(page_table) => page_table,
+        Err(_) => return TestResult::Fail("H: page-table construction failed"),
+    };
+    let free_before_drop = crate::memory::frame_allocator::free_list_len_for_gate();
+    drop(undecided);
+    let after_drop = disposition_gate_counters();
+    if after_drop[3] != after_abandon[3]
+        || after_drop[1] != after_abandon[1]
+        || after_drop[2] != after_abandon[2]
+        || after_drop[4] != after_abandon[4] + 1
+        || after_drop[5] != after_abandon[5]
+        || crate::memory::frame_allocator::free_list_len_for_gate() != free_before_drop
+    {
+        return TestResult::Fail("H: undecided Drop was not isolated and non-freeing");
+    }
+
+    TestResult::Pass
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "x86_64"))]
+pub fn run_x86_page_table_custody_gate() {
+    crate::serial_println!("[TEST:process:page_table_custody_disposition_gate:START]");
+    let result = page_table_custody_disposition_gate_test();
+    if result.is_pass() {
+        crate::serial_println!("[TEST:process:page_table_custody_disposition_gate:PASS]");
+    } else {
+        crate::serial_println!(
+            "[TEST:process:page_table_custody_disposition_gate:FAIL:{:?}]",
+            result
+        );
+    }
+    let values = disposition_gate_counters();
+    crate::serial_println!(
+        "[PT_CUSTODY_COUNTERS:x86:recorded={}:no_proof={}:no_arch={}:terminated={}:undecided={}:exec_unreturned={}]",
+        values[0], values[1], values[2], values[3], values[4], values[5]
+    );
+    assert!(result.is_pass(), "x86 page-table custody gate failed");
 }
 
 /// Switch to a process's page table (ARM64 version)

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -19,7 +19,7 @@ use crate::memory::arch_stub::VirtAddr;
 use super::{Process, ProcessId};
 #[cfg(target_arch = "x86_64")]
 use crate::elf;
-use crate::memory::process_memory::ProcessPageTable;
+use crate::memory::process_memory::{AbandonReason, ProcessPageTable};
 use crate::task::thread::Thread;
 
 /// Process manager handles all processes in the system
@@ -1147,7 +1147,9 @@ impl ProcessManager {
                 // Preserve the single-CoW-decref invariant: external terminate()
                 // already walked these mappings, so raw-drop them without ever
                 // routing the page table through another reclaim/decref path.
-                drop(process.page_table.take());
+                if let Some(page_table) = process.page_table.take() {
+                    page_table.abandon(AbandonReason::AlreadyTerminated);
+                }
                 drop(process.stack.take());
                 process.pending_old_page_tables.clear();
             } else {

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -4,6 +4,7 @@
 //! allowing processes to be scheduled as tasks.
 
 use crate::ipc::fd::FileDescriptor;
+use crate::memory::process_memory::AbandonReason;
 use crate::process::ProcessId;
 use crate::task::scheduler;
 use crate::task::thread::{Thread, ThreadPrivilege};
@@ -183,7 +184,9 @@ impl PendingProcessReclaim {
         for old_page_table in self.old_page_tables.drain(..) {
             old_page_table.cleanup_for_exec();
         }
-        drop(self.page_table.take());
+        if let Some(page_table) = self.page_table.take() {
+            page_table.abandon(AbandonReason::NoProofPipeline);
+        }
     }
 }
 
@@ -288,7 +291,12 @@ pub(crate) fn release_process_resources(process: &mut crate::process::Process) {
     }
     process.cleanup_cow_frames();
     process.drain_old_page_tables();
-    drop(process.page_table.take());
+    if let Some(page_table) = process.page_table.take() {
+        #[cfg(target_arch = "aarch64")]
+        page_table.abandon(AbandonReason::NoProofPipeline);
+        #[cfg(not(target_arch = "aarch64"))]
+        page_table.abandon(AbandonReason::NoArchPipeline);
+    }
     drop(process.stack.take());
     process.pending_old_page_tables.clear();
 }
@@ -468,7 +476,9 @@ impl ProcessScheduler {
                             // Preserve the single-CoW-decref invariant: external
                             // terminate() already walked these mappings, so raw-drop
                             // them without another reclaim/decref path.
-                            drop(process.page_table.take());
+                            if let Some(page_table) = process.page_table.take() {
+                                page_table.abandon(AbandonReason::AlreadyTerminated);
+                            }
                             drop(process.stack.take());
                             process.pending_old_page_tables.clear();
                             None

--- a/kernel/src/test_framework/registry.rs
+++ b/kernel/src/test_framework/registry.rs
@@ -5367,6 +5367,13 @@ static PROCESS_TESTS: &[TestDef] = &[
         stage: TestStage::SerialBoot,
     },
     TestDef {
+        name: "page_table_custody_disposition_gate",
+        func: crate::memory::process_memory::page_table_custody_disposition_gate_test,
+        arch: Arch::Aarch64,
+        timeout_ms: 5000,
+        stage: TestStage::SerialBoot,
+    },
+    TestDef {
         name: "deferred_fault_ring_overflow_injection",
         func: crate::tracing::providers::teardown::deferred_fault_ring_overflow_test,
         arch: Arch::Any,

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -425,6 +425,27 @@ counter!(
 counter!(FRAME_RETURN_REFUSED_UNTRACKED, "Untracked frame returns refused");
 counter!(FRAME_DUPLICATE_ALLOC_REFUSED, "Duplicate frame allocations refused");
 counter!(FRAME_LOST_CONTENDED, "Frame returns lost to contention");
+counter!(PT_TABLE_FRAMES_RECORDED, "Process table frames recorded");
+counter!(
+    PT_ROOT_ABANDONED_NO_PROOF,
+    "Process roots abandoned without a retirement pipeline"
+);
+counter!(
+    PT_ROOT_ABANDONED_NO_ARCH,
+    "Process roots abandoned without an architecture pipeline"
+);
+counter!(
+    PT_ROOT_ABANDONED_TERMINATED,
+    "Process roots abandoned after prior termination"
+);
+counter!(
+    PT_ROOT_DROPPED_UNDECIDED,
+    "Process roots dropped without a disposition"
+);
+counter!(
+    PT_EXEC_WALK_LEASES_UNRETURNED,
+    "Recorded table leases consumed by the legacy exec walk"
+);
 
 // Declaration-only until the phase named in PLAN.md. These intentionally have
 // no trace_count! producer yet.
@@ -453,7 +474,7 @@ counter!(
     "Fatal group signals dropped for init"
 );
 
-pub const COUNTER_COUNT: usize = 53;
+pub const COUNTER_COUNT: usize = 59;
 
 /// The registration and normal-context reader inventory. Keeping one inventory
 /// makes a write-only counter structurally impossible without changing the P0
@@ -498,6 +519,12 @@ pub static COUNTERS: [&TraceCounter; COUNTER_COUNT] = [
     &FRAME_RETURN_REFUSED_UNTRACKED,
     &FRAME_DUPLICATE_ALLOC_REFUSED,
     &FRAME_LOST_CONTENDED,
+    &PT_TABLE_FRAMES_RECORDED,
+    &PT_ROOT_ABANDONED_NO_PROOF,
+    &PT_ROOT_ABANDONED_NO_ARCH,
+    &PT_ROOT_ABANDONED_TERMINATED,
+    &PT_ROOT_DROPPED_UNDECIDED,
+    &PT_EXEC_WALK_LEASES_UNRETURNED,
     &RECLAIM_PASS_SKIPPED,
     &RECLAIM_PARKED,
     &RECLAIM_UNPARKED_EPOCH,

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -390,6 +390,46 @@ fn code_sites(sources: &[(String, String)], needle: &str) -> BTreeSet<Site> {
     sites
 }
 
+/// Code offsets for calls whose balanced argument subtree contains `needle`.
+/// Matching the final identifier covers both `drop(...)` and qualified forms
+/// such as `core::mem::drop({ ... })` without depending on their spelling.
+fn call_sites_with_argument(source: &str, callee: &str, needle: &str) -> Vec<usize> {
+    let mask = code_mask(source);
+    let bytes = source.as_bytes();
+    let mut matches = Vec::new();
+    for offset in identifier_offsets(source, &mask, callee) {
+        let mut open = offset + callee.len();
+        while open < bytes.len() && (!mask[open] || bytes[open].is_ascii_whitespace()) {
+            open += 1;
+        }
+        if bytes.get(open) != Some(&b'(') {
+            continue;
+        }
+        let mut depth = 0usize;
+        for close in open..bytes.len() {
+            if !mask[close] {
+                continue;
+            }
+            match bytes[close] {
+                b'(' => depth += 1,
+                b')' => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        let argument = &source[open + 1..close];
+                        let argument_mask = code_mask(argument);
+                        if !code_offsets(argument, &argument_mask, needle).is_empty() {
+                            matches.push(offset);
+                        }
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    matches
+}
+
 fn enclosing_test_def<'a>(source: &'a str, mask: &[bool], offset: usize) -> Option<&'a str> {
     let start = code_offsets(source, mask, "TestDef {")
         .into_iter()
@@ -1207,15 +1247,15 @@ let _same_line = "needle"; let _real = needle();
 
 const TERMINATE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/interrupts/context_switch.rs", 1017),
-    ("kernel/src/process/manager.rs", 1170),
+    ("kernel/src/process/manager.rs", 1172),
     ("kernel/src/signal/delivery.rs", 225),
     ("kernel/src/signal/delivery.rs", 260),
 ];
-const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 496)];
+const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 506)];
 const PRODUCTION_INIT_PID_SITES: &[(&str, usize)] = &[
-    ("kernel/src/process/manager.rs", 1187),
-    ("kernel/src/task/process_task.rs", 458),
-    ("kernel/src/task/process_task.rs", 528),
+    ("kernel/src/process/manager.rs", 1189),
+    ("kernel/src/task/process_task.rs", 466),
+    ("kernel/src/task/process_task.rs", 538),
 ];
 const TEST_INIT_PID_SITES: &[(&str, usize)] = &[
     ("kernel/src/test_userspace.rs", 84),
@@ -1231,13 +1271,13 @@ const QUARANTINE_CALLS: &[(&str, usize)] = &[
 ];
 const KERNEL_STACK_MUTATIONS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/syscall_entry.rs", 961),
-    ("kernel/src/process/manager.rs", 1856),
+    ("kernel/src/process/manager.rs", 1858),
     ("kernel/src/syscall/clone.rs", 252),
 ];
 const RECLAIM_ENQUEUE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 53),
     ("kernel/src/process/mod.rs", 280),
-    ("kernel/src/task/process_task.rs", 570),
+    ("kernel/src/task/process_task.rs", 580),
 ];
 const EXIT_PROCESS_AND_RETIRE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/exception.rs", 824),
@@ -1255,7 +1295,7 @@ const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 418),
 ];
 const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
-    &[("kernel/src/tracing/providers/teardown.rs", 1068)];
+    &[("kernel/src/tracing/providers/teardown.rs", 1095)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
     ("kernel/src/task/scheduler.rs", 1973),
     ("kernel/src/task/scheduler.rs", 2187),
@@ -1272,20 +1312,51 @@ const RAW_SCHEDULER_LOCK_SITES: &[(&str, usize)] = &[
     ("kernel/src/task/scheduler.rs", 288),
 ];
 const PROCESS_MEMORY_FRAME_RETURNS: &[(&str, usize)] = &[
-    ("kernel/src/memory/process_memory.rs", 1744),
-    ("kernel/src/memory/process_memory.rs", 1783),
-    ("kernel/src/memory/process_memory.rs", 1820),
-    ("kernel/src/memory/process_memory.rs", 1832),
-    ("kernel/src/memory/process_memory.rs", 1836),
+    ("kernel/src/memory/process_memory.rs", 1617),
+    ("kernel/src/memory/process_memory.rs", 1656),
+    ("kernel/src/memory/process_memory.rs", 1693),
+    ("kernel/src/memory/process_memory.rs", 1705),
+    ("kernel/src/memory/process_memory.rs", 1709),
+    ("kernel/src/memory/process_memory.rs", 1713),
+    ("kernel/src/memory/process_memory.rs", 1718),
+    ("kernel/src/memory/process_memory.rs", 1785),
+    ("kernel/src/memory/process_memory.rs", 1813),
     ("kernel/src/memory/process_memory.rs", 1840),
-    ("kernel/src/memory/process_memory.rs", 1845),
-    ("kernel/src/memory/process_memory.rs", 1906),
-    ("kernel/src/memory/process_memory.rs", 1934),
-    ("kernel/src/memory/process_memory.rs", 1961),
-    ("kernel/src/memory/process_memory.rs", 1973),
-    ("kernel/src/memory/process_memory.rs", 1977),
-    ("kernel/src/memory/process_memory.rs", 1981),
-    ("kernel/src/memory/process_memory.rs", 1986),
+    ("kernel/src/memory/process_memory.rs", 1852),
+    ("kernel/src/memory/process_memory.rs", 1856),
+    ("kernel/src/memory/process_memory.rs", 1860),
+    ("kernel/src/memory/process_memory.rs", 1865),
+];
+const TABLE_RECORDER_SITES: &[(&str, usize)] = &[
+    ("kernel/src/memory/process_memory.rs", 1117),
+    ("kernel/src/memory/process_memory.rs", 1228),
+];
+const PROCESS_PAGE_TABLE_ABANDON_SITES: &[(&str, usize, &str)] = &[
+    (
+        "kernel/src/task/process_task.rs",
+        188,
+        "AbandonReason::NoProofPipeline",
+    ),
+    (
+        "kernel/src/task/process_task.rs",
+        296,
+        "AbandonReason::NoProofPipeline",
+    ),
+    (
+        "kernel/src/task/process_task.rs",
+        298,
+        "AbandonReason::NoArchPipeline",
+    ),
+    (
+        "kernel/src/task/process_task.rs",
+        480,
+        "AbandonReason::AlreadyTerminated",
+    ),
+    (
+        "kernel/src/process/manager.rs",
+        1151,
+        "AbandonReason::AlreadyTerminated",
+    ),
 ];
 const FRAME_LEDGER_INIT_CALLS: &[(&str, usize)] = &[
     ("kernel/src/main_aarch64.rs", 493),
@@ -1296,15 +1367,17 @@ const PROCESS_PAGE_TABLE_CONSTRUCTORS: &[(&str, usize)] = &[
     ("kernel/src/process/manager.rs", 144),
     ("kernel/src/process/manager.rs", 399),
     ("kernel/src/process/manager.rs", 623),
-    ("kernel/src/process/manager.rs", 2240),
-    ("kernel/src/process/manager.rs", 2506),
-    ("kernel/src/process/manager.rs", 2834),
-    ("kernel/src/process/manager.rs", 3110),
-    ("kernel/src/process/manager.rs", 3391),
+    ("kernel/src/process/manager.rs", 2242),
+    ("kernel/src/process/manager.rs", 2508),
+    ("kernel/src/process/manager.rs", 2836),
+    ("kernel/src/process/manager.rs", 3112),
+    ("kernel/src/process/manager.rs", 3393),
     ("kernel/src/syscall/handlers.rs", 1822),
-    ("kernel/src/tracing/providers/teardown.rs", 964),
-    ("kernel/src/tracing/providers/teardown.rs", 1024),
-    ("kernel/src/tracing/providers/teardown.rs", 1085),
+    ("kernel/src/tracing/providers/teardown.rs", 991),
+    ("kernel/src/tracing/providers/teardown.rs", 1051),
+    ("kernel/src/tracing/providers/teardown.rs", 1112),
+    ("kernel/src/memory/process_memory.rs", 1914),
+    ("kernel/src/memory/process_memory.rs", 1931),
 ];
 
 const BLOCKING_NAMES: &[&str] = &[
@@ -1501,6 +1574,7 @@ fn validate_frame_return_choke_point(sources: &[(String, String)]) -> Result<(),
             "remove_duplicate_candidates",
             "republish_lost_frame",
             "free_frame_count",
+            "free_list_len_for_gate",
             "take_free_frame",
             "frame_custody_refusal_gate_test",
         ],
@@ -1923,6 +1997,8 @@ fn validate_x86_frame_custody_harness(script: &str) -> Result<(), ()> {
         && verdict_spent < counter_check
         && !script.contains("grep -q '\\[BOOT_TESTS:PASS\\]'")
         && script.contains("FRAME_CUSTODY_COUNTERS:x86:double=1:stale=1:never=1:untracked=1:duplicate=3:contended=[1-9][0-9]*")
+        && script.contains("page_table_custody_disposition_gate:PASS")
+        && script.contains("recorded=2:no_proof=0:no_arch=0:terminated=1:undecided=1:exec_unreturned=0")
         && script.contains("-eq 1")
         && script.contains("x86 frame-custody gate run")
         && script.contains("BOOT_TESTS:FAIL|KERNEL PANIC|panic!"))
@@ -2004,9 +2080,263 @@ fn validate_frame_ledger_counter_inventory(provider: &str) -> Result<(), ()> {
         && EXPECTED
             .iter()
             .all(|counter| inventory.contains(&format!("&{counter},")))
-        && provider.contains("pub const COUNTER_COUNT: usize = 53;"))
+        && provider.contains("pub const COUNTER_COUNT: usize = 59;"))
     .then_some(())
     .ok_or(())
+}
+
+fn validate_process_table_recorder(sources: &[(String, String)]) -> Result<(), ()> {
+    let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
+    let mask = code_mask(process_memory);
+    for forbidden in [
+        "GlobalFrameAllocator",
+        "pub fn mapper(",
+        "pub fn allocate_stack(",
+        "fn deep_copy_pml4_entry",
+        "fn deep_copy_l3_entry",
+        "fn deep_copy_l2_entry",
+    ] {
+        if !code_offsets(process_memory, &mask, forbidden).is_empty() {
+            eprintln!("R2 process mapper escape hatch restored: {forbidden}");
+            return Err(());
+        }
+    }
+
+    validate_exact(
+        &code_sites(sources, "TableRecorder(tables)")
+            .into_iter()
+            .filter(|(path, _)| path == "kernel/src/memory/process_memory.rs")
+            .collect(),
+        TABLE_RECORDER_SITES,
+    )?;
+
+    let recorder = function_body(process_memory, "allocate_frame");
+    (recorder.contains("let lease = allocate_frame_leased()?")
+        && recorder.contains("self.0.record(lease);")
+        && recorder.contains("Some(frame)")
+        && !recorder.contains("deallocate_frame")
+        && !recorder.contains("return_lease"))
+        .then_some(())
+        .ok_or(())
+}
+
+fn validate_process_page_table_drop_is_non_freeing(
+    sources: &[(String, String)],
+) -> Result<(), ()> {
+    let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
+    let drop_body = function_body(process_memory, "drop");
+    (drop_body.contains("Disposition::Undecided")
+        && drop_body.contains("trace_count!")
+        && drop_body.contains("PT_ROOT_DROPPED_UNDECIDED")
+        && ["deallocate_frame", "return_lease", "retire_bounded"]
+            .iter()
+            .all(|forbidden| !drop_body.contains(forbidden)))
+        .then_some(())
+        .ok_or(())
+}
+
+fn validate_process_page_table_dispositions(sources: &[(String, String)]) -> Result<(), ()> {
+    let adapted_paths = [
+        "kernel/src/task/process_task.rs",
+        "kernel/src/process/manager.rs",
+    ];
+    let actual = sites_matching(sources, |line| line.contains(".abandon(AbandonReason::"))
+        .into_iter()
+        .filter(|(path, _)| adapted_paths.contains(&path.as_str()))
+        .collect();
+    let expected_sites = PROCESS_PAGE_TABLE_ABANDON_SITES
+        .iter()
+        .map(|(path, line, _)| (*path, *line))
+        .collect::<Vec<_>>();
+    validate_exact(&actual, &expected_sites)?;
+    for (path, line, reason) in PROCESS_PAGE_TABLE_ABANDON_SITES {
+        let source_line = source(sources, path).lines().nth(line - 1).ok_or(())?;
+        if !source_line.contains(reason) {
+            eprintln!("R5 abandon reason changed at {path}:{line}");
+            return Err(());
+        }
+    }
+
+    for path in adapted_paths {
+        let module = source(sources, path);
+        if !call_sites_with_argument(module, "drop", "page_table.take()").is_empty() {
+            eprintln!("R5 raw page-table drop restored in {path}");
+            return Err(());
+        }
+    }
+
+    let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
+    let bodies = module_function_bodies(process_memory);
+    let cleanup_bodies = bodies.get("cleanup_for_exec").ok_or(())?;
+    (cleanup_bodies.len() == 2
+        && cleanup_bodies.iter().all(|body| {
+            body.matches("Disposition::RetiredByExecWalk").count() == 1
+                && body.matches("PT_EXEC_WALK_LEASES_UNRETURNED").count() == 1
+        }))
+    .then_some(())
+    .ok_or(())
+}
+
+fn validate_process_page_table_counter_inventory(
+    sources: &[(String, String)],
+) -> Result<(), ()> {
+    const EXPECTED: [&str; 6] = [
+        "PT_TABLE_FRAMES_RECORDED",
+        "PT_ROOT_ABANDONED_NO_PROOF",
+        "PT_ROOT_ABANDONED_NO_ARCH",
+        "PT_ROOT_ABANDONED_TERMINATED",
+        "PT_ROOT_DROPPED_UNDECIDED",
+        "PT_EXEC_WALK_LEASES_UNRETURNED",
+    ];
+    let provider = source(sources, "kernel/src/tracing/providers/teardown.rs");
+    let expected: BTreeSet<_> = EXPECTED.into_iter().map(str::to_owned).collect();
+    let declared: BTreeSet<_> = provider
+        .split("counter!(")
+        .skip(1)
+        .filter_map(|rest| {
+            rest.trim_start()
+                .split_once(',')
+                .map(|(name, _)| name.trim())
+        })
+        .filter(|name| name.starts_with("PT_"))
+        .map(str::to_owned)
+        .collect();
+    let inventory = provider
+        .split("pub static COUNTERS")
+        .nth(1)
+        .ok_or(())?
+        .split("];")
+        .next()
+        .ok_or(())?;
+    if declared != expected
+        || !EXPECTED
+            .iter()
+            .all(|counter| inventory.contains(&format!("&{counter},")))
+        || !provider.contains("pub const COUNTER_COUNT: usize = 59;")
+    {
+        return Err(());
+    }
+    for counter in EXPECTED {
+        let declaration = provider.find(counter).ok_or(())?;
+        if provider[declaration.saturating_sub(80)..declaration].contains("#[cfg(") {
+            return Err(());
+        }
+    }
+
+    let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
+    let record = function_body(process_memory, "record");
+    let abandon = function_body(process_memory, "abandon");
+    let drop_body = function_body(process_memory, "drop");
+    let cleanup_bodies = module_function_bodies(process_memory)
+        .remove("cleanup_for_exec")
+        .ok_or(())?;
+    (record.contains("PT_TABLE_FRAMES_RECORDED")
+        && abandon.contains("PT_ROOT_ABANDONED_NO_PROOF")
+        && abandon.contains("PT_ROOT_ABANDONED_NO_ARCH")
+        && abandon.contains("PT_ROOT_ABANDONED_TERMINATED")
+        && drop_body.contains("PT_ROOT_DROPPED_UNDECIDED")
+        && cleanup_bodies.len() == 2
+        && cleanup_bodies
+            .iter()
+            .all(|body| body.contains("PT_EXEC_WALK_LEASES_UNRETURNED")))
+    .then_some(())
+    .ok_or(())
+}
+
+fn validate_process_page_table_exit_paths_are_minimal(
+    sources: &[(String, String)],
+) -> Result<(), ()> {
+    let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
+    for body in [
+        function_body(process_memory, "abandon"),
+        function_body(process_memory, "drop"),
+    ] {
+        for forbidden in [
+            "log::",
+            "serial_println!",
+            "format!",
+            "vec!",
+            "Vec::",
+            "alloc::",
+            "reserve(",
+            "try_reserve(",
+        ] {
+            if body.contains(forbidden) {
+                eprintln!("R7 page-table exit path gained {forbidden}");
+                return Err(());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_process_page_table_runtime_oracle(sources: &[(String, String)]) -> Result<(), ()> {
+    let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
+    let gate = function_body(process_memory, "page_table_custody_disposition_gate_test");
+    if !gate.contains("terminated.abandon(AbandonReason::AlreadyTerminated);")
+        || !gate.contains("drop(undecided);")
+        || !gate.contains("after_abandon[3] != start[3] + 1")
+        || !gate.contains("after_drop[4] != after_abandon[4] + 1")
+        || gate.matches("free_list_len_for_gate()").count() != 4
+        || gate.contains("&& false")
+        || gate.contains("|| true")
+    {
+        return Err(());
+    }
+
+    let registry = source(sources, "kernel/src/test_framework/registry.rs");
+    let registry_mask = code_mask(registry);
+    let registrations = identifier_offsets(
+        registry,
+        &registry_mask,
+        "page_table_custody_disposition_gate_test",
+    );
+    if registrations.len() != 1
+        || registry.contains("page_table_custody_disposition_gate_test as")
+    {
+        return Err(());
+    }
+    let test_def = enclosing_test_def(registry, &registry_mask, registrations[0]).ok_or(())?;
+    if !test_def.contains("name: \"page_table_custody_disposition_gate\"")
+        || !test_def.contains("arch: Arch::Aarch64")
+        || !test_def.contains("stage: TestStage::SerialBoot")
+    {
+        return Err(());
+    }
+
+    let memory = source(sources, "kernel/src/memory/mod.rs");
+    if code_offsets(
+        memory,
+        &code_mask(memory),
+        "process_memory::run_x86_page_table_custody_gate();",
+    )
+    .len()
+        != 1
+    {
+        return Err(());
+    }
+    let harness = repo_text("docker/qemu/run-x86-boot-tests.sh");
+    (harness.contains("page_table_custody_disposition_gate:PASS")
+        && harness.contains("recorded=2:no_proof=0:no_arch=0:terminated=1:undecided=1:exec_unreturned=0")
+        && harness.matches("page_table_custody_disposition_gate:PASS").count() == 2)
+        .then_some(())
+        .ok_or(())
+}
+
+#[test]
+fn process_page_table_custody_ratchets_are_exact() {
+    let sources = rust_sources_below("kernel/src");
+    validate_process_table_recorder(&sources).expect("R2 process mapper recorder was bypassed");
+    validate_process_page_table_drop_is_non_freeing(&sources)
+        .expect("R4 ProcessPageTable Drop gained a freeing path");
+    validate_process_page_table_dispositions(&sources)
+        .expect("R5 process page-table disposition set changed");
+    validate_process_page_table_counter_inventory(&sources)
+        .expect("R6 process page-table counter inventory changed");
+    validate_process_page_table_exit_paths_are_minimal(&sources)
+        .expect("R7 process page-table exit path gained log/format/heap work");
+    validate_process_page_table_runtime_oracle(&sources)
+        .expect("O2/G-H process page-table runtime oracle became vacuous");
 }
 
 #[test]
@@ -2056,7 +2386,7 @@ fn frame_ledger_return_and_initialization_ratchets_are_exact() {
             "counter became conditional: {counter}"
         );
     }
-    assert!(provider.contains("pub const COUNTER_COUNT: usize = 53;"));
+    assert!(provider.contains("pub const COUNTER_COUNT: usize = 59;"));
 }
 
 #[test]
@@ -2138,7 +2468,7 @@ fn v3_structural_closures_are_exact() {
     );
     assert_exact(
         sites_matching(&sources, |line| line.contains("btrt::on_process_exit(")),
-        &[("kernel/src/task/process_task.rs", 597)],
+        &[("kernel/src/task/process_task.rs", 607)],
         "btrt::on_process_exit callers",
     );
 
@@ -2313,7 +2643,7 @@ fn all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates() {
         .filter_map(|rest| rest.strip_suffix(','))
         .map(str::to_owned)
         .collect();
-    assert_eq!(declarations.len(), 53);
+    assert_eq!(declarations.len(), 59);
     assert_eq!(
         readers, declarations,
         "every counter must have an inventory reader"
@@ -2981,6 +3311,149 @@ fn deliberately_broken_variants_fail_the_ratchet() {
     let allocator = source(&sources, "kernel/src/memory/frame_allocator.rs");
     let fixture = source(&sources, "kernel/src/memory/frame_allocator_tests.rs");
     let process_memory = source(&sources, "kernel/src/memory/process_memory.rs");
+
+    // R2: the mapper allocator and deleted escape hatches cannot be restored.
+    let bypassed_recorder = process_memory.replacen(
+        "&mut TableRecorder(tables)",
+        "&mut GlobalFrameAllocator",
+        1,
+    );
+    let bypassed_recorder = with_replaced_source(
+        &sources,
+        "kernel/src/memory/process_memory.rs",
+        bypassed_recorder,
+    );
+    assert!(validate_process_table_recorder(&bypassed_recorder).is_err());
+    for restored_escape in [
+        "pub fn mapper(&mut self) {}",
+        "pub fn allocate_stack(&mut self) {}",
+        "fn deep_copy_pml4_entry() {}",
+        "fn deep_copy_l3_entry() {}",
+        "fn deep_copy_l2_entry() {}",
+    ] {
+        let restored = with_replaced_source(
+            &sources,
+            "kernel/src/memory/process_memory.rs",
+            format!("{process_memory}\n{restored_escape}"),
+        );
+        assert!(validate_process_table_recorder(&restored).is_err());
+    }
+
+    // R4: ProcessPageTable's Drop can count but can never return a frame.
+    let freeing_drop = process_memory.replacen(
+        "fn drop(&mut self) {",
+        "fn drop(&mut self) { crate::memory::frame_allocator::deallocate_frame(self.level_4_frame);",
+        1,
+    );
+    let freeing_drop = with_replaced_source(
+        &sources,
+        "kernel/src/memory/process_memory.rs",
+        freeing_drop,
+    );
+    assert!(validate_process_page_table_drop_is_non_freeing(&freeing_drop).is_err());
+
+    // R5: bare, block-wrapped, and qualified raw drops are all rejected.
+    for raw_drop in [
+        "drop(process.page_table.take());",
+        "drop({ process.page_table.take() });",
+        "core::mem::drop((process.page_table.take()));",
+    ] {
+        let process_task = source(&sources, "kernel/src/task/process_task.rs");
+        let raw_drop = with_replaced_source(
+            &sources,
+            "kernel/src/task/process_task.rs",
+            format!("{process_task}\nfn synthetic_raw_drop(process: &mut Process) {{ {raw_drop} }}"),
+        );
+        assert!(validate_process_page_table_dispositions(&raw_drop).is_err());
+    }
+    let process_task = source(&sources, "kernel/src/task/process_task.rs");
+    let wrong_reason = process_task.replacen(
+        "page_table.abandon(AbandonReason::AlreadyTerminated);",
+        "page_table.abandon(AbandonReason::NoProofPipeline);",
+        1,
+    );
+    let wrong_reason = with_replaced_source(
+        &sources,
+        "kernel/src/task/process_task.rs",
+        wrong_reason,
+    );
+    assert!(validate_process_page_table_dispositions(&wrong_reason).is_err());
+    let missing_exec_disposition = process_memory.replacen(
+        "self.tables.disposition = Disposition::RetiredByExecWalk;",
+        "self.tables.disposition = Disposition::Undecided;",
+        1,
+    );
+    let missing_exec_disposition = with_replaced_source(
+        &sources,
+        "kernel/src/memory/process_memory.rs",
+        missing_exec_disposition,
+    );
+    assert!(validate_process_page_table_dispositions(&missing_exec_disposition).is_err());
+
+    // R6: inventory membership and unconditional declarations are both pinned.
+    let provider = source(&sources, "kernel/src/tracing/providers/teardown.rs");
+    let missing_pt_reader = provider.replacen("    &PT_ROOT_DROPPED_UNDECIDED,\n", "", 1);
+    let missing_pt_reader = with_replaced_source(
+        &sources,
+        "kernel/src/tracing/providers/teardown.rs",
+        missing_pt_reader,
+    );
+    assert!(validate_process_page_table_counter_inventory(&missing_pt_reader).is_err());
+    let conditional_pt_counter = provider.replacen(
+        "counter!(PT_TABLE_FRAMES_RECORDED,",
+        "#[cfg(target_arch = \"aarch64\")]\ncounter!(PT_TABLE_FRAMES_RECORDED,",
+        1,
+    );
+    let conditional_pt_counter = with_replaced_source(
+        &sources,
+        "kernel/src/tracing/providers/teardown.rs",
+        conditional_pt_counter,
+    );
+    assert!(validate_process_page_table_counter_inventory(&conditional_pt_counter).is_err());
+
+    // R7: neither explicit disposition path may gain formatting or heap work.
+    let logged_abandon = process_memory.replacen(
+        "pub(crate) fn abandon(mut self, reason: AbandonReason) {",
+        "pub(crate) fn abandon(mut self, reason: AbandonReason) { log::info!(\"abandon\");",
+        1,
+    );
+    let logged_abandon = with_replaced_source(
+        &sources,
+        "kernel/src/memory/process_memory.rs",
+        logged_abandon,
+    );
+    assert!(validate_process_page_table_exit_paths_are_minimal(&logged_abandon).is_err());
+    let allocating_drop = process_memory.replacen(
+        "fn drop(&mut self) {",
+        "fn drop(&mut self) { let _unexpected = Vec::<u8>::new();",
+        1,
+    );
+    let allocating_drop = with_replaced_source(
+        &sources,
+        "kernel/src/memory/process_memory.rs",
+        allocating_drop,
+    );
+    assert!(validate_process_page_table_exit_paths_are_minimal(&allocating_drop).is_err());
+
+    // O2/G-H: weaken either exact counter assertion and the named validator fails.
+    for (needle, replacement) in [
+        (
+            "after_abandon[3] != start[3] + 1",
+            "after_abandon[3] != start[3] + 1 && false",
+        ),
+        (
+            "after_drop[4] != after_abandon[4] + 1",
+            "after_drop[4] != after_abandon[4] + 1 && false",
+        ),
+    ] {
+        let weakened = process_memory.replacen(needle, replacement, 1);
+        let weakened = with_replaced_source(
+            &sources,
+            "kernel/src/memory/process_memory.rs",
+            weakened,
+        );
+        assert!(validate_process_page_table_runtime_oracle(&weakened).is_err());
+    }
 
     // R1: seven syntactically distinct ways to bypass the return choke point.
     for insertion in [


### PR DESCRIPTION
## Summary

PR-1b of the ratified DESIGN-470-v2 (plan 1a/1b/1c toward #470) — the address-space custody record.

- Every process page-table frame is now leased at allocation via `TableRecorder`/`OwnedTableFrames`, the *only* allocator handed to a process mapper (`map_page`/`update_page_flags`).
- Every `ProcessPageTable` root drop on both arches is classified — either `RetiredByExecWalk` (superseded by an exec walk) or an explicit `abandon(reason)` (`NoProofPipeline` / `NoArchPipeline` / `AlreadyTerminated`) — and counted **unconditionally**, in every build, not just `boot_tests` builds.
- The non-freeing `Drop` backstop only matches the disposition and increments a counter; it cannot free (`FrameLease: Copy`, no frame-owning `Drop` on `Vec<FrameLease>` or `OffsetPageTable`).
- Six new unconditional production counters (`PT_TABLE_FRAMES_RECORDED`, `PT_ROOT_ABANDONED_NO_PROOF`, `PT_ROOT_ABANDONED_NO_ARCH`, `PT_ROOT_ABANDONED_TERMINATED`, `PT_ROOT_DROPPED_UNDECIDED`, `PT_EXEC_WALK_LEASES_UNRETURNED`) turn the #470 leak into a measured production number instead of a suspected one.
- Dead escape hatches deleted: `mapper()`, `allocate_stack()`, and the three dead `deep_copy_*` helpers — and ratcheted gone (R2).

**Freeing behaviour is untouched. This PR is behaviour-preserving by construction:** `git diff -U0 origin/main...HEAD -- kernel/src | rg '^\+.*\b(deallocate_frame|return_lease)\('` produces no output (R1-proven, zero deallocate/return calls added anywhere in the diff). x86 and aarch64 both keep leaking exactly the frames main leaks today — the difference is that the leak is now counted.

Part of #470. **This is PR-1b only — it does NOT close #470.** PR-1c (aarch64 retirement), PR-2 (leaf/exec custody), and PR-3 (x86 liveness) remain.

## Evidence

### aarch64 — runtime-executed
- `cargo test --test teardown_structure`: 12/12 green, including `process_page_table_custody_ratchets_are_exact` and `deliberately_broken_variants_fail_the_ratchet`.
- `run-aarch64-full-test.sh --boot-tests-only --rebuild`: 92/92, `[BOOT_TESTS:PASS]`, `[TEST:process:frame_custody_refusal_gate:PASS]`, `[TEST:process:page_table_custody_disposition_gate:PASS]`, `[TEST:process:frame_custody_healthy_counters:PASS]` (the late zero-unexpected-refusal check, run after the injection window).
- 8 oracle mutations executed against the real tree and reverted (R2 recorder-bypass, R4 freeing `Drop`, three R5 raw-drop spellings, R6 counter-inventory swap, R7 `log::info!` in `abandon`, O2/G and O2/H counter mis-wiring) — every one FAILs its ratchet/gate as designed, every restoration PASSes. Full transcripts in the campaign record.
- Review round 1 (independent re-verification): sound — no mechanism-correctness defect, no hot-path violation, no campaign-invariant breach, no dishonest claim; the beast gate's cfg-gating suspicion was investigated and **refuted** (the six counter increments carry no `cfg`; only the three `boot_tests` reader/gate functions do, which is exactly what the design permits).
- Beast x86 gate: 3/3 clean runs, 0/100 clean-host runs, 0/100 starved runs (14-hog contention) — `FRAME_RETURN_REFUSED_DOUBLE=0` and `FRAME_DUPLICATE_ALLOC_REFUSED=0` across all three gate cycles (never present in any serial, i.e. never fired).
- Parallels: 3/3 long-window boots (196, 196, 207 heartbeats), zero fault markers, each from a force-stopped VM with a truncated serial log per the #525-established gate requirement.

### x86 — honest limitation
Beast kthread mode ran 3/3 clean, zero refusals. **`PT_ROOT_ABANDONED_*` is absent from those serials — expected, not a failure**: kthread mode builds `kthread_test_only` and never spawns or exits a userspace process, so the disposition counters are structurally unobservable in that mode. x86 does not currently have a boot-test gate mode that spawns/exits processes with counter visibility (`mode=full` hangs — pre-existing gap in `kernel/src/task/completion.rs`, which is missing the x86_64 timeout the aarch64 path has). That gap is filed as #540.

Given that harness gap, the x86 disposition-counter wiring in this PR is verified by:
1. **Code review** — the same `abandon`/`Drop`/`TableRecorder` code paths are shared across both arches (only the two root-lease sites and the conditional PML4[0] PDPT lease are arch-specific), verified line-by-line in review round 1.
2. **x86 release build** (`testing,external_test_bins`) and **x86 `boot_tests`-feature build**, both zero warnings/errors.
3. **aarch64 runtime parity** — the shared code that increments the counters is proven to fire correctly on a real boot on the other architecture.

x86 runtime observation of the disposition counters firing in production remains open until #540 is fixed; that is a harness limitation, not a defect in this PR's code.

## Deviation record (live, all disclosed)

1. **Deferred-reclaim root gets an interim explicit disposition.** `PendingProcessReclaim::reclaim` calls `abandon(NoProofPipeline)` until PR-1c connects the proof-discharged path to `retire_bounded`. Justification: every production root destruction must be classified; leaving this path `Undecided` would make the CI-asserted-zero backstop counter nonzero by construction. The interim call performs one atomic increment and returns no frame — the leak is unchanged.
2. **Counter total is 59, not 58.** The six PR-1b counters move the inventory from 53 to 59 because merged PR-1a already shipped the binding TRAP-LIST-1a MT-5c sixth frame-ledger counter; this is the mandated downstream shift, not a PR-1b addition beyond the six documented here.
3. **G/H are an adjacent architecture-exclusive gate**, not a single `Arch::Any` registration. This preserves PR-1a's deterministic serial boot-test scheduling and architecture-exclusive dispatch; the x86 harness pins the exact marker and counter vector and prevents double execution.

## Response to review round 1 non-blocking findings

Full review: `/private/tmp/claude-501/.../scratchpad/470pr1b/1b-review-r1.md`. Verdict: no mechanism-correctness defect, no hot-path violation, no campaign-invariant breach, no dishonest claim. Designated mutation set fully covered (12/12 green). Everything below is disclosure/completeness/forward-risk, not a defect requiring code changes in this PR.

- **F1 — a failed exec drops the superseded root `Undecided` (unclassified).** True: `exec_process` takes the old root before the new root's fallible construction, so an exec failure mid-construction drops `old_page_table` as `Undecided`, incrementing the CI-asserted-zero `PT_ROOT_DROPPED_UNDECIDED`. Behaviourally identical to main (the root leaked then too) — this is a completeness gap in the classification, not a new leak or a mechanism defect. Disclosed here as a residual: PR-1c's cohort floor on this counter must account for exec-construction-failure as a legitimate nonzero producer, or a follow-up should classify this path explicitly before that floor lands.
- **F2 — `pending_old_page_tables.clear()` drops roots `Undecided`, unseen by R5.** True in the two `already_terminated` arms that clear without draining first; the third site is vacuous (already drained). R5's raw-drop detector only matches `drop(page_table.take())` call shapes, so it structurally cannot see a `Vec::clear()` teardown. Disclosed as a residual for #537 (ratchet coverage) — not blocking because the arm's reachability is already flagged by the design as having no liveness evidence today.
- **F3 — the x86 gate has never been executed; its hard-coded expectations (e.g. `recorded=2`) are unverified predictions.** Accurate, and disclosed plainly above rather than claimed as proven. The gate is fail-loud (`assert!` inside `memory::init`, `set -euo pipefail`) so a wrong prediction surfaces immediately rather than silently — but the counter-visibility gap (#540) means nobody has run it yet on this branch. Flagged, not fixed in this PR; #540 is the tracked path to closing it.
- **F10 — three deviation-record omissions** (R1 boot-fixture allowlist widened for `free_list_len_for_gate`; `allocate_frame_leased` moved onto the production process-creation path and is no longer `boot_tests`-only, now `pub(crate)` with a fail-loud ledger-init assert; the x86 counter vector is an injection-time checkpoint before any process exists, not a post-cohort read). All three are accurate and are disclosed here rather than left implicit. None change behaviour or freeing; the second is arguably the correct fail-loud choice per the campaign's hardening bias, stated honestly rather than silently retiring PR-1a's "boot_tests-only" claim.

`[hardening]`-tagged findings (F4–F9, F11–F13 minus F10, which is disclosure not hardening) are novel-evasion/ratchet-shape observations out of this bounded review's bar — appended verbatim to issue #537 as tracked follow-up, not addressed in this PR.

## Verification

- `cargo test --test teardown_structure`: 12/12 passed
- x86 release check (`testing,external_test_bins`): zero warnings/errors
- x86 boot-test-feature check: zero warnings/errors
- aarch64 release build, with and without `boot_tests`: passed (only the excluded upstream `core v0.0.0` future-incompatibility notice)
- `run-aarch64-full-test.sh --boot-tests-only --rebuild`: 92/92, `[BOOT_TESTS:PASS]`
- Beast x86 gate: 3/3 clean, 0/100 clean-host, 0/100 starved (14-hog)
- Parallels: 3/3 long-window green (196/196/207 heartbeats), zero fault markers
- Final QEMU cleanup: no processes remain

## Revert

Total and clean: this PR adds new types, counters, and classification calls but changes no freeing behaviour and deletes only dead code. `git revert` of the merge commit applies cleanly against a synced main (dry-run verified before merge).

## Residual work

#470 still owes PR-1c (aarch64 retirement), PR-2 (leaf/exec custody), and PR-3 (x86 liveness retirement + closing #540's harness gap). This PR deliberately returns no additional frame.
