### PR TITLE
build(aarch64): guard kernel ELF against NEON/FP re-arming #528; fix wrong-target build sites

### DIFF
--- a/docker/qemu/run-aarch64-full-test.sh
+++ b/docker/qemu/run-aarch64-full-test.sh
@@ -51,6 +51,11 @@ if [ ! -f "$KERNEL" ]; then
     exit 1
 fi
 
+# Durable #528 guard: the kernel MUST be soft-float. Fail fast if it was built
+# with the NEON hardfloat target (aarch64-breenix.json) — that re-arms #528.
+# (set -e aborts the test if the guard trips.)
+"$BREENIX_ROOT/scripts/check-kernel-no-neon.sh" "$KERNEL"
+
 # Find ext2 disk
 EXT2_DISK="$BREENIX_ROOT/target/ext2-aarch64.img"
 if [ ! -f "$EXT2_DISK" ]; then

--- a/scripts/check-kernel-no-neon.sh
+++ b/scripts/check-kernel-no-neon.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# check-kernel-no-neon.sh — durable guard against re-arming issue #528.
+#
+# The aarch64 kernel MUST be built with the soft-float target
+# aarch64-breenix-kernel.json ("features": "...,-neon,-fp-armv8",
+# "abi": "softfloat"). A correctly-built kernel therefore contains ZERO
+# vector/FP load or store instructions in its .text sections.
+#
+# If the kernel is ever built with the userspace NEON hardfloat target
+# (aarch64-breenix.json) by mistake — as throwaway gate scripts did, silently
+# re-arming #528 (see the #470 PR-1c RCA) — compiler-builtins' memcpy/memset
+# and ordinary register spills begin using q/d/s/v registers on the kernel
+# stack before the FPU trap is configured, producing the #528 fault class.
+#
+# This guard objdumps the kernel ELF, walks every .text* section, and FAILS
+# if any FP/SIMD (q/d/s/v) load or store instruction appears in kernel code
+# outside the documented allowlist (scripts/kernel-neon-allowlist.txt, which
+# is intentionally empty — kernel code must be zero).
+#
+# Exit code:
+#   0 - clean (no non-allowlisted FP/SIMD load/store in kernel .text)
+#   1 - guard tripped (offending instructions found)  OR  usage/tooling error
+#
+# Usage:
+#   ./scripts/check-kernel-no-neon.sh [path/to/kernel-elf]
+# Default ELF: target/aarch64-breenix-kernel/release/kernel-aarch64
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+KERNEL_ELF="${1:-$REPO_ROOT/target/aarch64-breenix-kernel/release/kernel-aarch64}"
+ALLOWLIST="$REPO_ROOT/scripts/kernel-neon-allowlist.txt"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+
+if [ ! -f "$KERNEL_ELF" ]; then
+    echo -e "${RED}ERROR:${NC} kernel ELF not found: $KERNEL_ELF" >&2
+    echo "Build it first with the SOFT-FLOAT kernel target:" >&2
+    echo "  cargo build --release --target aarch64-breenix-kernel.json \\" >&2
+    echo "    -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem \\" >&2
+    echo "    -p kernel --bin kernel-aarch64" >&2
+    exit 1
+fi
+
+# --- locate an aarch64-capable objdump -------------------------------------
+# Prefer llvm-objdump (ships with the rust toolchain, disassembles any target).
+find_objdump() {
+    if command -v llvm-objdump >/dev/null 2>&1; then
+        echo "llvm-objdump"; return 0
+    fi
+    local sysroot cand
+    sysroot="$(rustc --print sysroot 2>/dev/null)"
+    if [ -n "$sysroot" ]; then
+        cand="$(ls "$sysroot"/lib/rustlib/*/bin/llvm-objdump 2>/dev/null | head -1)"
+        if [ -n "$cand" ]; then echo "$cand"; return 0; fi
+    fi
+    # GNU binutils fallback (Linux CI hosts). macOS /usr/bin/objdump is llvm-based.
+    if command -v objdump >/dev/null 2>&1; then
+        echo "objdump"; return 0
+    fi
+    return 1
+}
+
+OBJDUMP="$(find_objdump)" || {
+    echo -e "${RED}ERROR:${NC} no objdump found (need llvm-objdump or objdump on PATH)." >&2
+    exit 1
+}
+
+echo "Guard: kernel FP/SIMD instruction check"
+echo "  ELF:       $KERNEL_ELF"
+echo "  objdump:   $OBJDUMP"
+echo "  allowlist: $ALLOWLIST"
+
+# --- disassemble and scan ---------------------------------------------------
+DISASM="$("$OBJDUMP" -d "$KERNEL_ELF" 2>/dev/null)" || {
+    echo -e "${RED}ERROR:${NC} objdump failed on $KERNEL_ELF" >&2
+    exit 1
+}
+
+# One awk pass over the full disassembly:
+#   * track the current section (only .text* is kernel code)
+#   * track the owning symbol of each instruction
+#   * flag any load/store whose first operand is an FP/SIMD (q/d/s/v) register
+#   * suppress offenders whose owning symbol matches an allowlist regex
+REPORT="$(printf '%s\n' "$DISASM" | awk -v allowfile="$ALLOWLIST" '
+BEGIN {
+    na = 0;
+    while ((getline line < allowfile) > 0) {
+        sub(/#.*/, "", line);
+        gsub(/^[ \t]+|[ \t]+$/, "", line);
+        if (line != "") allow[na++] = line;
+    }
+    insection = 0; sym = "?";
+    total = 0; suppressed = 0; violations = 0; nprinted = 0;
+    # FP/SIMD load or store: mnemonic starts ld/st, first operand is a
+    # q/d/s/v register. GP registers are x/w/sp/xzr/wzr and never match
+    # [qdsv][0-9], so this uniquely selects vector/FP loads and stores.
+    fpre = "[ \t](ld|st)[a-z0-9]*[ \t]+[{]?[ \t]*[qdsv][0-9]";
+}
+/^Disassembly of section / {
+    insection = ($0 ~ /section \.text/) ? 1 : 0;
+    next;
+}
+/^[0-9a-fA-F]+ <.*>:/ {
+    s = $0;
+    sub(/^[0-9a-fA-F]+ </, "", s);
+    sub(/>:.*$/, "", s);
+    sym = s;
+    next;
+}
+{
+    if (!insection) next;
+    if ($0 !~ /^[ \t]*[0-9a-fA-F]+:/) next;   # instruction lines only
+    if ($0 !~ fpre) next;                      # FP/SIMD load/store only
+    total++;
+    allowed = 0;
+    for (i = 0; i < na; i++) {
+        if (sym ~ allow[i]) { allowed = 1; break; }
+    }
+    if (allowed) { suppressed++; next; }
+    v = $0; sub(/^[ \t]+/, "", v);
+    if (nprinted < 40) { printf("  %-58s  %s\n", sym, v); nprinted++; }
+    violations++;
+}
+END {
+    printf("__SUMMARY__ total=%d suppressed=%d violations=%d\n",
+           total, suppressed, violations);
+}
+')"
+
+SUMMARY="$(printf '%s\n' "$REPORT" | grep '^__SUMMARY__')"
+SUPPRESSED="$(echo "$SUMMARY" | sed -n 's/.*suppressed=\([0-9]*\).*/\1/p')"
+VIOLATIONS="$(echo "$SUMMARY" | sed -n 's/.*violations=\([0-9]*\).*/\1/p')"
+SUPPRESSED="${SUPPRESSED:-0}"; VIOLATIONS="${VIOLATIONS:-0}"
+
+OFFENDERS="$(printf '%s\n' "$REPORT" | grep -v '^__SUMMARY__' | grep -v '^[[:space:]]*$')"
+
+if [ "$VIOLATIONS" -eq 0 ]; then
+    echo -e "${GREEN}PASS:${NC} 0 FP/SIMD load/store instructions in kernel .text" \
+            "(allowlisted & suppressed: $SUPPRESSED)."
+    exit 0
+fi
+
+echo -e "${RED}FAIL:${NC} found $VIOLATIONS FP/SIMD load/store instruction(s) in kernel .text." >&2
+echo -e "${YELLOW}This means the kernel was built with the NEON hardfloat target" >&2
+echo -e "(aarch64-breenix.json) instead of the soft-float kernel target" >&2
+echo -e "(aarch64-breenix-kernel.json) — re-arming issue #528.${NC}" >&2
+echo "Offending instructions (symbol  ->  instruction), first 40:" >&2
+printf '%s\n' "$OFFENDERS" >&2
+exit 1

--- a/scripts/kernel-neon-allowlist.txt
+++ b/scripts/kernel-neon-allowlist.txt
@@ -1,0 +1,23 @@
+# Kernel NEON/FP-store guard allowlist  (see scripts/check-kernel-no-neon.sh)
+#
+# The aarch64 kernel is compiled with the SOFT-FLOAT target
+# aarch64-breenix-kernel.json ("features": "...,-neon,-fp-armv8", "abi":
+# "softfloat"). A correctly-built kernel therefore contains ZERO vector/FP
+# load or store instructions in its .text sections. If the kernel is ever
+# built with the userspace NEON hardfloat target (aarch64-breenix.json) by
+# mistake, compiler-builtins' memcpy/memset and ordinary spills start using
+# q/d/s/v registers on the kernel stack before the FPU trap is configured —
+# this is the exact fault class tracked by issue #528 (see the #470 PR-1c RCA).
+#
+# Each non-comment, non-blank line is an EXTENDED-REGEX matched against the
+# demangled/mangled symbol name that owns an offending instruction. A match
+# means "this FP/SIMD use in kernel code is intentional and reviewed."
+#
+# POLICY: keep this list EMPTY. Kernel code must not use FP/SIMD. Only add a
+# symbol here if a maintainer has deliberately introduced reviewed FP/SIMD
+# kernel code (e.g. an explicit userspace FPSIMD context save/restore routine),
+# and document why on the same line. An allowlisted entry is NOT a licence to
+# build the whole kernel with the NEON target — that path stays banned.
+#
+# --- allowlisted symbols (regex, one per line) ---
+# (intentionally empty)

--- a/tests/kernel_no_neon_guard.rs
+++ b/tests/kernel_no_neon_guard.rs
@@ -1,0 +1,93 @@
+//! Durable guard against re-arming issue #528.
+//!
+//! The aarch64 kernel MUST be compiled with the soft-float kernel target
+//! `aarch64-breenix-kernel.json` (`-neon,-fp-armv8`, `abi: softfloat`). A
+//! correctly-built kernel therefore contains **zero** vector/FP load or store
+//! instructions in its `.text` sections.
+//!
+//! If the kernel is ever built with the userspace NEON hardfloat target
+//! `aarch64-breenix.json` by mistake — as throwaway gate scripts did, silently
+//! re-arming #528 (see the #470 PR-1c RCA) — `compiler-builtins`' memcpy/memset
+//! and ordinary register spills begin using `q`/`d`/`s`/`v` registers on the
+//! kernel stack before the FPU trap is configured, producing the #528 fault
+//! class.
+//!
+//! This host-side test builds the aarch64 kernel with the correct soft-float
+//! target and runs `scripts/check-kernel-no-neon.sh`, which objdumps the ELF
+//! and asserts zero non-allowlisted FP/SIMD load/store instructions in kernel
+//! code. It is wired into the standard `cargo test` invocation and mirrors the
+//! guard that `docker/qemu/run-aarch64-full-test.sh` runs on every boot test.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Build the aarch64 kernel with the SOFT-FLOAT kernel target, then assert the
+/// resulting ELF contains no FP/SIMD load/store instructions in kernel code.
+#[test]
+fn kernel_elf_has_no_neon_fp_stores() {
+    let root = repo_root();
+
+    // Build the kernel with the correct soft-float target. The toolchain is
+    // pinned via rust-toolchain.toml, so plain `cargo build` is correct.
+    let build = Command::new("cargo")
+        .current_dir(&root)
+        .args([
+            "build",
+            "--release",
+            "--target",
+            "aarch64-breenix-kernel.json",
+            "-Z",
+            "build-std=core,alloc",
+            "-Z",
+            "build-std-features=compiler-builtins-mem",
+            "-p",
+            "kernel",
+            "--bin",
+            "kernel-aarch64",
+        ])
+        .output()
+        .expect("failed to spawn cargo build for the aarch64 kernel");
+
+    if !build.status.success() {
+        panic!(
+            "aarch64 kernel build failed:\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr),
+        );
+    }
+
+    let kernel_elf = root.join("target/aarch64-breenix-kernel/release/kernel-aarch64");
+    assert!(
+        kernel_elf.exists(),
+        "expected kernel ELF at {} after build",
+        kernel_elf.display()
+    );
+
+    let guard = root.join("scripts/check-kernel-no-neon.sh");
+    let check = Command::new("bash")
+        .current_dir(&root)
+        .arg(&guard)
+        .arg(&kernel_elf)
+        .output()
+        .expect("failed to spawn scripts/check-kernel-no-neon.sh");
+
+    let stdout = String::from_utf8_lossy(&check.stdout);
+    let stderr = String::from_utf8_lossy(&check.stderr);
+    println!("{stdout}");
+    if !stderr.is_empty() {
+        eprintln!("{stderr}");
+    }
+
+    assert!(
+        check.status.success(),
+        "NEON/FP guard tripped: the kernel ELF contains FP/SIMD load/store \
+         instructions in kernel code. The kernel was almost certainly built \
+         with the NEON hardfloat target (aarch64-breenix.json) instead of the \
+         soft-float kernel target (aarch64-breenix-kernel.json), re-arming \
+         issue #528. See the guard output above."
+    );
+}


### PR DESCRIPTION
## Root cause
The aarch64 kernel must be compiled with the **soft-float** target `aarch64-breenix-kernel.json` (`features: ...,-neon,-fp-armv8`, `abi: softfloat`). Throwaway/untracked gate scripts silently re-armed **#528** by building the kernel with the **userspace NEON hardfloat** target `aarch64-breenix.json`. Under NEON codegen, `compiler-builtins`' `memcpy`/`memset` and ordinary register spills emit `q`/`d`/`s`/`v` stores onto the kernel stack **before the FPU trap is configured** — the exact fault class of #528 (see the #470 PR-1c RCA). Nothing at the ELF level caught it, so the mistake was invisible until it faulted at boot.

## Durable fix (the class, not the symptom)
A tracked guard that asserts the compiled kernel ELF has **zero** vector/FP load/store instructions in kernel code:

- **`scripts/check-kernel-no-neon.sh`** — objdumps `target/aarch64-breenix-kernel/release/kernel-aarch64`, walks every `.text*` section, and FAILS (exit 1) on any FP/SIMD (`q`/`d`/`s`/`v`) load/store outside a documented allowlist. Locates `llvm-objdump` via PATH → rust sysroot → GNU `objdump` fallback, so it runs on both the ARM Mac and Linux CI hosts.
- **`scripts/kernel-neon-allowlist.txt`** — documented, **intentionally empty** (kernel code must be zero); mechanism proven to suppress by symbol regex if a maintainer ever adds reviewed FPSIMD kernel code.
- **`tests/kernel_no_neon_guard.rs`** — builds the kernel with the correct target and runs the guard, so the standard `cargo test` invocation covers it (`cargo test --test kernel_no_neon_guard`).
- **`docker/qemu/run-aarch64-full-test.sh`** — runs the guard before every boot test; `set -e` aborts on a trip.

Proven both ways: **0** FP/SIMD stores on the correct soft-float build, **2869** on a deliberately poisoned NEON build (scheduler, ahci, context-switch, `launch_init_from_elf`, …). This guard would have caught the gate-script bug immediately.

## Audit of wrong-target build sites
Grepped the whole tree (`run.sh`, `docker/qemu/*`, `scripts/*`, `xtask`, `CLAUDE.md`). **Every current tracked build site already uses the correct `aarch64-breenix-kernel.json`** — including `CLAUDE.md`, which pins the soft-float target with an explanatory comment. The remaining `aarch64-breenix.json` kernel references are historical factory/handoff records under `docs/planning/` that were correct pre-split and are left as history. There was **no tracked executable build site to fix**; the re-arming came from untracked throwaway scripts — which is precisely why the ELF-level guard, not another script edit, is the durable fix.

## Verification
- Both aarch64 kernel builds (default + `boot_tests`) clean, zero real warnings (excluding the core v0.0.0 toolchain notice).
- `cargo test --test teardown_structure` — 12/12 pass.
- `cargo test --test kernel_no_neon_guard` — pass.
- `docker/qemu/run-aarch64-full-test.sh --boot-tests-only --rebuild` — guard PASS, then `[BOOT_TESTS:PASS]` 92/92, exit 0.
- 100-boot correctness gate on the corrected soft-float target (re-confirms main is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)