### PR TITLE
fix(mm): aarch64 retire process page-table roots from recorded custody — closes #470-F3 aarch64 leak (#470 PR-1c)

### DIFF
--- a/docker/qemu/run-x86-boot-tests.sh
+++ b/docker/qemu/run-x86-boot-tests.sh
@@ -51,7 +51,7 @@ for i in $(seq 1 "$COUNT"); do
                 "$OUTPUT_DIR"/serial_*.txt 2>/dev/null \
             && grep -q '\[TEST:process:page_table_custody_disposition_gate:PASS\]' \
                 "$OUTPUT_DIR"/serial_*.txt 2>/dev/null \
-            && grep -q '\[PT_CUSTODY_COUNTERS:x86:recorded=2:no_proof=0:no_arch=0:terminated=1:undecided=1:exec_unreturned=0\]' \
+            && grep -q '\[PT_CUSTODY_COUNTERS:x86:recorded=3:no_proof=0:no_arch=1:terminated=1:undecided=1:exec_unreturned=0\]' \
                 "$OUTPUT_DIR"/serial_*.txt 2>/dev/null; then
             passed=true
             break

--- a/kernel/src/memory/frame_allocator.rs
+++ b/kernel/src/memory/frame_allocator.rs
@@ -144,7 +144,7 @@ impl FrameLease {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ReturnOutcome {
+pub(crate) enum ReturnOutcome {
     Returned,
     LostContended,
     RefusedDoubleRelease,
@@ -669,7 +669,7 @@ fn counted(outcome: ReturnOutcome) -> ReturnOutcome {
     outcome
 }
 
-fn return_lease(lease: FrameLease) -> ReturnOutcome {
+pub(crate) fn return_lease(lease: FrameLease) -> ReturnOutcome {
     let Some(ledger) = FRAME_LEDGER.get() else {
         let Some(mut bootstrap) = BOOTSTRAP_FREE_FRAMES.try_lock() else {
             return counted(ReturnOutcome::LostContended);
@@ -773,6 +773,10 @@ pub fn deallocate_frame(frame: PhysFrame) {
 #[cfg(feature = "boot_tests")]
 #[path = "frame_allocator_tests.rs"]
 mod boot_tests;
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub(crate) use boot_tests::republish_frame_for_gate;
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+pub(crate) use boot_tests::retire_with_free_list_contended;
 #[cfg(all(feature = "boot_tests", target_arch = "x86_64"))]
 pub use boot_tests::run_x86_frame_custody_gate;
 #[cfg(feature = "boot_tests")]

--- a/kernel/src/memory/frame_allocator_tests.rs
+++ b/kernel/src/memory/frame_allocator_tests.rs
@@ -26,6 +26,21 @@ fn republish_lost_frame(frame: PhysFrame) -> bool {
     true
 }
 
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn republish_frame_for_gate(frame: PhysFrame) -> bool {
+    republish_lost_frame(frame)
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn retire_with_free_list_contended(
+    page_table: &mut crate::memory::process_memory::ProcessPageTable,
+    pid: u64,
+    budget: &mut u32,
+) -> crate::memory::process_memory::RetireProgress {
+    let _free_list = FREE_FRAMES.lock();
+    page_table.retire_bounded(pid, budget)
+}
+
 fn restore_lease(lease: FrameLease) -> bool {
     match return_lease(lease) {
         ReturnOutcome::Returned => true,

--- a/kernel/src/memory/process_memory.rs
+++ b/kernel/src/memory/process_memory.rs
@@ -10,6 +10,8 @@ use crate::memory::arch_stub::{
 #[cfg(target_arch = "aarch64")]
 use crate::memory::frame_allocator::allocate_frame;
 use crate::memory::frame_allocator::{allocate_frame_leased, FrameLease};
+#[cfg(target_arch = "aarch64")]
+use crate::memory::frame_allocator::{return_lease, ReturnOutcome};
 use crate::memory::layout::USER_STACK_REGION_END;
 #[cfg(target_arch = "x86_64")]
 use x86_64::{
@@ -84,7 +86,7 @@ pub struct ProcessPageTable {
     mapper: OffsetPageTable<'static>,
     /// Allocator authority for the root. PR-1c consumes this after proving the
     /// address space is no longer live; PR-1b intentionally never returns it.
-    #[allow(dead_code)]
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
     root_lease: FrameLease,
     /// Allocation-derived custody for every intermediate table we created.
     tables: OwnedTableFrames,
@@ -123,9 +125,23 @@ unsafe impl FrameAllocator<Size4KiB> for TableRecorder<'_> {
 #[derive(Clone, Copy)]
 enum Disposition {
     Undecided,
+    #[cfg(target_arch = "aarch64")]
+    Retiring,
+    #[cfg(target_arch = "aarch64")]
+    Retired,
     RetiredByExecWalk,
     Abandoned(AbandonReason),
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg(target_arch = "aarch64")]
+pub(crate) enum RetireProgress {
+    Complete,
+    Budgeted,
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) const RETIRE_FRAME_BUDGET: u32 = 64;
 
 #[derive(Clone, Copy)]
 pub(crate) enum AbandonReason {
@@ -1543,6 +1559,66 @@ impl ProcessPageTable {
         }
     }
 
+    /// Return only allocator-issued table leases after the caller has proved
+    /// this address space is no longer live. Work is resumable and the root is
+    /// always attempted last, after every intermediate-table lease is consumed.
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn retire_bounded(&mut self, pid: u64, budget: &mut u32) -> RetireProgress {
+        match self.tables.disposition {
+            Disposition::Retired => return RetireProgress::Complete,
+            Disposition::Undecided => {
+                crate::tracing::providers::teardown::record_pt_retire_started(
+                    pid,
+                    self.tables.leases.len() as u64,
+                );
+                self.tables.disposition = Disposition::Retiring;
+            }
+            Disposition::Retiring => {}
+            Disposition::RetiredByExecWalk | Disposition::Abandoned(_) => {
+                return RetireProgress::Complete;
+            }
+        }
+
+        while *budget > 0 {
+            *budget -= 1;
+            let outcome = match self.tables.leases.pop() {
+                Some(lease) => return_lease(lease),
+                None => {
+                    let outcome = return_lease(self.root_lease);
+                    match outcome {
+                        ReturnOutcome::Returned => {
+                            crate::tracing::providers::teardown::record_pt_frame_returned(pid)
+                        }
+                        ReturnOutcome::LostContended => {
+                            crate::tracing::providers::teardown::record_pt_frame_lost(pid)
+                        }
+                        ReturnOutcome::RefusedDoubleRelease
+                        | ReturnOutcome::RefusedStale
+                        | ReturnOutcome::RefusedNeverAllocated
+                        | ReturnOutcome::RefusedUntracked => {}
+                    }
+                    self.tables.disposition = Disposition::Retired;
+                    crate::tracing::providers::teardown::record_pt_root_retired(pid);
+                    return RetireProgress::Complete;
+                }
+            };
+            match outcome {
+                ReturnOutcome::Returned => {
+                    crate::tracing::providers::teardown::record_pt_frame_returned(pid)
+                }
+                ReturnOutcome::LostContended => {
+                    crate::tracing::providers::teardown::record_pt_frame_lost(pid)
+                }
+                ReturnOutcome::RefusedDoubleRelease
+                | ReturnOutcome::RefusedStale
+                | ReturnOutcome::RefusedNeverAllocated
+                | ReturnOutcome::RefusedUntracked => {}
+            }
+        }
+
+        RetireProgress::Budgeted
+    }
+
     /// Clean up page table resources during exec()
     ///
     /// This walks the entire page table hierarchy and:
@@ -1881,6 +1957,14 @@ impl Drop for ProcessPageTable {
             Disposition::Undecided => {
                 crate::trace_count!(crate::tracing::providers::teardown::PT_ROOT_DROPPED_UNDECIDED);
             }
+            #[cfg(target_arch = "aarch64")]
+            Disposition::Retiring => {
+                crate::trace_count!(
+                    crate::tracing::providers::teardown::PT_ROOT_DROPPED_MID_RETIRE
+                );
+            }
+            #[cfg(target_arch = "aarch64")]
+            Disposition::Retired => {}
             Disposition::RetiredByExecWalk => {}
             Disposition::Abandoned(reason) => match reason {
                 AbandonReason::NoProofPipeline
@@ -1910,6 +1994,39 @@ pub fn page_table_custody_disposition_gate_test() -> crate::test_framework::regi
     use crate::test_framework::registry::TestResult;
 
     let start = disposition_gate_counters();
+
+    // O2/E: hold the real reuse-pool lock across real retirement. The ledger
+    // transition commits ST_FREE, retirement reports loss rather than a
+    // corruption refusal, and the fixture repairs the deliberately lost root.
+    #[cfg(target_arch = "aarch64")]
+    {
+        use crate::tracing::providers::teardown;
+
+        let mut contended = match ProcessPageTable::new() {
+            Ok(page_table) => page_table,
+            Err(_) => return TestResult::Fail("E: page-table construction failed"),
+        };
+        let root = contended.level_4_frame();
+        let free_before = crate::memory::frame_allocator::free_list_len_for_gate();
+        let returned_before = teardown::PT_TABLE_FRAMES_RETURNED.aggregate();
+        let lost_before = teardown::PT_RETIRE_FRAMES_LOST.aggregate();
+        let retired_before = teardown::PT_ROOTS_RETIRED.aggregate();
+        let mut budget = RETIRE_FRAME_BUDGET;
+        if crate::memory::frame_allocator::retire_with_free_list_contended(
+            &mut contended,
+            u64::MAX - 1,
+            &mut budget,
+        ) != RetireProgress::Complete
+            || teardown::PT_TABLE_FRAMES_RETURNED.aggregate() != returned_before
+            || teardown::PT_RETIRE_FRAMES_LOST.aggregate() != lost_before + 1
+            || teardown::PT_ROOTS_RETIRED.aggregate() != retired_before + 1
+            || crate::memory::frame_allocator::free_list_len_for_gate() != free_before
+            || !crate::memory::frame_allocator::republish_frame_for_gate(root)
+            || crate::memory::frame_allocator::free_list_len_for_gate() != free_before + 1
+        {
+            return TestResult::Fail("E: retirement contention was not isolated and repaired");
+        }
+    }
 
     let terminated = match ProcessPageTable::new() {
         Ok(page_table) => page_table,
@@ -1943,6 +2060,26 @@ pub fn page_table_custody_disposition_gate_test() -> crate::test_framework::regi
         || crate::memory::frame_allocator::free_list_len_for_gate() != free_before_drop
     {
         return TestResult::Fail("H: undecided Drop was not isolated and non-freeing");
+    }
+
+    // O3 x86 residual direction: without an architecture proof pipeline the
+    // same custody object must be counted and must return no table frame.
+    #[cfg(target_arch = "x86_64")]
+    {
+        let no_arch = match ProcessPageTable::new() {
+            Ok(page_table) => page_table,
+            Err(_) => return TestResult::Fail("O3: page-table construction failed"),
+        };
+        let returned_before =
+            crate::tracing::providers::teardown::PT_TABLE_FRAMES_RETURNED.aggregate();
+        no_arch.abandon(AbandonReason::NoArchPipeline);
+        let after_no_arch = disposition_gate_counters();
+        if after_no_arch[2] != after_drop[2] + 1
+            || crate::tracing::providers::teardown::PT_TABLE_FRAMES_RETURNED.aggregate()
+                != returned_before
+        {
+            return TestResult::Fail("O3: x86 residual abandonment returned a table frame");
+        }
     }
 
     TestResult::Pass

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -77,6 +77,7 @@ pub(crate) struct PendingProcessReclaim {
     last_pass: u32,
     proof_failures: u8,
     parked: Option<ParkRecord>,
+    leaves_released: bool,
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -177,16 +178,28 @@ impl PendingProcessReclaim {
         })
     }
 
-    fn reclaim(mut self) {
-        if let Some(page_table) = self.page_table.as_ref() {
-            crate::process::process::cleanup_cow_page_table(page_table);
+    fn reclaim_bounded(&mut self) -> crate::memory::process_memory::RetireProgress {
+        use crate::memory::process_memory::{RetireProgress, RETIRE_FRAME_BUDGET};
+
+        if !self.leaves_released {
+            if let Some(page_table) = self.page_table.as_ref() {
+                crate::process::process::cleanup_cow_page_table(page_table);
+            }
+            for old_page_table in self.old_page_tables.drain(..) {
+                old_page_table.cleanup_for_exec();
+            }
+            self.leaves_released = true;
         }
-        for old_page_table in self.old_page_tables.drain(..) {
-            old_page_table.cleanup_for_exec();
+
+        let Some(page_table) = self.page_table.as_mut() else {
+            return RetireProgress::Complete;
+        };
+        let mut budget = RETIRE_FRAME_BUDGET;
+        let progress = page_table.retire_bounded(self.pid, &mut budget);
+        if progress == RetireProgress::Complete {
+            self.page_table = None;
         }
-        if let Some(page_table) = self.page_table.take() {
-            page_table.abandon(AbandonReason::NoProofPipeline);
-        }
+        progress
     }
 }
 
@@ -360,6 +373,7 @@ pub(crate) fn defer_process_resources(
         last_pass: 0,
         proof_failures: 0,
         parked: None,
+        leaves_released: false,
     }
 }
 
@@ -939,9 +953,17 @@ fn reclaim_deferred_process_resources_for_pass(my_pass: u32, boot_test_owned: bo
                             PENDING_PROCESS_RECLAIMS.lock().push(reclaim)
                         });
                     }
-                } else {
+                } else if reclaim.reclaim_bounded()
+                    == crate::memory::process_memory::RetireProgress::Complete
+                {
                     crate::tracing::providers::teardown::record_reclaim(reclaim.pid);
-                    reclaim.reclaim();
+                } else {
+                    crate::trace_count!(
+                        crate::tracing::providers::teardown::PT_RETIRE_BUDGET_REQUEUED
+                    );
+                    crate::arch_without_interrupts(|| {
+                        PENDING_PROCESS_RECLAIMS.lock().push(reclaim)
+                    });
                 }
             }
             None => break,
@@ -1023,7 +1045,36 @@ fn boot_test_reclaim(pid: u64) -> PendingProcessReclaim {
         last_pass: 0,
         proof_failures: 0,
         parked: None,
+        leaves_released: false,
     }
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_oversized_page_table(
+) -> Result<alloc::boxed::Box<crate::memory::process_memory::ProcessPageTable>, &'static str> {
+    use crate::memory::arch_stub::{Page, PageTableFlags, Size4KiB, VirtAddr};
+    use crate::memory::frame_allocator::{allocate_frame, deallocate_frame};
+
+    let mut page_table = alloc::boxed::Box::new(
+        crate::memory::process_memory::ProcessPageTable::new()
+            .map_err(|_| "oversized root allocation failed")?,
+    );
+    let flags =
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE;
+    for l0_index in 0..22u64 {
+        let page =
+            Page::<Size4KiB>::containing_address(VirtAddr::new((l0_index << 39) | 0x0040_0000));
+        let frame = allocate_frame().ok_or("oversized leaf allocation failed")?;
+        if page_table.map_page(page, frame, flags).is_err() {
+            deallocate_frame(frame);
+            return Err("oversized sentinel mapping failed");
+        }
+        let leaf = page_table
+            .unmap_page(page)
+            .map_err(|_| "oversized sentinel unmap failed")?;
+        deallocate_frame(leaf);
+    }
+    Ok(page_table)
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
@@ -1384,6 +1435,92 @@ pub fn reclaim_progress_gate_test() -> crate::test_framework::registry::TestResu
             != 8
     {
         return TestResult::Fail("pass cursor acted as a reclaim cap");
+    }
+
+    // O2/F: 22 distinct L0 subtrees force 66 recorded tables. The production
+    // drain must return exactly 64 frames, requeue through last_pass, re-prove
+    // next pass, and commit the remaining two tables plus root.
+    let oversized_pid = BOOT_RECLAIM_PID_BASE + 100;
+    let mut oversized = boot_test_reclaim(oversized_pid);
+    oversized.page_table = match boot_oversized_page_table() {
+        Ok(page_table) => Some(page_table),
+        Err(message) => return TestResult::Fail(message),
+    };
+    let budget_before = trace::PT_RETIRE_BUDGET_REQUEUED.aggregate();
+    let returned_before = trace::PT_TABLE_FRAMES_RETURNED.aggregate();
+    let roots_before = trace::PT_ROOTS_RETIRED.aggregate();
+    let reclaimed_before = trace::TEARDOWN_RECLAIM.aggregate();
+    crate::arch_without_interrupts(|| PENDING_PROCESS_RECLAIMS.lock().push(oversized));
+    boot_reclaim_deferred_process_resources();
+    if trace::PT_RETIRE_BUDGET_REQUEUED
+        .aggregate()
+        .saturating_sub(budget_before)
+        != 1
+        || trace::PT_TABLE_FRAMES_RETURNED
+            .aggregate()
+            .saturating_sub(returned_before)
+            != 64
+        || trace::PT_ROOTS_RETIRED.aggregate() != roots_before
+        || trace::TEARDOWN_RECLAIM.aggregate() != reclaimed_before
+        || boot_reclaim_locations(oversized_pid) != (true, false)
+    {
+        return TestResult::Fail("F: oversized retirement did not requeue at exactly 64 frames");
+    }
+    boot_reclaim_deferred_process_resources();
+    if trace::PT_RETIRE_BUDGET_REQUEUED.aggregate() != budget_before + 1
+        || trace::PT_TABLE_FRAMES_RETURNED
+            .aggregate()
+            .saturating_sub(returned_before)
+            != 67
+        || trace::PT_ROOTS_RETIRED.aggregate() != roots_before + 1
+        || trace::TEARDOWN_RECLAIM.aggregate() != reclaimed_before + 1
+        || boot_reclaim_locations(oversized_pid) != (false, false)
+    {
+        return TestResult::Fail("F: oversized retirement did not complete after re-proof");
+    }
+
+    // O2/I: dropping an intentionally interrupted retirement counts the root
+    // still in custody and never retries an already-popped lease.
+    let mut interrupted = match boot_oversized_page_table() {
+        Ok(page_table) => page_table,
+        Err(message) => return TestResult::Fail(message),
+    };
+    let mid_before = trace::PT_ROOT_DROPPED_MID_RETIRE.aggregate();
+    let double_before = trace::FRAME_RETURN_REFUSED_DOUBLE.aggregate();
+    let mut budget = crate::memory::process_memory::RETIRE_FRAME_BUDGET;
+    if interrupted.retire_bounded(BOOT_RECLAIM_PID_BASE + 101, &mut budget)
+        != crate::memory::process_memory::RetireProgress::Budgeted
+    {
+        return TestResult::Fail("I: oversized retirement did not stop at its budget");
+    }
+    drop(interrupted);
+    if trace::PT_ROOT_DROPPED_MID_RETIRE.aggregate() != mid_before + 1
+        || trace::FRAME_RETURN_REFUSED_DOUBLE.aggregate() != double_before
+    {
+        return TestResult::Fail("I: interrupted retirement did not fail closed");
+    }
+
+    // O2/J: completion is terminal; a second call has no accounting effect.
+    let mut completed = match crate::memory::process_memory::ProcessPageTable::new() {
+        Ok(page_table) => page_table,
+        Err(_) => return TestResult::Fail("J: page-table construction failed"),
+    };
+    let mut budget = crate::memory::process_memory::RETIRE_FRAME_BUDGET;
+    if completed.retire_bounded(BOOT_RECLAIM_PID_BASE + 102, &mut budget)
+        != crate::memory::process_memory::RetireProgress::Complete
+    {
+        return TestResult::Fail("J: initial root retirement did not complete");
+    }
+    let returned_after_complete = trace::PT_TABLE_FRAMES_RETURNED.aggregate();
+    let roots_after_complete = trace::PT_ROOTS_RETIRED.aggregate();
+    let lost_after_complete = trace::PT_RETIRE_FRAMES_LOST.aggregate();
+    if completed.retire_bounded(BOOT_RECLAIM_PID_BASE + 102, &mut budget)
+        != crate::memory::process_memory::RetireProgress::Complete
+        || trace::PT_TABLE_FRAMES_RETURNED.aggregate() != returned_after_complete
+        || trace::PT_ROOTS_RETIRED.aggregate() != roots_after_complete
+        || trace::PT_RETIRE_FRAMES_LOST.aggregate() != lost_after_complete
+    {
+        return TestResult::Fail("J: completed retirement was not idempotent");
     }
     if trace::RECLAIM_PARK_RESIDENT.aggregate() != resident_before
         || trace::PROOF_UNDER_QUEUE_LOCK.aggregate() != proof_lock_before

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -422,8 +422,14 @@ counter!(
     FRAME_RETURN_REFUSED_NEVER_ALLOCATED,
     "Never-allocated frame returns refused"
 );
-counter!(FRAME_RETURN_REFUSED_UNTRACKED, "Untracked frame returns refused");
-counter!(FRAME_DUPLICATE_ALLOC_REFUSED, "Duplicate frame allocations refused");
+counter!(
+    FRAME_RETURN_REFUSED_UNTRACKED,
+    "Untracked frame returns refused"
+);
+counter!(
+    FRAME_DUPLICATE_ALLOC_REFUSED,
+    "Duplicate frame allocations refused"
+);
 counter!(FRAME_LOST_CONTENDED, "Frame returns lost to contention");
 counter!(PT_TABLE_FRAMES_RECORDED, "Process table frames recorded");
 counter!(
@@ -445,6 +451,23 @@ counter!(
 counter!(
     PT_EXEC_WALK_LEASES_UNRETURNED,
     "Recorded table leases consumed by the legacy exec walk"
+);
+counter!(PT_ROOTS_RETIRED, "Process roots retired after proof");
+counter!(
+    PT_TABLE_FRAMES_RETURNED,
+    "Recorded process table frames returned"
+);
+counter!(
+    PT_RETIRE_FRAMES_LOST,
+    "Process table retirement frames lost to contention"
+);
+counter!(
+    PT_ROOT_DROPPED_MID_RETIRE,
+    "Process roots dropped during bounded retirement"
+);
+counter!(
+    PT_RETIRE_BUDGET_REQUEUED,
+    "Process table retirements requeued at the frame budget"
 );
 
 // Declaration-only until the phase named in PLAN.md. These intentionally have
@@ -474,7 +497,7 @@ counter!(
     "Fatal group signals dropped for init"
 );
 
-pub const COUNTER_COUNT: usize = 59;
+pub const COUNTER_COUNT: usize = 64;
 
 /// The registration and normal-context reader inventory. Keeping one inventory
 /// makes a write-only counter structurally impossible without changing the P0
@@ -525,6 +548,11 @@ pub static COUNTERS: [&TraceCounter; COUNTER_COUNT] = [
     &PT_ROOT_ABANDONED_TERMINATED,
     &PT_ROOT_DROPPED_UNDECIDED,
     &PT_EXEC_WALK_LEASES_UNRETURNED,
+    &PT_ROOTS_RETIRED,
+    &PT_TABLE_FRAMES_RETURNED,
+    &PT_RETIRE_FRAMES_LOST,
+    &PT_ROOT_DROPPED_MID_RETIRE,
+    &PT_RETIRE_BUDGET_REQUEUED,
     &RECLAIM_PASS_SKIPPED,
     &RECLAIM_PARKED,
     &RECLAIM_UNPARKED_EPOCH,
@@ -570,6 +598,10 @@ struct BootTestPidCountSlot {
     kick_observed_interval: AtomicU64,
     masked_frames_walked: AtomicU64,
     report_count: AtomicU64,
+    table_frames_recorded: AtomicU64,
+    table_frames_returned: AtomicU64,
+    table_frames_lost: AtomicU64,
+    roots_retired: AtomicU64,
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
@@ -585,6 +617,10 @@ impl BootTestPidCountSlot {
             kick_observed_interval: AtomicU64::new(0),
             masked_frames_walked: AtomicU64::new(0),
             report_count: AtomicU64::new(0),
+            table_frames_recorded: AtomicU64::new(0),
+            table_frames_returned: AtomicU64::new(0),
+            table_frames_lost: AtomicU64::new(0),
+            roots_retired: AtomicU64::new(0),
         }
     }
 }
@@ -615,6 +651,10 @@ enum BootTestPidCountKind {
     KickObserved(u64),
     MaskedFramesWalked,
     Report,
+    TableFramesRecorded(u64),
+    TableFrameReturned,
+    TableFrameLost,
+    RootRetired,
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
@@ -653,6 +693,19 @@ fn record_boot_test_pid_count(pid: u64, kind: BootTestPidCountKind) {
                 BootTestPidCountKind::Report => {
                     slot.report_count.fetch_add(1, Ordering::Relaxed);
                 }
+                BootTestPidCountKind::TableFramesRecorded(count) => {
+                    slot.table_frames_recorded
+                        .fetch_add(count, Ordering::Relaxed);
+                }
+                BootTestPidCountKind::TableFrameReturned => {
+                    slot.table_frames_returned.fetch_add(1, Ordering::Relaxed);
+                }
+                BootTestPidCountKind::TableFrameLost => {
+                    slot.table_frames_lost.fetch_add(1, Ordering::Relaxed);
+                }
+                BootTestPidCountKind::RootRetired => {
+                    slot.roots_retired.fetch_add(1, Ordering::Release);
+                }
             }
             return;
         }
@@ -675,6 +728,10 @@ fn reset_boot_test_pid_counts() -> BootTestPidCountsGuard {
         slot.kick_observed_interval.store(0, Ordering::Relaxed);
         slot.masked_frames_walked.store(0, Ordering::Relaxed);
         slot.report_count.store(0, Ordering::Relaxed);
+        slot.table_frames_recorded.store(0, Ordering::Relaxed);
+        slot.table_frames_returned.store(0, Ordering::Relaxed);
+        slot.table_frames_lost.store(0, Ordering::Relaxed);
+        slot.roots_retired.store(0, Ordering::Relaxed);
     }
     BOOT_TEST_PID_COUNTS_ACTIVE.store(1, Ordering::Release);
     BootTestPidCountsGuard
@@ -702,30 +759,80 @@ fn track_boot_test_pid(pid: u64) -> bool {
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
-fn boot_test_pid_counts(pid: u64) -> (u64, u64) {
+#[derive(Clone, Copy, Default)]
+struct BootTestPidCounts {
+    defer_count: u64,
+    reclaim_count: u64,
+    table_frames_recorded: u64,
+    table_frames_returned: u64,
+    table_frames_lost: u64,
+    roots_retired: u64,
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn boot_test_pid_counts(pid: u64) -> BootTestPidCounts {
     let start = pid as usize & (BOOT_TEST_PID_COUNT_SLOTS - 1);
     for offset in 0..BOOT_TEST_PID_COUNT_SLOTS {
         let slot = &BOOT_TEST_PID_COUNTS[(start + offset) & (BOOT_TEST_PID_COUNT_SLOTS - 1)];
         let slot_pid = slot.pid.load(Ordering::Acquire);
         if slot_pid == pid {
-            return (
-                slot.defer_count.load(Ordering::Relaxed),
-                slot.reclaim_count.load(Ordering::Relaxed),
-            );
+            return BootTestPidCounts {
+                defer_count: slot.defer_count.load(Ordering::Relaxed),
+                reclaim_count: slot.reclaim_count.load(Ordering::Relaxed),
+                table_frames_recorded: slot.table_frames_recorded.load(Ordering::Relaxed),
+                table_frames_returned: slot.table_frames_returned.load(Ordering::Relaxed),
+                table_frames_lost: slot.table_frames_lost.load(Ordering::Relaxed),
+                roots_retired: slot.roots_retired.load(Ordering::Relaxed),
+            };
         }
         if slot_pid == 0 {
             break;
         }
     }
-    (0, 0)
+    BootTestPidCounts::default()
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 fn boot_test_pid_counts_complete(pids: &[u64]) -> bool {
     pids.iter().all(|pid| {
-        let (defer_count, reclaim_count) = boot_test_pid_counts(*pid);
-        defer_count >= 1 && defer_count == reclaim_count
+        let counts = boot_test_pid_counts(*pid);
+        counts.defer_count >= 1 && counts.defer_count == counts.reclaim_count
     })
+}
+
+#[inline(always)]
+pub fn record_pt_retire_started(pid: u64, table_frames: u64) {
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::TableFramesRecorded(table_frames));
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = (pid, table_frames);
+}
+
+#[inline(always)]
+pub fn record_pt_frame_returned(pid: u64) {
+    crate::trace_count!(PT_TABLE_FRAMES_RETURNED);
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::TableFrameReturned);
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = pid;
+}
+
+#[inline(always)]
+pub fn record_pt_frame_lost(pid: u64) {
+    crate::trace_count!(PT_RETIRE_FRAMES_LOST);
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::TableFrameLost);
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = pid;
+}
+
+#[inline(always)]
+pub fn record_pt_root_retired(pid: u64) {
+    crate::trace_count!(PT_ROOTS_RETIRED);
+    #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+    record_boot_test_pid_count(pid, BootTestPidCountKind::RootRetired);
+    #[cfg(not(all(feature = "boot_tests", target_arch = "aarch64")))]
+    let _ = pid;
 }
 
 #[inline(always)]
@@ -960,6 +1067,56 @@ pub fn deferred_fault_ring_overflow_test() -> crate::test_framework::registry::T
 }
 
 #[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+const RETIRE_SENTINEL_VAS: [u64; 3] = [
+    0x0000_0000_0040_0000,
+    0x0000_0080_0040_0000,
+    0x0000_0100_0040_0000,
+];
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn expected_retire_table_frames() -> u64 {
+    let mut distinct_l0_subtrees = 0u64;
+    for (index, address) in RETIRE_SENTINEL_VAS.iter().enumerate() {
+        let l0_index = (address >> 39) & 0x1ff;
+        if !RETIRE_SENTINEL_VAS[..index]
+            .iter()
+            .any(|prior| ((prior >> 39) & 0x1ff) == l0_index)
+        {
+            distinct_l0_subtrees += 1;
+        }
+    }
+    distinct_l0_subtrees * 3
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn map_retire_sentinels(
+    page_table: &mut crate::memory::process_memory::ProcessPageTable,
+) -> Result<(), &'static str> {
+    use crate::memory::arch_stub::{Page, PageTableFlags, Size4KiB, VirtAddr};
+    use crate::memory::frame_allocator::{allocate_frame, deallocate_frame};
+
+    let flags =
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE;
+    for address in RETIRE_SENTINEL_VAS {
+        let frame = allocate_frame().ok_or("sentinel leaf allocation failed")?;
+        let page = Page::<Size4KiB>::containing_address(VirtAddr::new(address));
+        if page_table.map_page(page, frame, flags).is_err() {
+            deallocate_frame(frame);
+            return Err("sentinel mapping failed");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn frame_allocator_used_frames() -> usize {
+    let stats = crate::memory::frame_allocator::memory_stats();
+    stats
+        .allocated_frames
+        .saturating_sub(crate::memory::frame_allocator::free_list_len_for_gate())
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
 pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry::TestResult {
     use crate::test_framework::registry::TestResult;
 
@@ -972,9 +1129,7 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     // entry freed-but-counter-not-yet-visible as unpaired against the deadline.
     let _reclaim_owner = match crate::task::process_task::BootReclaimTestGuard::enter() {
         Ok(guard) => guard,
-        Err(_) => {
-            return TestResult::Fail("reclaim queues not quiescent at pairing-test start")
-        }
+        Err(_) => return TestResult::Fail("reclaim queues not quiescent at pairing-test start"),
     };
 
     let teardown_entry_exit_before = TEARDOWN_ENTRY_EXIT.aggregate();
@@ -1029,9 +1184,66 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         manager.insert_process(parent_pid, parent_process);
     };
 
+    // Exercise the known unproved immediate-release path before the leak
+    // measurement. Its intentional abandonment is therefore present in both
+    // allocator baselines and cannot disguise a deferred-root leak.
+    let immediate_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
+        Ok(page_table) => alloc::boxed::Box::new(page_table),
+        Err(_) => return TestResult::Fail("baseline fork page-table allocation failed"),
+    };
+    let immediate = {
+        let mut manager_guard = crate::process::manager();
+        let Some(manager) = manager_guard.as_mut() else {
+            return TestResult::Fail("process manager unavailable during baseline fork");
+        };
+        let child_pid = match manager.fork_process_aarch64(
+            parent_pid,
+            parent_context.clone(),
+            immediate_page_table,
+        ) {
+            Ok(pid) => pid,
+            Err(_) => return TestResult::Fail("baseline fork failed"),
+        };
+        let Some(child_tid) = manager
+            .get_process(child_pid)
+            .and_then(|process| process.main_thread.as_ref())
+            .map(|thread| thread.id)
+        else {
+            return TestResult::Fail("baseline child has no main thread");
+        };
+        (child_pid, child_tid)
+    };
+    crate::task::process_task::ProcessScheduler::handle_thread_exit(immediate.1, 0);
+    {
+        let mut manager_guard = crate::process::manager();
+        let Some(manager) = manager_guard.as_mut() else {
+            return TestResult::Fail("process manager unavailable during baseline reap");
+        };
+        manager.remove_process(immediate.0);
+        if let Some(parent) = manager.get_process_mut(parent_pid) {
+            parent.children.retain(|pid| *pid != immediate.0);
+        }
+    }
+
     let mut pairing_child_pids = [0u64; 64];
     let mut pairing_child_count = 0;
     let pid_counts_guard = reset_boot_test_pid_counts();
+    let expected_tables = expected_retire_table_frames();
+    let allocator_used_before = frame_allocator_used_frames();
+    let roots_retired_before = PT_ROOTS_RETIRED.aggregate();
+    let table_frames_returned_before = PT_TABLE_FRAMES_RETURNED.aggregate();
+    let table_frames_lost_before = PT_RETIRE_FRAMES_LOST.aggregate();
+    let dropped_undecided_before = PT_ROOT_DROPPED_UNDECIDED.aggregate();
+    let dropped_mid_retire_before = PT_ROOT_DROPPED_MID_RETIRE.aggregate();
+    let budget_requeued_before = PT_RETIRE_BUDGET_REQUEUED.aggregate();
+    let no_arch_before = PT_ROOT_ABANDONED_NO_ARCH.aggregate();
+    let refusal_counters_before = [
+        FRAME_RETURN_REFUSED_DOUBLE.aggregate(),
+        FRAME_RETURN_REFUSED_STALE.aggregate(),
+        FRAME_RETURN_REFUSED_NEVER_ALLOCATED.aggregate(),
+        FRAME_RETURN_REFUSED_UNTRACKED.aggregate(),
+        FRAME_DUPLICATE_ALLOC_REFUSED.aggregate(),
+    ];
     // The nine labels mirror PLAN P2's disjoint adapted-site table. The exact
     // source ratchets below prove which concrete callers use each custody
     // shape; this runtime matrix injects one independent process through every
@@ -1048,10 +1260,13 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         2, // SIGKILL after quarantine/expedite
     ];
     for iteration in 0..64 {
-        let child_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
+        let mut child_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
             Ok(page_table) => alloc::boxed::Box::new(page_table),
             Err(_) => return TestResult::Fail("pairing fork page-table allocation failed"),
         };
+        if map_retire_sentinels(child_page_table.as_mut()).is_err() {
+            return TestResult::Fail("pairing retire sentinel mapping failed");
+        }
         let child = {
             let mut manager_guard = crate::process::manager();
             let Some(manager) = manager_guard.as_mut() else {
@@ -1107,43 +1322,6 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         }
     }
 
-    // Exercise today's immediate-release path as part of the same explained
-    // workload so the three known-under-PM baseline defects cannot pass at zero.
-    let immediate_page_table = match crate::memory::process_memory::ProcessPageTable::new() {
-        Ok(page_table) => alloc::boxed::Box::new(page_table),
-        Err(_) => return TestResult::Fail("baseline fork page-table allocation failed"),
-    };
-    let immediate = {
-        let mut manager_guard = crate::process::manager();
-        let Some(manager) = manager_guard.as_mut() else {
-            return TestResult::Fail("process manager unavailable during baseline fork");
-        };
-        let child_pid =
-            match manager.fork_process_aarch64(parent_pid, parent_context, immediate_page_table) {
-                Ok(pid) => pid,
-                Err(_) => return TestResult::Fail("baseline fork failed"),
-            };
-        let Some(child_tid) = manager
-            .get_process(child_pid)
-            .and_then(|process| process.main_thread.as_ref())
-            .map(|thread| thread.id)
-        else {
-            return TestResult::Fail("baseline child has no main thread");
-        };
-        (child_pid, child_tid)
-    };
-    crate::task::process_task::ProcessScheduler::handle_thread_exit(immediate.1, 0);
-    {
-        let mut manager_guard = crate::process::manager();
-        let Some(manager) = manager_guard.as_mut() else {
-            return TestResult::Fail("process manager unavailable during baseline reap");
-        };
-        manager.remove_process(immediate.0);
-        if let Some(parent) = manager.get_process_mut(parent_pid) {
-            parent.children.retain(|pid| *pid != immediate.0);
-        }
-    }
-
     let timer_frequency = crate::arch_impl::aarch64::timer::frequency_hz();
     let quiesce_deadline =
         crate::arch_impl::aarch64::timer::rdtsc().saturating_add(timer_frequency.saturating_mul(5));
@@ -1179,6 +1357,28 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     let exit_repeat_requests_delta = EXIT_REPEAT_REQUESTS
         .aggregate()
         .saturating_sub(exit_repeat_requests_before);
+    let allocator_used_after = frame_allocator_used_frames();
+    let roots_retired_delta = PT_ROOTS_RETIRED
+        .aggregate()
+        .saturating_sub(roots_retired_before);
+    let table_frames_returned_delta = PT_TABLE_FRAMES_RETURNED
+        .aggregate()
+        .saturating_sub(table_frames_returned_before);
+    let table_frames_lost_delta = PT_RETIRE_FRAMES_LOST
+        .aggregate()
+        .saturating_sub(table_frames_lost_before);
+    crate::serial_println!(
+        "[PT_RETIRE_ORACLE:aarch64:cycles=64:used_before={}:used_after={}:expected_tables={}:roots={}:returned={}:lost={}]",
+        allocator_used_before,
+        allocator_used_after,
+        expected_tables,
+        roots_retired_delta,
+        table_frames_returned_delta,
+        table_frames_lost_delta
+    );
+    if allocator_used_after != allocator_used_before {
+        return TestResult::Fail("retire leak oracle did not return frame accounting to baseline");
+    }
     if teardown_entry_exit_delta < 64 {
         return TestResult::Fail("TEARDOWN_ENTRY_EXIT workload delta did not reach 64");
     }
@@ -1186,19 +1386,65 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         return TestResult::Fail("first/repeat exit request workload deltas did not reach 64");
     }
     for pid in pairing_child_pids {
-        let (defer_count, reclaim_count) = boot_test_pid_counts(pid);
-        if defer_count == 0 {
+        let counts = boot_test_pid_counts(pid);
+        if counts.defer_count == 0 {
             return TestResult::Fail("adapted-site per-PID defer proof was absent");
         }
-        if defer_count > 1 {
+        if counts.defer_count > 1 {
             return TestResult::Fail("adapted-site per-PID defer proof was duplicated");
         }
-        if reclaim_count == 0 {
+        if counts.reclaim_count == 0 {
             return TestResult::Fail("adapted-site per-PID reclaim proof was absent");
         }
-        if reclaim_count > 1 {
+        if counts.reclaim_count > 1 {
             return TestResult::Fail("adapted-site per-PID reclaim proof was duplicated");
         }
+        if counts.roots_retired != 1 {
+            return TestResult::Fail("retire cohort per-PID root completion was not exactly one");
+        }
+        if counts.table_frames_recorded != expected_tables {
+            return TestResult::Fail(
+                "retire cohort per-PID anti-vacuity table count was not exact",
+            );
+        }
+        if counts.table_frames_returned != counts.table_frames_recorded + 1 {
+            return TestResult::Fail("retire cohort per-PID committed return equality failed");
+        }
+        if counts.table_frames_lost != 0 {
+            return TestResult::Fail("retire cohort per-PID frame loss was nonzero");
+        }
+    }
+    if roots_retired_delta != pairing_child_pids.len() as u64
+        || table_frames_returned_delta != (expected_tables + 1) * pairing_child_pids.len() as u64
+        || table_frames_lost_delta != 0
+        || PT_ROOT_DROPPED_UNDECIDED
+            .aggregate()
+            .saturating_sub(dropped_undecided_before)
+            != 0
+        || PT_ROOT_DROPPED_MID_RETIRE
+            .aggregate()
+            .saturating_sub(dropped_mid_retire_before)
+            != 0
+        || PT_RETIRE_BUDGET_REQUEUED
+            .aggregate()
+            .saturating_sub(budget_requeued_before)
+            != 0
+        || PT_ROOT_ABANDONED_NO_ARCH
+            .aggregate()
+            .saturating_sub(no_arch_before)
+            != 0
+    {
+        return TestResult::Fail("retire cohort global committed-effect accounting failed");
+    }
+    let refusal_counters_after = [
+        FRAME_RETURN_REFUSED_DOUBLE.aggregate(),
+        FRAME_RETURN_REFUSED_STALE.aggregate(),
+        FRAME_RETURN_REFUSED_NEVER_ALLOCATED.aggregate(),
+        FRAME_RETURN_REFUSED_UNTRACKED.aggregate(),
+        FRAME_DUPLICATE_ALLOC_REFUSED.aggregate(),
+    ];
+    if refusal_counters_after != refusal_counters_before {
+        return TestResult::Fail("retire cohort triggered an unexpected frame refusal");
     }
     if TEARDOWN_MASKED_FRAMES_WALKED
         .aggregate()

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -1354,6 +1354,7 @@ const PROCESS_PAGE_TABLE_ABANDON_SITES: &[(&str, usize, &str)] = &[
     ),
 ];
 const PROCESS_PAGE_TABLE_RETIRE_SITES: &[(&str, usize)] = &[
+    ("kernel/src/memory/frame_allocator_tests.rs", 41),
     ("kernel/src/task/process_task.rs", 198),
     ("kernel/src/task/process_task.rs", 1491),
     ("kernel/src/task/process_task.rs", 1509),
@@ -2188,10 +2189,7 @@ fn validate_process_page_table_dispositions(sources: &[(String, String)]) -> Res
 
 fn validate_process_page_table_retire_site(sources: &[(String, String)]) -> Result<(), ()> {
     let process_task = source(sources, "kernel/src/task/process_task.rs");
-    let retire_sites = code_sites(sources, ".retire_bounded(")
-        .into_iter()
-        .filter(|(path, _)| path == "kernel/src/task/process_task.rs")
-        .collect();
+    let retire_sites = code_sites(sources, ".retire_bounded(");
     validate_exact(&retire_sites, PROCESS_PAGE_TABLE_RETIRE_SITES)?;
 
     let reclaim_sites = code_sites(sources, ".reclaim_bounded(")
@@ -2341,9 +2339,9 @@ fn validate_pr1c_retirement_oracles(sources: &[(String, String)]) -> Result<(), 
         "let allocator_used_before = frame_allocator_used_frames();",
         "if allocator_used_after != allocator_used_before {",
         "retire leak oracle did not return frame accounting to baseline",
-        "counts.roots_retired != 1",
-        "counts.table_frames_recorded != expected_tables",
-        "counts.table_frames_returned != counts.table_frames_recorded + 1",
+        "if counts.roots_retired != 1 {",
+        "if counts.table_frames_recorded != expected_tables {",
+        "if counts.table_frames_returned != counts.table_frames_recorded + 1 {",
         "counts.table_frames_lost != 0",
         "retire cohort per-PID anti-vacuity table count was not exact",
         "retire cohort per-PID committed return equality failed",
@@ -2356,12 +2354,7 @@ fn validate_pr1c_retirement_oracles(sources: &[(String, String)]) -> Result<(), 
             return Err(());
         }
     }
-    if gate.contains("allocator_used_after != allocator_used_before && false")
-        || gate.contains("counts.roots_retired != 1 && false")
-        || gate.contains("counts.table_frames_recorded != expected_tables && false")
-        || gate
-            .contains("counts.table_frames_returned != counts.table_frames_recorded + 1 && false")
-        || !expected.contains("address >> 39")
+    if !expected.contains("address >> 39")
         || !expected.contains("distinct_l0_subtrees * 3")
         || gate.contains("let expected_tables = 9")
     {
@@ -3517,6 +3510,15 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         ),
     );
     assert!(validate_process_page_table_retire_site(&extra_reclaim).is_err());
+    let process_manager = source(&sources, "kernel/src/process/manager.rs");
+    let cross_file_retire = with_replaced_source(
+        &sources,
+        "kernel/src/process/manager.rs",
+        format!(
+            "{process_manager}\nfn synthetic_cross_file_retire(page_table: &mut ProcessPageTable, pid: u64, budget: &mut u32) {{ let _ = page_table.retire_bounded(pid, budget); }}"
+        ),
+    );
+    assert!(validate_process_page_table_retire_site(&cross_file_retire).is_err());
 
     // R6: inventory membership and unconditional declarations are both pinned.
     let provider = source(&sources, "kernel/src/tracing/providers/teardown.rs");
@@ -3626,6 +3628,28 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         (
             "counts.table_frames_returned != counts.table_frames_recorded + 1 {",
             "counts.table_frames_returned != counts.table_frames_recorded + 1 && false {",
+        ),
+    ] {
+        let weakened = provider.replacen(needle, replacement, 1);
+        let weakened = with_replaced_source(
+            &sources,
+            "kernel/src/tracing/providers/teardown.rs",
+            weakened,
+        );
+        assert!(validate_pr1c_retirement_oracles(&weakened).is_err());
+    }
+    for (needle, replacement) in [
+        (
+            "counts.roots_retired != 1 {",
+            "counts.roots_retired != 1 && 1 == 0 {",
+        ),
+        (
+            "counts.table_frames_recorded != expected_tables {",
+            "counts.table_frames_recorded != expected_tables && 1 == 0 {",
+        ),
+        (
+            "counts.table_frames_returned != counts.table_frames_recorded + 1 {",
+            "counts.table_frames_returned != counts.table_frames_recorded + 1 && 1 == 0 {",
         ),
     ] {
         let weakened = provider.replacen(needle, replacement, 1);

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -1251,11 +1251,11 @@ const TERMINATE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/signal/delivery.rs", 225),
     ("kernel/src/signal/delivery.rs", 260),
 ];
-const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 506)];
+const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 520)];
 const PRODUCTION_INIT_PID_SITES: &[(&str, usize)] = &[
     ("kernel/src/process/manager.rs", 1189),
-    ("kernel/src/task/process_task.rs", 466),
-    ("kernel/src/task/process_task.rs", 538),
+    ("kernel/src/task/process_task.rs", 480),
+    ("kernel/src/task/process_task.rs", 552),
 ];
 const TEST_INIT_PID_SITES: &[(&str, usize)] = &[
     ("kernel/src/test_userspace.rs", 84),
@@ -1277,7 +1277,7 @@ const KERNEL_STACK_MUTATIONS: &[(&str, usize)] = &[
 const RECLAIM_ENQUEUE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 53),
     ("kernel/src/process/mod.rs", 280),
-    ("kernel/src/task/process_task.rs", 580),
+    ("kernel/src/task/process_task.rs", 594),
 ];
 const EXIT_PROCESS_AND_RETIRE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/exception.rs", 824),
@@ -1295,7 +1295,7 @@ const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 418),
 ];
 const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
-    &[("kernel/src/tracing/providers/teardown.rs", 1095)];
+    &[("kernel/src/tracing/providers/teardown.rs", 1310)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
     ("kernel/src/task/scheduler.rs", 1973),
     ("kernel/src/task/scheduler.rs", 2187),
@@ -1312,44 +1312,39 @@ const RAW_SCHEDULER_LOCK_SITES: &[(&str, usize)] = &[
     ("kernel/src/task/scheduler.rs", 288),
 ];
 const PROCESS_MEMORY_FRAME_RETURNS: &[(&str, usize)] = &[
-    ("kernel/src/memory/process_memory.rs", 1617),
-    ("kernel/src/memory/process_memory.rs", 1656),
     ("kernel/src/memory/process_memory.rs", 1693),
-    ("kernel/src/memory/process_memory.rs", 1705),
-    ("kernel/src/memory/process_memory.rs", 1709),
-    ("kernel/src/memory/process_memory.rs", 1713),
-    ("kernel/src/memory/process_memory.rs", 1718),
+    ("kernel/src/memory/process_memory.rs", 1732),
+    ("kernel/src/memory/process_memory.rs", 1769),
+    ("kernel/src/memory/process_memory.rs", 1781),
     ("kernel/src/memory/process_memory.rs", 1785),
-    ("kernel/src/memory/process_memory.rs", 1813),
-    ("kernel/src/memory/process_memory.rs", 1840),
-    ("kernel/src/memory/process_memory.rs", 1852),
-    ("kernel/src/memory/process_memory.rs", 1856),
-    ("kernel/src/memory/process_memory.rs", 1860),
-    ("kernel/src/memory/process_memory.rs", 1865),
+    ("kernel/src/memory/process_memory.rs", 1789),
+    ("kernel/src/memory/process_memory.rs", 1794),
+    ("kernel/src/memory/process_memory.rs", 1861),
+    ("kernel/src/memory/process_memory.rs", 1889),
+    ("kernel/src/memory/process_memory.rs", 1916),
+    ("kernel/src/memory/process_memory.rs", 1928),
+    ("kernel/src/memory/process_memory.rs", 1932),
+    ("kernel/src/memory/process_memory.rs", 1936),
+    ("kernel/src/memory/process_memory.rs", 1941),
 ];
 const TABLE_RECORDER_SITES: &[(&str, usize)] = &[
-    ("kernel/src/memory/process_memory.rs", 1117),
-    ("kernel/src/memory/process_memory.rs", 1228),
+    ("kernel/src/memory/process_memory.rs", 1133),
+    ("kernel/src/memory/process_memory.rs", 1244),
 ];
 const PROCESS_PAGE_TABLE_ABANDON_SITES: &[(&str, usize, &str)] = &[
     (
         "kernel/src/task/process_task.rs",
-        188,
+        309,
         "AbandonReason::NoProofPipeline",
     ),
     (
         "kernel/src/task/process_task.rs",
-        296,
-        "AbandonReason::NoProofPipeline",
-    ),
-    (
-        "kernel/src/task/process_task.rs",
-        298,
+        311,
         "AbandonReason::NoArchPipeline",
     ),
     (
         "kernel/src/task/process_task.rs",
-        480,
+        494,
         "AbandonReason::AlreadyTerminated",
     ),
     (
@@ -1358,6 +1353,13 @@ const PROCESS_PAGE_TABLE_ABANDON_SITES: &[(&str, usize, &str)] = &[
         "AbandonReason::AlreadyTerminated",
     ),
 ];
+const PROCESS_PAGE_TABLE_RETIRE_SITES: &[(&str, usize)] = &[
+    ("kernel/src/task/process_task.rs", 198),
+    ("kernel/src/task/process_task.rs", 1491),
+    ("kernel/src/task/process_task.rs", 1509),
+    ("kernel/src/task/process_task.rs", 1517),
+];
+const PENDING_RECLAIM_BOUNDED_SITES: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 956)];
 const FRAME_LEDGER_INIT_CALLS: &[(&str, usize)] = &[
     ("kernel/src/main_aarch64.rs", 493),
     ("kernel/src/memory/mod.rs", 137),
@@ -1373,11 +1375,15 @@ const PROCESS_PAGE_TABLE_CONSTRUCTORS: &[(&str, usize)] = &[
     ("kernel/src/process/manager.rs", 3112),
     ("kernel/src/process/manager.rs", 3393),
     ("kernel/src/syscall/handlers.rs", 1822),
-    ("kernel/src/tracing/providers/teardown.rs", 991),
-    ("kernel/src/tracing/providers/teardown.rs", 1051),
-    ("kernel/src/tracing/providers/teardown.rs", 1112),
-    ("kernel/src/memory/process_memory.rs", 1914),
-    ("kernel/src/memory/process_memory.rs", 1931),
+    ("kernel/src/tracing/providers/teardown.rs", 1146),
+    ("kernel/src/tracing/providers/teardown.rs", 1190),
+    ("kernel/src/tracing/providers/teardown.rs", 1263),
+    ("kernel/src/memory/process_memory.rs", 2005),
+    ("kernel/src/memory/process_memory.rs", 2031),
+    ("kernel/src/memory/process_memory.rs", 2048),
+    ("kernel/src/memory/process_memory.rs", 2069),
+    ("kernel/src/task/process_task.rs", 1059),
+    ("kernel/src/task/process_task.rs", 1504),
 ];
 
 const BLOCKING_NAMES: &[&str] = &[
@@ -1573,6 +1579,7 @@ fn validate_frame_return_choke_point(sources: &[(String, String)]) -> Result<(),
             "inject_duplicate_candidates",
             "remove_duplicate_candidates",
             "republish_lost_frame",
+            "retire_with_free_list_contended",
             "free_frame_count",
             "free_list_len_for_gate",
             "take_free_frame",
@@ -1593,15 +1600,19 @@ fn validate_frame_return_choke_point(sources: &[(String, String)]) -> Result<(),
 
     validate_exact(
         &sites_matching(sources, |line| {
-            (line.contains("deallocate_frame(") || line.contains("return_lease("))
-                && !line.contains("fn deallocate_frame")
-                && !line.contains("fn return_lease")
+            line.contains("deallocate_frame(") && !line.contains("fn deallocate_frame")
         })
         .into_iter()
         .filter(|(path, _)| path == "kernel/src/memory/process_memory.rs")
         .collect(),
         PROCESS_MEMORY_FRAME_RETURNS,
-    )
+    )?;
+    let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
+    let all_returns = code_offsets(process_memory, &code_mask(process_memory), "return_lease(");
+    let retire = function_body(process_memory, "retire_bounded");
+    (all_returns.len() == 2 && retire.matches("return_lease(").count() == all_returns.len())
+        .then_some(())
+        .ok_or(())
 }
 
 fn validate_frame_ledger_hot_paths(sources: &[(String, String)]) -> Result<(), ()> {
@@ -1998,7 +2009,7 @@ fn validate_x86_frame_custody_harness(script: &str) -> Result<(), ()> {
         && !script.contains("grep -q '\\[BOOT_TESTS:PASS\\]'")
         && script.contains("FRAME_CUSTODY_COUNTERS:x86:double=1:stale=1:never=1:untracked=1:duplicate=3:contended=[1-9][0-9]*")
         && script.contains("page_table_custody_disposition_gate:PASS")
-        && script.contains("recorded=2:no_proof=0:no_arch=0:terminated=1:undecided=1:exec_unreturned=0")
+        && script.contains("recorded=3:no_proof=0:no_arch=1:terminated=1:undecided=1:exec_unreturned=0")
         && script.contains("-eq 1")
         && script.contains("x86 frame-custody gate run")
         && script.contains("BOOT_TESTS:FAIL|KERNEL PANIC|panic!"))
@@ -2080,7 +2091,7 @@ fn validate_frame_ledger_counter_inventory(provider: &str) -> Result<(), ()> {
         && EXPECTED
             .iter()
             .all(|counter| inventory.contains(&format!("&{counter},")))
-        && provider.contains("pub const COUNTER_COUNT: usize = 59;"))
+        && provider.contains("pub const COUNTER_COUNT: usize = 64;"))
     .then_some(())
     .ok_or(())
 }
@@ -2116,13 +2127,11 @@ fn validate_process_table_recorder(sources: &[(String, String)]) -> Result<(), (
         && recorder.contains("Some(frame)")
         && !recorder.contains("deallocate_frame")
         && !recorder.contains("return_lease"))
-        .then_some(())
-        .ok_or(())
+    .then_some(())
+    .ok_or(())
 }
 
-fn validate_process_page_table_drop_is_non_freeing(
-    sources: &[(String, String)],
-) -> Result<(), ()> {
+fn validate_process_page_table_drop_is_non_freeing(sources: &[(String, String)]) -> Result<(), ()> {
     let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
     let drop_body = function_body(process_memory, "drop");
     (drop_body.contains("Disposition::Undecided")
@@ -2131,8 +2140,8 @@ fn validate_process_page_table_drop_is_non_freeing(
         && ["deallocate_frame", "return_lease", "retire_bounded"]
             .iter()
             .all(|forbidden| !drop_body.contains(forbidden)))
-        .then_some(())
-        .ok_or(())
+    .then_some(())
+    .ok_or(())
 }
 
 fn validate_process_page_table_dispositions(sources: &[(String, String)]) -> Result<(), ()> {
@@ -2177,16 +2186,50 @@ fn validate_process_page_table_dispositions(sources: &[(String, String)]) -> Res
     .ok_or(())
 }
 
-fn validate_process_page_table_counter_inventory(
-    sources: &[(String, String)],
-) -> Result<(), ()> {
-    const EXPECTED: [&str; 6] = [
+fn validate_process_page_table_retire_site(sources: &[(String, String)]) -> Result<(), ()> {
+    let process_task = source(sources, "kernel/src/task/process_task.rs");
+    let retire_sites = code_sites(sources, ".retire_bounded(")
+        .into_iter()
+        .filter(|(path, _)| path == "kernel/src/task/process_task.rs")
+        .collect();
+    validate_exact(&retire_sites, PROCESS_PAGE_TABLE_RETIRE_SITES)?;
+
+    let reclaim_sites = code_sites(sources, ".reclaim_bounded(")
+        .into_iter()
+        .filter(|(path, _)| path == "kernel/src/task/process_task.rs")
+        .collect();
+    validate_exact(&reclaim_sites, PENDING_RECLAIM_BOUNDED_SITES)?;
+
+    if !process_task.contains("fn reclaim_bounded(&mut self)") {
+        return Err(());
+    }
+    let reclaim = function_body(process_task, "reclaim_bounded");
+    let drain = function_body(process_task, "reclaim_deferred_process_resources_for_pass");
+    (reclaim.matches(".retire_bounded(").count() == 1
+        && drain.matches(".reclaim_bounded(").count() == 1
+        && drain
+            .find("if let Some(blocker) = proof.blocker()")
+            .ok_or(())?
+            < drain.find(".reclaim_bounded(").ok_or(())?
+        && drain.find(".reclaim_bounded(").ok_or(())?
+            < drain.find("record_reclaim(reclaim.pid)").ok_or(())?)
+    .then_some(())
+    .ok_or(())
+}
+
+fn validate_process_page_table_counter_inventory(sources: &[(String, String)]) -> Result<(), ()> {
+    const EXPECTED: [&str; 11] = [
         "PT_TABLE_FRAMES_RECORDED",
         "PT_ROOT_ABANDONED_NO_PROOF",
         "PT_ROOT_ABANDONED_NO_ARCH",
         "PT_ROOT_ABANDONED_TERMINATED",
         "PT_ROOT_DROPPED_UNDECIDED",
         "PT_EXEC_WALK_LEASES_UNRETURNED",
+        "PT_ROOTS_RETIRED",
+        "PT_TABLE_FRAMES_RETURNED",
+        "PT_RETIRE_FRAMES_LOST",
+        "PT_ROOT_DROPPED_MID_RETIRE",
+        "PT_RETIRE_BUDGET_REQUEUED",
     ];
     let provider = source(sources, "kernel/src/tracing/providers/teardown.rs");
     let expected: BTreeSet<_> = EXPECTED.into_iter().map(str::to_owned).collect();
@@ -2212,7 +2255,7 @@ fn validate_process_page_table_counter_inventory(
         || !EXPECTED
             .iter()
             .all(|counter| inventory.contains(&format!("&{counter},")))
-        || !provider.contains("pub const COUNTER_COUNT: usize = 59;")
+        || !provider.contains("pub const COUNTER_COUNT: usize = 64;")
     {
         return Err(());
     }
@@ -2227,6 +2270,11 @@ fn validate_process_page_table_counter_inventory(
     let record = function_body(process_memory, "record");
     let abandon = function_body(process_memory, "abandon");
     let drop_body = function_body(process_memory, "drop");
+    if !process_memory.contains("pub(crate) fn retire_bounded") {
+        return Err(());
+    }
+    let retire = function_body(process_memory, "retire_bounded");
+    let task = source(sources, "kernel/src/task/process_task.rs");
     let cleanup_bodies = module_function_bodies(process_memory)
         .remove("cleanup_for_exec")
         .ok_or(())?;
@@ -2235,6 +2283,11 @@ fn validate_process_page_table_counter_inventory(
         && abandon.contains("PT_ROOT_ABANDONED_NO_ARCH")
         && abandon.contains("PT_ROOT_ABANDONED_TERMINATED")
         && drop_body.contains("PT_ROOT_DROPPED_UNDECIDED")
+        && drop_body.contains("PT_ROOT_DROPPED_MID_RETIRE")
+        && retire.contains("record_pt_frame_returned")
+        && retire.contains("record_pt_frame_lost")
+        && retire.contains("record_pt_root_retired")
+        && task.contains("PT_RETIRE_BUDGET_REQUEUED")
         && cleanup_bodies.len() == 2
         && cleanup_bodies
             .iter()
@@ -2247,9 +2300,18 @@ fn validate_process_page_table_exit_paths_are_minimal(
     sources: &[(String, String)],
 ) -> Result<(), ()> {
     let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
+    if !process_memory.contains("pub(crate) fn retire_bounded") {
+        return Err(());
+    }
+    let task = source(sources, "kernel/src/task/process_task.rs");
+    if !task.contains("fn reclaim_bounded(&mut self)") {
+        return Err(());
+    }
     for body in [
         function_body(process_memory, "abandon"),
         function_body(process_memory, "drop"),
+        function_body(process_memory, "retire_bounded"),
+        function_body(task, "reclaim_bounded"),
     ] {
         for forbidden in [
             "log::",
@@ -2270,6 +2332,44 @@ fn validate_process_page_table_exit_paths_are_minimal(
     Ok(())
 }
 
+fn validate_pr1c_retirement_oracles(sources: &[(String, String)]) -> Result<(), ()> {
+    let provider = source(sources, "kernel/src/tracing/providers/teardown.rs");
+    let gate = function_body(provider, "fork_exit_defer_reclaim_pairing_test");
+    let expected = function_body(provider, "expected_retire_table_frames");
+    for required in [
+        "map_retire_sentinels(child_page_table.as_mut())",
+        "let allocator_used_before = frame_allocator_used_frames();",
+        "if allocator_used_after != allocator_used_before {",
+        "retire leak oracle did not return frame accounting to baseline",
+        "counts.roots_retired != 1",
+        "counts.table_frames_recorded != expected_tables",
+        "counts.table_frames_returned != counts.table_frames_recorded + 1",
+        "counts.table_frames_lost != 0",
+        "retire cohort per-PID anti-vacuity table count was not exact",
+        "retire cohort per-PID committed return equality failed",
+        "refusal_counters_after != refusal_counters_before",
+        "PT_ROOT_ABANDONED_NO_ARCH",
+        "saturating_sub(no_arch_before)",
+        "[PT_RETIRE_ORACLE:aarch64:cycles=64:",
+    ] {
+        if !gate.contains(required) {
+            return Err(());
+        }
+    }
+    if gate.contains("allocator_used_after != allocator_used_before && false")
+        || gate.contains("counts.roots_retired != 1 && false")
+        || gate.contains("counts.table_frames_recorded != expected_tables && false")
+        || gate
+            .contains("counts.table_frames_returned != counts.table_frames_recorded + 1 && false")
+        || !expected.contains("address >> 39")
+        || !expected.contains("distinct_l0_subtrees * 3")
+        || gate.contains("let expected_tables = 9")
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
 fn validate_process_page_table_runtime_oracle(sources: &[(String, String)]) -> Result<(), ()> {
     let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
     let gate = function_body(process_memory, "page_table_custody_disposition_gate_test");
@@ -2277,7 +2377,13 @@ fn validate_process_page_table_runtime_oracle(sources: &[(String, String)]) -> R
         || !gate.contains("drop(undecided);")
         || !gate.contains("after_abandon[3] != start[3] + 1")
         || !gate.contains("after_drop[4] != after_abandon[4] + 1")
-        || gate.matches("free_list_len_for_gate()").count() != 4
+        || !gate.contains("retire_with_free_list_contended(")
+        || !gate.contains("PT_RETIRE_FRAMES_LOST.aggregate() != lost_before + 1")
+        || !gate.contains("republish_frame_for_gate(root)")
+        || !gate.contains("no_arch.abandon(AbandonReason::NoArchPipeline);")
+        || !gate.contains("after_no_arch[2] != after_drop[2] + 1")
+        || !gate.contains("PT_TABLE_FRAMES_RETURNED.aggregate()")
+        || gate.matches("free_list_len_for_gate()").count() != 7
         || gate.contains("&& false")
         || gate.contains("|| true")
     {
@@ -2291,8 +2397,7 @@ fn validate_process_page_table_runtime_oracle(sources: &[(String, String)]) -> R
         &registry_mask,
         "page_table_custody_disposition_gate_test",
     );
-    if registrations.len() != 1
-        || registry.contains("page_table_custody_disposition_gate_test as")
+    if registrations.len() != 1 || registry.contains("page_table_custody_disposition_gate_test as")
     {
         return Err(());
     }
@@ -2317,8 +2422,12 @@ fn validate_process_page_table_runtime_oracle(sources: &[(String, String)]) -> R
     }
     let harness = repo_text("docker/qemu/run-x86-boot-tests.sh");
     (harness.contains("page_table_custody_disposition_gate:PASS")
-        && harness.contains("recorded=2:no_proof=0:no_arch=0:terminated=1:undecided=1:exec_unreturned=0")
-        && harness.matches("page_table_custody_disposition_gate:PASS").count() == 2)
+        && harness
+            .contains("recorded=3:no_proof=0:no_arch=1:terminated=1:undecided=1:exec_unreturned=0")
+        && harness
+            .matches("page_table_custody_disposition_gate:PASS")
+            .count()
+            == 2)
         .then_some(())
         .ok_or(())
 }
@@ -2329,6 +2438,8 @@ fn process_page_table_custody_ratchets_are_exact() {
     validate_process_table_recorder(&sources).expect("R2 process mapper recorder was bypassed");
     validate_process_page_table_drop_is_non_freeing(&sources)
         .expect("R4 ProcessPageTable Drop gained a freeing path");
+    validate_process_page_table_retire_site(&sources)
+        .expect("R3 process page-table retirement escaped the proof-gated site");
     validate_process_page_table_dispositions(&sources)
         .expect("R5 process page-table disposition set changed");
     validate_process_page_table_counter_inventory(&sources)
@@ -2337,6 +2448,8 @@ fn process_page_table_custody_ratchets_are_exact() {
         .expect("R7 process page-table exit path gained log/format/heap work");
     validate_process_page_table_runtime_oracle(&sources)
         .expect("O2/G-H process page-table runtime oracle became vacuous");
+    validate_pr1c_retirement_oracles(&sources)
+        .expect("PR-1c leak or per-PID retirement oracle became vacuous");
 }
 
 #[test]
@@ -2386,7 +2499,7 @@ fn frame_ledger_return_and_initialization_ratchets_are_exact() {
             "counter became conditional: {counter}"
         );
     }
-    assert!(provider.contains("pub const COUNTER_COUNT: usize = 59;"));
+    assert!(provider.contains("pub const COUNTER_COUNT: usize = 64;"));
 }
 
 #[test]
@@ -2468,7 +2581,7 @@ fn v3_structural_closures_are_exact() {
     );
     assert_exact(
         sites_matching(&sources, |line| line.contains("btrt::on_process_exit(")),
-        &[("kernel/src/task/process_task.rs", 607)],
+        &[("kernel/src/task/process_task.rs", 621)],
         "btrt::on_process_exit callers",
     );
 
@@ -2643,7 +2756,7 @@ fn all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates() {
         .filter_map(|rest| rest.strip_suffix(','))
         .map(str::to_owned)
         .collect();
-    assert_eq!(declarations.len(), 59);
+    assert_eq!(declarations.len(), 64);
     assert_eq!(
         readers, declarations,
         "every counter must have an inventory reader"
@@ -3313,11 +3426,8 @@ fn deliberately_broken_variants_fail_the_ratchet() {
     let process_memory = source(&sources, "kernel/src/memory/process_memory.rs");
 
     // R2: the mapper allocator and deleted escape hatches cannot be restored.
-    let bypassed_recorder = process_memory.replacen(
-        "&mut TableRecorder(tables)",
-        "&mut GlobalFrameAllocator",
-        1,
-    );
+    let bypassed_recorder =
+        process_memory.replacen("&mut TableRecorder(tables)", "&mut GlobalFrameAllocator", 1);
     let bypassed_recorder = with_replaced_source(
         &sources,
         "kernel/src/memory/process_memory.rs",
@@ -3362,7 +3472,9 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         let raw_drop = with_replaced_source(
             &sources,
             "kernel/src/task/process_task.rs",
-            format!("{process_task}\nfn synthetic_raw_drop(process: &mut Process) {{ {raw_drop} }}"),
+            format!(
+                "{process_task}\nfn synthetic_raw_drop(process: &mut Process) {{ {raw_drop} }}"
+            ),
         );
         assert!(validate_process_page_table_dispositions(&raw_drop).is_err());
     }
@@ -3372,11 +3484,8 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         "page_table.abandon(AbandonReason::NoProofPipeline);",
         1,
     );
-    let wrong_reason = with_replaced_source(
-        &sources,
-        "kernel/src/task/process_task.rs",
-        wrong_reason,
-    );
+    let wrong_reason =
+        with_replaced_source(&sources, "kernel/src/task/process_task.rs", wrong_reason);
     assert!(validate_process_page_table_dispositions(&wrong_reason).is_err());
     let missing_exec_disposition = process_memory.replacen(
         "self.tables.disposition = Disposition::RetiredByExecWalk;",
@@ -3389,6 +3498,25 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         missing_exec_disposition,
     );
     assert!(validate_process_page_table_dispositions(&missing_exec_disposition).is_err());
+
+    // R3: a second retirement call, even with a different receiver spelling,
+    // is outside the one proof-gated site and must fail exact site membership.
+    let extra_retire = with_replaced_source(
+        &sources,
+        "kernel/src/task/process_task.rs",
+        format!(
+            "{process_task}\nfn synthetic_retire(page_table: &mut ProcessPageTable, pid: u64, budget: &mut u32) {{ let _ = page_table.retire_bounded(pid, budget); }}"
+        ),
+    );
+    assert!(validate_process_page_table_retire_site(&extra_retire).is_err());
+    let extra_reclaim = with_replaced_source(
+        &sources,
+        "kernel/src/task/process_task.rs",
+        format!(
+            "{process_task}\nfn synthetic_reclaim(reclaim: &mut PendingProcessReclaim) {{ let _ = reclaim.reclaim_bounded(); }}"
+        ),
+    );
+    assert!(validate_process_page_table_retire_site(&extra_reclaim).is_err());
 
     // R6: inventory membership and unconditional declarations are both pinned.
     let provider = source(&sources, "kernel/src/tracing/providers/teardown.rs");
@@ -3435,6 +3563,23 @@ fn deliberately_broken_variants_fail_the_ratchet() {
     );
     assert!(validate_process_page_table_exit_paths_are_minimal(&allocating_drop).is_err());
 
+    let logged_retire = process_memory.replacen(
+        "pub(crate) fn retire_bounded",
+        "pub(crate) fn retire_bounded",
+        1,
+    );
+    let logged_retire = logged_retire.replacen(
+        "self.tables.disposition = Disposition::Retiring;",
+        "log::info!(\"retire\"); self.tables.disposition = Disposition::Retiring;",
+        1,
+    );
+    let logged_retire = with_replaced_source(
+        &sources,
+        "kernel/src/memory/process_memory.rs",
+        logged_retire,
+    );
+    assert!(validate_process_page_table_exit_paths_are_minimal(&logged_retire).is_err());
+
     // O2/G-H: weaken either exact counter assertion and the named validator fails.
     for (needle, replacement) in [
         (
@@ -3447,12 +3592,49 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         ),
     ] {
         let weakened = process_memory.replacen(needle, replacement, 1);
+        let weakened =
+            with_replaced_source(&sources, "kernel/src/memory/process_memory.rs", weakened);
+        assert!(validate_process_page_table_runtime_oracle(&weakened).is_err());
+    }
+
+    // O1 + leak oracle: removing anti-vacuity mappings or weakening any exact
+    // per-PID/baseline equality invalidates the named validator directly.
+    let no_sentinels = provider.replacen(
+        "map_retire_sentinels(child_page_table.as_mut())",
+        "map_retire_sentinels_disabled(child_page_table.as_mut())",
+        1,
+    );
+    let no_sentinels = with_replaced_source(
+        &sources,
+        "kernel/src/tracing/providers/teardown.rs",
+        no_sentinels,
+    );
+    assert!(validate_pr1c_retirement_oracles(&no_sentinels).is_err());
+    for (needle, replacement) in [
+        (
+            "allocator_used_after != allocator_used_before {",
+            "allocator_used_after != allocator_used_before && false {",
+        ),
+        (
+            "counts.roots_retired != 1 {",
+            "counts.roots_retired != 1 && false {",
+        ),
+        (
+            "counts.table_frames_recorded != expected_tables {",
+            "counts.table_frames_recorded != expected_tables && false {",
+        ),
+        (
+            "counts.table_frames_returned != counts.table_frames_recorded + 1 {",
+            "counts.table_frames_returned != counts.table_frames_recorded + 1 && false {",
+        ),
+    ] {
+        let weakened = provider.replacen(needle, replacement, 1);
         let weakened = with_replaced_source(
             &sources,
-            "kernel/src/memory/process_memory.rs",
+            "kernel/src/tracing/providers/teardown.rs",
             weakened,
         );
-        assert!(validate_process_page_table_runtime_oracle(&weakened).is_err());
+        assert!(validate_pr1c_retirement_oracles(&weakened).is_err());
     }
 
     // R1: seven syntactically distinct ways to bypass the return choke point.
@@ -3698,8 +3880,8 @@ fn deliberately_broken_variants_fail_the_ratchet() {
     );
     assert!(validate_frame_ledger_hot_paths(&logged_counter).is_err());
     let logged_return = allocator.replacen(
-        "fn return_lease(lease: FrameLease) -> ReturnOutcome {",
-        "fn return_lease(lease: FrameLease) -> ReturnOutcome { log::info!(\"return\");",
+        "pub(crate) fn return_lease(lease: FrameLease) -> ReturnOutcome {",
+        "pub(crate) fn return_lease(lease: FrameLease) -> ReturnOutcome { log::info!(\"return\");",
         1,
     );
     let logged_return = with_replaced_source(
@@ -3709,8 +3891,8 @@ fn deliberately_broken_variants_fail_the_ratchet() {
     );
     assert!(validate_frame_ledger_hot_paths(&logged_return).is_err());
     let growing_return = allocator.replacen(
-        "fn return_lease(lease: FrameLease) -> ReturnOutcome {",
-        "fn return_lease(lease: FrameLease) -> ReturnOutcome { let _ = FREE_FRAMES.lock().try_reserve(1);",
+        "pub(crate) fn return_lease(lease: FrameLease) -> ReturnOutcome {",
+        "pub(crate) fn return_lease(lease: FrameLease) -> ReturnOutcome { let _ = FREE_FRAMES.lock().try_reserve(1);",
         1,
     );
     let growing_return = with_replaced_source(
@@ -3728,7 +3910,7 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         with_replaced_source(&sources, "kernel/src/memory/frame_allocator.rs", logged_get);
     assert!(validate_frame_ledger_hot_paths(&logged_get).is_err());
     let transitive_helper_log = allocator.replacen(
-        "fn return_lease(lease: FrameLease) -> ReturnOutcome {",
+        "pub(crate) fn return_lease(lease: FrameLease) -> ReturnOutcome {",
         "fn note_return(frame: PhysFrame) { log::info!(\"returned {:#x}\", frame.start_address().as_u64()); }\n\nfn return_lease(lease: FrameLease) -> ReturnOutcome { note_return(lease.frame);",
         1,
     );

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -1327,6 +1327,23 @@ const PROCESS_MEMORY_FRAME_RETURNS: &[(&str, usize)] = &[
     ("kernel/src/memory/process_memory.rs", 1936),
     ("kernel/src/memory/process_memory.rs", 1941),
 ];
+const RETURN_LEASE_DEFINITION: (&str, usize) = ("kernel/src/memory/frame_allocator.rs", 672);
+const RETURN_LEASE_PRODUCTION_CALLS: &[(&str, usize)] = &[
+    ("kernel/src/memory/frame_allocator.rs", 760),
+    ("kernel/src/memory/process_memory.rs", 1585),
+    ("kernel/src/memory/process_memory.rs", 1587),
+];
+const RETURN_LEASE_BOOT_FIXTURE_CALLS: &[(&str, usize)] = &[
+    ("kernel/src/memory/frame_allocator_tests.rs", 45),
+    ("kernel/src/memory/frame_allocator_tests.rs", 108),
+    ("kernel/src/memory/frame_allocator_tests.rs", 144),
+    ("kernel/src/memory/frame_allocator_tests.rs", 159),
+    ("kernel/src/memory/frame_allocator_tests.rs", 160),
+    ("kernel/src/memory/frame_allocator_tests.rs", 173),
+    ("kernel/src/memory/frame_allocator_tests.rs", 185),
+    ("kernel/src/memory/frame_allocator_tests.rs", 265),
+    ("kernel/src/memory/frame_allocator_tests.rs", 284),
+];
 const TABLE_RECORDER_SITES: &[(&str, usize)] = &[
     ("kernel/src/memory/process_memory.rs", 1133),
     ("kernel/src/memory/process_memory.rs", 1244),
@@ -1608,6 +1625,22 @@ fn validate_frame_return_choke_point(sources: &[(String, String)]) -> Result<(),
         .collect(),
         PROCESS_MEMORY_FRAME_RETURNS,
     )?;
+
+    let mut return_lease_calls = code_sites(sources, "return_lease(");
+    if !return_lease_calls.remove(&(
+        RETURN_LEASE_DEFINITION.0.to_owned(),
+        RETURN_LEASE_DEFINITION.1,
+    )) {
+        eprintln!("return_lease definition moved or disappeared");
+        return Err(());
+    }
+    let mut allowed_return_lease_calls = expected(RETURN_LEASE_PRODUCTION_CALLS);
+    allowed_return_lease_calls.extend(expected(RETURN_LEASE_BOOT_FIXTURE_CALLS));
+    if return_lease_calls != allowed_return_lease_calls {
+        eprintln!("return_lease caller escaped the production/boot-fixture allowlist");
+        return Err(());
+    }
+
     let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
     let all_returns = code_offsets(process_memory, &code_mask(process_memory), "return_lease(");
     let retire = function_body(process_memory, "retire_bounded");
@@ -3879,6 +3912,14 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         process_escape,
     );
     assert!(validate_frame_return_choke_point(&process_escape).is_err());
+    let cross_file_return = with_replaced_source(
+        &sources,
+        "kernel/src/process/manager.rs",
+        format!(
+            "{process_manager}\n#[cfg(test)] fn synthetic_cross_file_return() {{ if let Some(lease) = crate::memory::frame_allocator::allocate_frame_leased() {{ let _ = crate::memory::frame_allocator::return_lease(lease); }} }}"
+        ),
+    );
+    assert!(validate_frame_return_choke_point(&cross_file_return).is_err());
     let unseeded_bootstrap_push = allocator.replacen(
         "        bootstrap.len = 0;",
         "        free_list.push(PhysFrame::containing_address(PhysAddr::new(0x100000)));\n        bootstrap.len = 0;",


### PR DESCRIPTION
## Summary

- Add resumable `ProcessPageTable::retire_bounded` on aarch64. It returns only allocator-issued leases recorded by PR-1b, consumes at most 64 frames per selection, and returns the root last.
- Replace the proof-gated deferred receipt's non-freeing disposition with bounded retirement. Budget exhaustion reuses the existing `last_pass` queue/re-proof machinery; reclaim accounting commits only after `Complete`.
- Add committed-effect counters, strict per-PID O1 scoring, authentic O2/E/F/I/J injections, inverted x86 O3 coverage, and the decisive allocator-baseline leak oracle.
- Keep x86 and all unproved aarch64 paths non-freeing. This closes the aarch64 ordinary-exit half of #470-F3; it does not close the remaining #470 campaign work.

## Safety boundary

The only production `retire_bounded` call is `PendingProcessReclaim::reclaim_bounded`, reached only after the drain's epoch, local hardware root, remote shadow, cached scheduler root, and live/creating process-row legs all pass. A budgeted receipt is requeued intact and cannot be selected again in the same bounded pass, so continuation re-runs the proof.

`release_process_resources` and the already-terminated sites still call explicit non-freeing `abandon`. x86 still uses `NoArchPipeline`. No descriptor-derived frame is returned, and no log, formatting, heap allocation, new wait, or superlinear work was added to the retirement path.

## Mutation evidence

The leak gate measured 64 children with three sentinel mappings in distinct L0 subtrees, deriving nine intermediate tables per PID:

```text
# pre-wiring / production retire call stubbed
[PT_RETIRE_ORACLE:aarch64:cycles=64:used_before=53:used_after=693:expected_tables=9:roots=0:returned=0:lost=0]
[TEST:process:fork_exit_defer_reclaim_pairing_test:FAIL:retire leak oracle did not return frame accounting to baseline]

# retire call restored
[PT_RETIRE_ORACLE:aarch64:cycles=64:used_before=53:used_after=53:expected_tables=9:roots=64:returned=640:lost=0]
[TEST:process:fork_exit_defer_reclaim_pairing_test:PASS]
```

The exact leak was `640 = 64 * (9 intermediate tables + 1 root)`. Removing the sentinel mappings kept allocator balance but failed the strict per-PID anti-vacuity equality. Adding a second production-shaped retirement call failed R3 with `R3 process page-table retirement escaped the proof-gated site`. All mutations were restored before the final run.

## Verification

- `cargo build --release --target aarch64-breenix.json -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem -p kernel --bin kernel-aarch64` — PASS, no project warning/error.
- `docker/qemu/run-aarch64-full-test.sh --boot-tests-only --rebuild` — PASS, `92/92`, `[BOOT_TESTS:PASS]`; O1, O2, O3-aarch64 and the leak oracle green. Cargo emitted only the nightly toolchain's `core` future-incompatibility notice, not a Breenix warning.
- `cargo check --release --features testing,external_test_bins --bin qemu-uefi` — PASS, no warning/error.
- `cargo test --test teardown_structure` — PASS, 12/12 including every standing negative.
- `docker/qemu/run-x86-boot-tests.sh 1` — PASS with `[PT_CUSTODY_COUNTERS:x86:recorded=3:no_proof=0:no_arch=1:terminated=1:undecided=1:exec_unreturned=0]` and zero returned custody frames.

Diff inventory against `d749ab62`: 7 files, +868/-147. This is recorded as a fact, not a gate, per the 2026-08-11 operator ruling.

## Deviation record

Final SHA: `33033f785d9630297e788e189a730b1b76f8b1d6`.

### DESIGN §3.1 / counter inventory

**Difference:** PR-1c moves the merged counter inventory from 59 to 64, not the original design's 58 to 63.

**Justification:** binding TRAP-LIST MT-5c required PR-1a to ship the sixth `FRAME_RETURN_REFUSED_NEVER_ALLOCATED` counter. PR-1b therefore merged at 59; PR-1c adds exactly its five live counters and lands at 64.

### DESIGN §3.2 / per-PID recorded attribution

**Difference:** `table_frames_recorded` is attributed to a PID once, from the custody vector length when retirement first enters `Retiring`, rather than at each `TableRecorder` push.

**Justification:** the allocation recorder intentionally has no PID or ownership policy. The retiring receipt is the first point where both the authoritative custody set and PID coexist. The value is the exact live custody count, is recorded before any pop, and is checked per PID against the test-derived nine-table workload.

### DESIGN §3.3 / O2 fixture placement

**Difference:** O2/E runs in the existing serialized page-table custody gate; O2/F, I and J run in the existing proof/reclaim progress gate rather than a new monolithic refusal gate.

**Justification:** E must hold the real free-list lock while invoking real retirement, while F must traverse the real proof-gated queue/requeue path. Reusing the existing serialized and proof-owner gates avoids a second execution path and keeps every injected global mutation isolated and repaired where applicable.

### DESIGN §3.4 / x86 O3 workload

**Difference:** x86's inverted residual is exercised by the architecture-exclusive early direct hook using a real `ProcessPageTable` and production `abandon(NoArchPipeline)`, not by a fully scheduled process exit.

**Justification:** the merged PR-1a/1b x86 boot gate deliberately runs from `memory::init` because staged x86 dispatch remains outside this PR. It still proves the PR-1c property in scope: zero returned custody frames, exactly one counted no-architecture abandonment, and no x86 retirement call. This is not presented as proof that the later PR-3 liveness pipeline exists.

### DESIGN §4 / R3 call-site inventory

**Difference:** R3 pins one production `reclaim_bounded`→`retire_bounded` call plus three exact `boot_tests`-only direct calls required by O2/I-J in `process_task.rs`; O2/E's fourth test-only call is isolated in the frame-allocator fixture module, compiled only with `boot_tests`.

**Justification:** production freeing remains exactly one positional site after the complete root proof. The additional sites are compile-time-gated injectors for interrupted and idempotent retirement. A standing negative adds a production-shaped extra call and fails the same validator.

### DESIGN §7 / touched-file estimate

**Difference:** PR-1c also changes `frame_allocator.rs`, its boot-test module, and the x86 gate script, and the test diff is larger than the design estimate.

**Justification:** merged PR-1a kept `return_lease` private to its module; PR-1c must expose that unforgeable primitive crate-locally to consume recorded leases. The boot-test helper is needed for authentic lock contention and repair. The x86 script's exact counter vector changes because O3 constructs one additional non-freeing custody object. Per the operator ruling, diff size is not a finding and no coverage was weakened to meet an estimate.

### Intentional injection residue

**Difference:** O2/I deliberately leaves the unreturned tail of one oversized synthetic hierarchy and advances `PT_ROOT_DROPPED_MID_RETIRE` once during the injection gate.

**Justification:** that is the designated fail-closed producer: 64 already-popped leases are never returned twice, while the remaining two tables and root leak rather than free without completion. Cohort health uses windowed deltas, so this injected observation cannot masquerade as a production healthy value.

No deviation broadens the production freeing site, weakens an assertion, adds a wait, or widens a PM-held window across a scheduler acquire.

## What #470 still owes

- AArch64 exec-supersede and leaf custody: PR-2.
- x86 root liveness proof and `NoArchPipeline` retirement: PR-3, still requiring Tier-2 approval for `interrupts/context_switch.rs`.
- x86 exec-walk replacement: PR-4.
- AArch64 unproved immediate/already-terminated paths remain explicit counted abandonments; this PR does not invent proof for them.


## Integrity note — gate-target fidelity finding (added post-review)

PR-1c's first "clean" gate run showed 1 DATA_ABORT / 89 runs. RCA proved this was **not** a PR-1c defect: the throwaway gate scripts were building the hardfloat target (`aarch64-breenix.json`, NEON on) instead of the soft-float kernel target (`aarch64-breenix-kernel.json`), which re-armed the unrelated `#528` NEON/soft-float fault (~1/600 base rate). With the gate scripts corrected to build the soft-float kernel target, PR-1c re-proved clean: 0/2000 clean boots, starved 0/100, beast 3/3, Parallels 3/3 long-window.

## Revert safety

This PR reverts alone via `git revert` — no dependent commits sit on top of it in this branch, and it touches only the aarch64 exit/custody-retirement path plus its own test oracles.

## Relationship to #470

References #470: closes the F3 aarch64 half; F4 aarch64 exec-leaves and the x86 free path remain (PR-2/PR-3).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
