### PR TITLE
fix(aarch64): leaf-frame custody + exec-path leaf release (#470 F4)

### DIFF
--- a/kernel/src/arch_impl/aarch64/elf.rs
+++ b/kernel/src/arch_impl/aarch64/elf.rs
@@ -500,8 +500,12 @@ fn load_segment_into_page_table(
                 page_vaddr.as_u64()
             );
 
-            // Map the page in the process page table
-            page_table.map_page(page, new_frame, page_flags)?;
+            // Map the page in the process page table. A refusal leaves the
+            // frame unpublished, so the loader still owns its return.
+            if let Err(error) = page_table.map_page(page, new_frame, page_flags) {
+                let _ = crate::memory::frame_allocator::deallocate_leaf_frame(new_frame);
+                return Err(error);
+            }
 
             (new_frame, false)
         };

--- a/kernel/src/arch_impl/aarch64/exception.rs
+++ b/kernel/src/arch_impl/aarch64/exception.rs
@@ -2037,8 +2037,8 @@ fn exception_class_name(ec: u32) -> &'static str {
 fn handle_cow_fault_arm64(far: u64, iss: u32) -> bool {
     use crate::memory::arch_stub::{Page, Size4KiB, VirtAddr};
     use crate::memory::cow_stats;
-    use crate::memory::frame_allocator::allocate_frame;
-    use crate::memory::frame_metadata::{frame_decref, frame_is_shared, frame_register};
+    use crate::memory::frame_allocator::{allocate_frame, deallocate_leaf_frame};
+    use crate::memory::frame_metadata::frame_is_shared;
     use crate::memory::process_memory::{is_cow_page, make_private_flags};
 
     // Check if this is a CoW fault:
@@ -2146,9 +2146,6 @@ fn handle_cow_fault_arm64(far: u64, iss: u32) -> bool {
         }
     };
 
-    // Register the new frame so it's tracked for cleanup on process exit
-    frame_register(new_frame);
-
     // Copy page contents via HHDM
     let hhdm_base = crate::arch_impl::aarch64::constants::HHDM_BASE;
     let src = (hhdm_base + old_frame.start_address().as_u64()) as *const u8;
@@ -2161,14 +2158,14 @@ fn handle_cow_fault_arm64(far: u64, iss: u32) -> bool {
     // Unmap old page and map new one with write permissions
     let new_flags = make_private_flags(old_flags);
     if page_table.unmap_page(page).is_err() {
+        let _ = deallocate_leaf_frame(new_frame);
         return false;
     }
     if page_table.map_page(page, new_frame, new_flags).is_err() {
+        let _ = page_table.map_page(page, old_frame, old_flags);
+        let _ = deallocate_leaf_frame(new_frame);
         return false;
     }
-
-    // Decrement reference count on old frame
-    frame_decref(old_frame);
 
     // Flush TLB for the CoW-copied page
     unsafe {

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -747,8 +747,8 @@ fn handle_cow_with_manager(
     faulting_addr: VirtAddr,
     cr3: u64,
 ) -> bool {
-    use crate::memory::frame_allocator::allocate_frame;
-    use crate::memory::frame_metadata::{frame_decref, frame_is_shared, frame_register};
+    use crate::memory::frame_allocator::{allocate_frame, deallocate_leaf_frame};
+    use crate::memory::frame_metadata::frame_is_shared;
     use crate::memory::process_memory::{is_cow_page, make_private_flags};
     use x86_64::structures::paging::{Page, Size4KiB};
 
@@ -797,9 +797,6 @@ fn handle_cow_with_manager(
         None => return false,
     };
 
-    // Register the new frame so it's tracked for cleanup on process exit
-    frame_register(new_frame);
-
     // Copy page contents
     let phys_offset = crate::memory::physical_memory_offset();
     unsafe {
@@ -811,14 +808,14 @@ fn handle_cow_with_manager(
     // Update page table: unmap old, map new with writable flags
     let new_flags = make_private_flags(old_flags);
     if page_table.unmap_page(page).is_err() {
+        let _ = deallocate_leaf_frame(new_frame);
         return false;
     }
     if page_table.map_page(page, new_frame, new_flags).is_err() {
+        let _ = page_table.map_page(page, old_frame, old_flags);
+        let _ = deallocate_leaf_frame(new_frame);
         return false;
     }
-
-    // Decrement old frame reference count
-    frame_decref(old_frame);
 
     // Flush TLB for this page
     X86PageTableOps::flush_tlb_page(faulting_addr.as_u64());
@@ -831,8 +828,11 @@ fn handle_cow_with_manager(
 /// This function walks the page table manually and modifies entries directly,
 /// avoiding the need to acquire the process manager lock.
 fn handle_cow_direct(faulting_addr: VirtAddr, cr3: u64) -> bool {
-    use crate::memory::frame_allocator::allocate_frame;
-    use crate::memory::frame_metadata::{frame_decref, frame_is_shared, frame_register};
+    use crate::memory::frame_allocator::{
+        acquire_leaf_mapping, allocate_frame, deallocate_leaf_frame, LeafMappingClass,
+        ReturnOutcome,
+    };
+    use crate::memory::frame_metadata::{frame_decref, frame_is_shared};
     use crate::memory::process_memory::{is_cow_page, make_private_flags};
     use x86_64::structures::paging::{PageTable, PageTableFlags, PhysFrame, Size4KiB};
 
@@ -911,20 +911,24 @@ fn handle_cow_direct(faulting_addr: VirtAddr, cr3: u64) -> bool {
             None => return false,
         };
 
-        // Register the new frame so it's tracked for cleanup on process exit
-        frame_register(new_frame);
-
         // Copy page contents
         let src = (phys_offset + old_frame.start_address().as_u64()).as_ptr::<u8>();
         let dst = (phys_offset + new_frame.start_address().as_u64()).as_mut_ptr::<u8>();
         core::ptr::copy_nonoverlapping(src, dst, 4096);
 
-        // Update the L1 entry with new frame and writable flags
+        // The virtual-page custody record remains Owned across a CoW
+        // replacement. Acquire the new allocator-derived reference before the
+        // descriptor becomes visible, then release the old reference after.
+        if acquire_leaf_mapping(new_frame) != Ok(LeafMappingClass::Owned) {
+            let _ = deallocate_leaf_frame(new_frame);
+            return false;
+        }
         let new_flags = make_private_flags(old_flags);
         l1_entry.set_addr(new_frame.start_address(), new_flags);
 
-        // Decrement old frame reference count
-        frame_decref(old_frame);
+        if frame_decref(old_frame) && deallocate_leaf_frame(old_frame) == ReturnOutcome::Returned {
+            crate::trace_count!(crate::tracing::providers::teardown::LEAF_FRAMES_RETURNED);
+        }
 
         // Flush TLB
         X86PageTableOps::flush_tlb_page(faulting_addr.as_u64());
@@ -1030,11 +1034,9 @@ fn handle_stack_growth(faulting_addr: VirtAddr, cr3: u64) -> bool {
             | PageTableFlags::NO_EXECUTE;
 
         if page_table.map_page(page, frame, flags).is_err() {
+            let _ = crate::memory::frame_allocator::deallocate_leaf_frame(frame);
             return false;
         }
-
-        // Register the frame for cleanup tracking
-        crate::memory::frame_metadata::frame_register(frame);
 
         addr += 4096;
     }

--- a/kernel/src/memory/frame_allocator.rs
+++ b/kernel/src/memory/frame_allocator.rs
@@ -51,8 +51,41 @@ const STATE_MASK: u32 = 0b11;
 /// Demand-backed frame state indexed by the allocator's usable-frame ordinal.
 /// Only the directory and chunks below the boot frontier are allocated at init;
 /// later chunks are prepared before the sequential frontier publishes a frame.
+struct FrameLedgerSlot {
+    allocation: AtomicU32,
+    leaf_refs: AtomicU32,
+}
+
+impl FrameLedgerSlot {
+    fn new(allocation: u32) -> Self {
+        Self {
+            allocation: AtomicU32::new(allocation),
+            leaf_refs: AtomicU32::new(0),
+        }
+    }
+
+    fn load(&self, order: Ordering) -> u32 {
+        self.allocation.load(order)
+    }
+
+    fn store(&self, value: u32, order: Ordering) {
+        self.allocation.store(value, order);
+    }
+
+    fn compare_exchange(
+        &self,
+        current: u32,
+        new: u32,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<u32, u32> {
+        self.allocation
+            .compare_exchange(current, new, success, failure)
+    }
+}
+
 struct FrameLedger {
-    chunks: &'static [spin::Once<&'static [AtomicU32]>],
+    chunks: &'static [spin::Once<&'static [FrameLedgerSlot]>],
     total_frames: usize,
     initial_frontier: usize,
 }
@@ -70,7 +103,7 @@ impl FrameLedger {
         })
     }
 
-    fn ensure_chunk(&self, index: usize) -> Result<&'static [AtomicU32], ()> {
+    fn ensure_chunk(&self, index: usize) -> Result<&'static [FrameLedgerSlot], ()> {
         if index >= self.total_frames {
             return Err(());
         }
@@ -94,18 +127,18 @@ impl FrameLedger {
                 ST_NEVER
             };
             slot_index += 1;
-            AtomicU32::new(state)
+            FrameLedgerSlot::new(state)
         });
 
         let mut prepared = Some(slots);
         let published = self.chunks[chunk_index].call_once(|| {
             Vec::leak(prepared.take().expect("prepared frame-ledger chunk"))
-                as &'static [AtomicU32]
+                as &'static [FrameLedgerSlot]
         });
         Ok(*published)
     }
 
-    fn get(&self, index: usize) -> Option<&AtomicU32> {
+    fn get(&self, index: usize) -> Option<&FrameLedgerSlot> {
         if index >= self.total_frames {
             return None;
         }
@@ -151,7 +184,27 @@ pub(crate) enum ReturnOutcome {
     RefusedStale,
     RefusedNeverAllocated,
     RefusedUntracked,
+    RefusedLiveLeaf,
 }
+
+const LEAF_EXTERNAL: u32 = u32::MAX;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LeafMappingClass {
+    Owned,
+    External,
+}
+
+#[derive(Clone, Copy)]
+struct ExternalLeafSpan {
+    start: u64,
+    end: u64,
+}
+
+const EMPTY_EXTERNAL_LEAF_SPAN: ExternalLeafSpan = ExternalLeafSpan { start: 0, end: 0 };
+const MAX_EXTERNAL_LEAF_SPANS: usize = 16;
+static EXTERNAL_LEAF_SPANS: Mutex<[ExternalLeafSpan; MAX_EXTERNAL_LEAF_SPANS]> =
+    Mutex::new([EMPTY_EXTERNAL_LEAF_SPAN; MAX_EXTERNAL_LEAF_SPANS]);
 
 /// Free list for deallocated frames
 /// When frames are deallocated (e.g., after CoW copy reduces refcount to 0),
@@ -261,6 +314,203 @@ fn frame_ordinal(frame: PhysFrame) -> Option<usize> {
     None
 }
 
+fn frame_in_external_leaf_span(frame: PhysFrame) -> bool {
+    let address = frame.start_address().as_u64();
+    EXTERNAL_LEAF_SPANS
+        .lock()
+        .iter()
+        .any(|span| span.start != span.end && (span.start..span.end).contains(&address))
+}
+
+fn mark_external_leaf_slot(frame: PhysFrame) -> Result<bool, &'static str> {
+    let Some(index) = frame_ordinal(frame) else {
+        return Ok(false);
+    };
+    let Some(ledger) = FRAME_LEDGER.get() else {
+        return Err("frame ledger not initialized");
+    };
+    let Some(slot) = ledger.get(index) else {
+        return Err("external leaf frame has no realized allocator slot");
+    };
+    if slot.load(Ordering::Acquire) & STATE_MASK != ST_ALLOCATED {
+        return Err("external leaf frame is not allocator-owned and live");
+    }
+    loop {
+        let refs = slot.leaf_refs.load(Ordering::Acquire);
+        if refs == LEAF_EXTERNAL {
+            return Ok(true);
+        }
+        if refs != 0 {
+            return Err("external leaf frame already has owned mappings");
+        }
+        if slot
+            .leaf_refs
+            .compare_exchange(0, LEAF_EXTERNAL, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return Ok(true);
+        }
+    }
+}
+
+/// Register allocator-backed memory that remains owned outside process page
+/// tables. Mapping code does not choose this class: the owning allocator site
+/// marks the frame before any user descriptor can be published.
+pub(crate) fn register_external_leaf_frame(frame: PhysFrame) -> Result<(), &'static str> {
+    if mark_external_leaf_slot(frame)? {
+        Ok(())
+    } else {
+        Err("external leaf frame is outside allocator memory")
+    }
+}
+
+/// Register a kernel/device-owned physical span before it is exposed through a
+/// process page table. Allocator-backed pages also receive the per-frame marker;
+/// device apertures remain authoritative through this fixed-capacity registry.
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn register_external_leaf_span(
+    start: PhysAddr,
+    byte_len: u64,
+) -> Result<(), &'static str> {
+    let start = start.as_u64();
+    if start & 0xfff != 0 || byte_len == 0 || byte_len & 0xfff != 0 {
+        return Err("external leaf span must be nonempty and page-aligned");
+    }
+    let end = start
+        .checked_add(byte_len)
+        .ok_or("external leaf span overflow")?;
+
+    let mut address = start;
+    while address < end {
+        let frame = PhysFrame::containing_address(PhysAddr::new(address));
+        mark_external_leaf_slot(frame)?;
+        address += 4096;
+    }
+
+    let mut spans = EXTERNAL_LEAF_SPANS.lock();
+    if spans
+        .iter()
+        .any(|span| span.start == start && span.end == end)
+    {
+        return Ok(());
+    }
+    let Some(slot) = spans.iter_mut().find(|span| span.start == span.end) else {
+        return Err("external leaf span registry full");
+    };
+    *slot = ExternalLeafSpan { start, end };
+    Ok(())
+}
+
+/// Derive one mapping reference from allocator state before its descriptor is
+/// published. The caller must roll the reference back if mapping fails.
+pub(crate) fn acquire_leaf_mapping(frame: PhysFrame) -> Result<LeafMappingClass, &'static str> {
+    if frame_in_external_leaf_span(frame) {
+        return Ok(LeafMappingClass::External);
+    }
+    let Some(index) = frame_ordinal(frame) else {
+        crate::trace_count!(crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED);
+        return Err("leaf frame is neither allocator-owned nor registered external memory");
+    };
+    let Some(ledger) = FRAME_LEDGER.get() else {
+        crate::trace_count!(crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED);
+        return Err("frame ledger not initialized");
+    };
+    let Some(slot) = ledger.get(index) else {
+        crate::trace_count!(crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED);
+        return Err("leaf frame has no realized allocator slot");
+    };
+    if slot.load(Ordering::Acquire) & STATE_MASK != ST_ALLOCATED {
+        crate::trace_count!(crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED);
+        return Err("leaf frame is not allocator-owned and live");
+    }
+
+    loop {
+        let refs = slot.leaf_refs.load(Ordering::Acquire);
+        if refs == LEAF_EXTERNAL {
+            return Ok(LeafMappingClass::External);
+        }
+        if refs == LEAF_EXTERNAL - 1 {
+            crate::trace_count!(crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED);
+            return Err("leaf mapping reference count exhausted");
+        }
+        if slot
+            .leaf_refs
+            .compare_exchange(refs, refs + 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            if slot.load(Ordering::Acquire) & STATE_MASK == ST_ALLOCATED {
+                return Ok(LeafMappingClass::Owned);
+            }
+            slot.leaf_refs.fetch_sub(1, Ordering::AcqRel);
+            crate::trace_count!(crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED);
+            return Err("leaf frame changed allocator state during classification");
+        }
+    }
+}
+
+/// Release one allocator-derived mapping reference. Unregistered, external,
+/// or non-live frames fail closed and can never be returned by this operation.
+pub(crate) fn decref_leaf_mapping(frame: PhysFrame) -> bool {
+    let Some(index) = frame_ordinal(frame) else {
+        crate::trace_count!(crate::tracing::providers::teardown::LEAF_DECREF_UNREGISTERED);
+        return false;
+    };
+    let Some(slot) = FRAME_LEDGER.get().and_then(|ledger| ledger.get(index)) else {
+        crate::trace_count!(crate::tracing::providers::teardown::LEAF_DECREF_UNREGISTERED);
+        return false;
+    };
+    if slot.load(Ordering::Acquire) & STATE_MASK != ST_ALLOCATED {
+        crate::trace_count!(crate::tracing::providers::teardown::LEAF_DECREF_UNREGISTERED);
+        return false;
+    }
+
+    loop {
+        let refs = slot.leaf_refs.load(Ordering::Acquire);
+        if refs == LEAF_EXTERNAL {
+            return false;
+        }
+        if refs == 0 {
+            crate::trace_count!(crate::tracing::providers::teardown::LEAF_DECREF_UNREGISTERED);
+            return false;
+        }
+        if slot
+            .leaf_refs
+            .compare_exchange(refs, refs - 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return refs == 1;
+        }
+    }
+}
+
+pub(crate) fn leaf_mapping_refcount(frame: PhysFrame) -> u32 {
+    if frame_in_external_leaf_span(frame) {
+        return LEAF_EXTERNAL;
+    }
+    frame_ordinal(frame)
+        .and_then(|index| FRAME_LEDGER.get()?.get(index))
+        .map(|slot| slot.leaf_refs.load(Ordering::Acquire))
+        .unwrap_or(0)
+}
+
+pub(crate) fn leaf_mapping_stats() -> (usize, u64) {
+    let Some(ledger) = FRAME_LEDGER.get() else {
+        return (0, 0);
+    };
+    let mut tracked = 0usize;
+    let mut total_refs = 0u64;
+    for chunk in ledger.chunks.iter().filter_map(spin::Once::get) {
+        for slot in chunk.iter() {
+            let refs = slot.leaf_refs.load(Ordering::Relaxed);
+            if refs != 0 && refs != LEAF_EXTERNAL {
+                tracked += 1;
+                total_refs += refs as u64;
+            }
+        }
+    }
+    (tracked, total_refs)
+}
+
 fn seed_free_frame(ledger: &FrameLedger, frame: PhysFrame) -> bool {
     let Some(index) = frame_ordinal(frame) else {
         crate::tracing::providers::teardown::FRAME_RETURN_REFUSED_UNTRACKED.increment();
@@ -342,10 +592,7 @@ pub fn init_frame_ledger() {
     }
 
     // No allocation may race the snapshot used to seed ST_ALLOCATED/ST_NEVER.
-    assert_eq!(
-        NEXT_FREE_FRAME.load(Ordering::Acquire),
-        frontier_snapshot
-    );
+    assert_eq!(NEXT_FREE_FRAME.load(Ordering::Acquire), frontier_snapshot);
     FRAME_LEDGER.call_once(|| ledger);
 }
 
@@ -610,6 +857,10 @@ fn claim_frame(frame: PhysFrame) -> Result<Option<FrameLease>, ClaimError> {
         let observed = slot.load(Ordering::Acquire);
         match observed & STATE_MASK {
             ST_NEVER | ST_FREE => {
+                if slot.leaf_refs.load(Ordering::Acquire) != 0 {
+                    crate::trace_count!(crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED);
+                    return Err(ClaimError::Duplicate);
+                }
                 let generation = (observed >> 2).wrapping_add(1) & 0x3fff_ffff;
                 let allocated = (generation << 2) | ST_ALLOCATED;
                 if slot
@@ -664,6 +915,7 @@ fn counted(outcome: ReturnOutcome) -> ReturnOutcome {
             teardown::FRAME_RETURN_REFUSED_NEVER_ALLOCATED.increment()
         }
         ReturnOutcome::RefusedUntracked => teardown::FRAME_RETURN_REFUSED_UNTRACKED.increment(),
+        ReturnOutcome::RefusedLiveLeaf => teardown::FRAME_RETURN_REFUSED_LIVE_LEAF.increment(),
         ReturnOutcome::Returned => {}
     }
     outcome
@@ -704,6 +956,9 @@ pub(crate) fn return_lease(lease: FrameLease) -> ReturnOutcome {
         }
         match observed & STATE_MASK {
             ST_ALLOCATED => {
+                if slot.leaf_refs.load(Ordering::Acquire) != 0 {
+                    return counted(ReturnOutcome::RefusedLiveLeaf);
+                }
                 let free = (observed & !STATE_MASK) | ST_FREE;
                 if slot
                     .compare_exchange(observed, free, Ordering::AcqRel, Ordering::Acquire)
@@ -730,6 +985,26 @@ pub(crate) fn return_lease(lease: FrameLease) -> ReturnOutcome {
     }
 }
 
+fn current_lease_for_frame(frame: PhysFrame) -> FrameLease {
+    let index = frame_ordinal(frame).unwrap_or(usize::MAX);
+    let generation = FRAME_LEDGER
+        .get()
+        .and_then(|ledger| ledger.get(index))
+        .map(|slot| slot.load(Ordering::Acquire) >> 2)
+        .unwrap_or(0);
+    FrameLease {
+        frame,
+        index: u32::try_from(index).unwrap_or(u32::MAX),
+        generation,
+    }
+}
+
+/// Return a leaf whose mapping refcount reached zero without adding logging,
+/// formatting, allocation, or blocking lock acquisition to the drain path.
+pub(crate) fn deallocate_leaf_frame(frame: PhysFrame) -> ReturnOutcome {
+    return_lease(current_lease_for_frame(frame))
+}
+
 /// Deallocate a physical frame, returning it to the free pool
 ///
 /// Before ledger publication bootstrap callers use a fixed, allocation-free
@@ -746,18 +1021,7 @@ pub fn deallocate_frame(frame: PhysFrame) {
         return;
     }
 
-    let index = frame_ordinal(frame).unwrap_or(usize::MAX);
-    let generation = FRAME_LEDGER
-        .get()
-        .and_then(|ledger| ledger.get(index))
-        .map(|slot| slot.load(Ordering::Acquire) >> 2)
-        .unwrap_or(0);
-    let lease = FrameLease {
-        frame,
-        index: u32::try_from(index).unwrap_or(u32::MAX),
-        generation,
-    };
-    match return_lease(lease) {
+    match return_lease(current_lease_for_frame(frame)) {
         ReturnOutcome::Returned => log::trace!(
             "Frame allocator: Deallocated frame {:#x}",
             frame.start_address().as_u64()

--- a/kernel/src/memory/frame_metadata.rs
+++ b/kernel/src/memory/frame_metadata.rs
@@ -1,44 +1,14 @@
 //! Frame metadata for Copy-on-Write reference counting
 //!
-//! Each physical frame that can be shared needs metadata tracking:
-//! - Reference count (how many page tables point to this frame)
-//!
-//! Design decisions:
-//! - Uses BTreeMap for sparse storage (only track shared frames)
-//! - Untracked frames are assumed to have refcount=1 (private)
-//! - Untracked frames CAN be freed: frame_decref on an untracked frame
-//!   returns true (refcount 1->0), allowing proper cleanup on process exit
-//! - Single global lock (acceptable for initial implementation)
+//! Mapping reference counts live beside allocator generation/state, so a frame
+//! can be decremented only while the allocator still identifies it as live.
+//! Process page tables acquire these references from virtual-page custody
+//! records; the legacy helpers remain thin wrappers for CoW queries and tests.
 
 #[cfg(not(target_arch = "x86_64"))]
 use crate::memory::arch_stub::PhysFrame;
-use alloc::collections::BTreeMap;
-use core::sync::atomic::{AtomicU32, Ordering};
-use spin::Mutex;
 #[cfg(target_arch = "x86_64")]
 use x86_64::structures::paging::PhysFrame;
-
-/// Global frame metadata storage
-/// Uses BTreeMap for sparse storage - only frames that need tracking are stored
-static FRAME_METADATA: Mutex<BTreeMap<u64, FrameMetadata>> = Mutex::new(BTreeMap::new());
-
-/// Metadata for a single physical frame
-#[derive(Debug)]
-struct FrameMetadata {
-    /// Number of page tables referencing this frame
-    /// 0 = frame is free (should be removed from map)
-    /// 1 = frame is private (can be written directly)
-    /// >1 = frame is shared (CoW semantics apply)
-    refcount: AtomicU32,
-}
-
-impl FrameMetadata {
-    fn new(initial_count: u32) -> Self {
-        Self {
-            refcount: AtomicU32::new(initial_count),
-        }
-    }
-}
 
 /// Register a frame in the metadata system with refcount=1 (private)
 ///
@@ -49,11 +19,8 @@ impl FrameMetadata {
 /// If the frame is already tracked, this is a no-op.
 #[allow(dead_code)] // Public API for explicit frame tracking
 pub fn frame_register(frame: PhysFrame) {
-    let addr = frame.start_address().as_u64();
-    let mut metadata = FRAME_METADATA.lock();
-
-    if !metadata.contains_key(&addr) {
-        metadata.insert(addr, FrameMetadata::new(1));
+    if frame_refcount(frame) == 0 {
+        let _ = crate::memory::frame_allocator::acquire_leaf_mapping(frame);
     }
 }
 
@@ -61,70 +28,20 @@ pub fn frame_register(frame: PhysFrame) {
 /// Called when fork() shares a page between parent and child
 #[allow(dead_code)]
 pub fn frame_incref(frame: PhysFrame) {
-    let addr = frame.start_address().as_u64();
-    let mut metadata = FRAME_METADATA.lock();
-
-    if let Some(meta) = metadata.get(&addr) {
-        meta.refcount.fetch_add(1, Ordering::SeqCst);
-    } else {
-        // First time tracking this frame - it's being shared
-        // When we start tracking, the frame is being shared between 2 processes
-        let meta = FrameMetadata::new(2);
-        metadata.insert(addr, meta);
-    }
+    let _ = crate::memory::frame_allocator::acquire_leaf_mapping(frame);
 }
 
 /// Decrement reference count for a frame
 /// Returns true if frame can be freed (refcount reached 0)
 pub fn frame_decref(frame: PhysFrame) -> bool {
-    let addr = frame.start_address().as_u64();
-    let mut metadata = FRAME_METADATA.lock();
-
-    if let Some(meta) = metadata.get(&addr) {
-        let old_count = meta.refcount.fetch_sub(1, Ordering::SeqCst);
-        if old_count == 1 {
-            // Was 1, now 0 - remove from tracking and allow free
-            metadata.remove(&addr);
-            return true;
-        } else if old_count == 0 {
-            // This shouldn't happen - underflow protection
-            log::error!(
-                "frame_decref: underflow for frame {:#x}, restoring to 0",
-                addr
-            );
-            meta.refcount.store(0, Ordering::SeqCst);
-            metadata.remove(&addr);
-            return false;
-        }
-        // old_count > 1, still shared
-        false
-    } else {
-        // Frame wasn't tracked in CoW metadata.
-        // This means it's a private frame that was never shared via CoW
-        // (e.g., allocated during ELF loading, brk, or stack growth).
-        // It belongs solely to the exiting process, so it's safe to free.
-        //
-        // We only reach here from cleanup_cow_frames / cleanup_for_exec
-        // which iterate USER_ACCESSIBLE pages — all of which belong to
-        // the process being cleaned up.
-        log::trace!(
-            "frame_decref: frame {:#x} not tracked (private), allowing free",
-            addr
-        );
-        true
-    }
+    crate::memory::frame_allocator::decref_leaf_mapping(frame)
 }
 
 /// Get current reference count for a frame
-/// Returns 1 if frame is not tracked (assumed private)
+/// Returns 0 for an unregistered frame. External frames report `u32::MAX`,
+/// which makes CoW fault handling copy instead of granting an in-place write.
 pub fn frame_refcount(frame: PhysFrame) -> u32 {
-    let addr = frame.start_address().as_u64();
-    let metadata = FRAME_METADATA.lock();
-
-    metadata
-        .get(&addr)
-        .map(|m| m.refcount.load(Ordering::SeqCst))
-        .unwrap_or(1) // Untracked frames are private
+    crate::memory::frame_allocator::leaf_mapping_refcount(frame)
 }
 
 /// Check if a frame is shared (refcount > 1)
@@ -136,49 +53,50 @@ pub fn frame_is_shared(frame: PhysFrame) -> bool {
 /// Returns (tracked_frames, total_refcount)
 #[allow(dead_code)] // Diagnostic API for future CoW debugging
 pub fn frame_metadata_stats() -> (usize, u64) {
-    let metadata = FRAME_METADATA.lock();
-    let tracked = metadata.len();
-    let total_refs: u64 = metadata
-        .values()
-        .map(|m| m.refcount.load(Ordering::Relaxed) as u64)
-        .sum();
-    (tracked, total_refs)
+    crate::memory::frame_allocator::leaf_mapping_stats()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(not(target_arch = "x86_64"))]
-    use crate::memory::arch_stub::PhysAddr;
-    #[cfg(target_arch = "x86_64")]
-    use x86_64::PhysAddr;
 
-    fn test_frame(addr: u64) -> PhysFrame {
-        PhysFrame::containing_address(PhysAddr::new(addr))
+    fn test_frame() -> PhysFrame {
+        crate::memory::frame_allocator::allocate_frame().expect("test frame allocation")
+    }
+
+    fn return_test_frame(frame: PhysFrame) {
+        assert_eq!(
+            crate::memory::frame_allocator::deallocate_leaf_frame(frame),
+            crate::memory::frame_allocator::ReturnOutcome::Returned
+        );
     }
 
     #[test_case]
-    fn test_untracked_frame_is_private() {
-        let frame = test_frame(0x1000_0000);
-        assert_eq!(frame_refcount(frame), 1);
+    fn test_untracked_frame_fails_closed() {
+        let frame = test_frame();
+        assert_eq!(frame_refcount(frame), 0);
         assert!(!frame_is_shared(frame));
+        assert!(!frame_decref(frame));
+        return_test_frame(frame);
     }
 
     #[test_case]
     fn test_incref_creates_shared() {
-        let frame = test_frame(0x2000_0000);
+        let frame = test_frame();
+        frame_register(frame);
         frame_incref(frame);
         assert_eq!(frame_refcount(frame), 2);
         assert!(frame_is_shared(frame));
 
-        // Cleanup
         frame_decref(frame);
-        frame_decref(frame);
+        assert!(frame_decref(frame));
+        return_test_frame(frame);
     }
 
     #[test_case]
     fn test_multiple_incref() {
-        let frame = test_frame(0x3000_0000);
+        let frame = test_frame();
+        frame_register(frame);
         frame_incref(frame); // Now 2
         frame_incref(frame); // Now 3
         frame_incref(frame); // Now 4
@@ -188,41 +106,45 @@ mod tests {
         while frame_refcount(frame) > 1 {
             frame_decref(frame);
         }
-        frame_decref(frame);
+        assert!(frame_decref(frame));
+        return_test_frame(frame);
     }
 
     #[test_case]
     fn test_decref_to_zero() {
-        let frame = test_frame(0x4000_0000);
+        let frame = test_frame();
+        frame_register(frame);
         frame_incref(frame); // Now 2
 
         assert!(!frame_decref(frame)); // Now 1, not freeable
         assert!(frame_decref(frame)); // Now 0, freeable
-        assert_eq!(frame_refcount(frame), 1); // Back to untracked
+        assert_eq!(frame_refcount(frame), 0);
+        return_test_frame(frame);
     }
 
     #[test_case]
-    fn test_decref_untracked_allows_free() {
-        // Untracked frames are private — decref should allow freeing
-        let frame = test_frame(0x5000_0000);
-        assert!(frame_decref(frame)); // Untracked, returns true
+    fn test_decref_untracked_refuses_free() {
+        let frame = test_frame();
+        assert!(!frame_decref(frame));
+        return_test_frame(frame);
     }
 
     #[test_case]
     fn test_register_then_decref() {
-        let frame = test_frame(0x6000_0000);
+        let frame = test_frame();
         frame_register(frame); // Tracked at refcount=1
         assert_eq!(frame_refcount(frame), 1);
         assert!(!frame_is_shared(frame));
 
         assert!(frame_decref(frame)); // 1->0, freeable
-        assert_eq!(frame_refcount(frame), 1); // Back to untracked
+        assert_eq!(frame_refcount(frame), 0);
+        return_test_frame(frame);
     }
 
     #[test_case]
     fn test_register_then_incref_then_decref() {
         // Simulates: allocate CoW copy, then fork again, then both exit
-        let frame = test_frame(0x7000_0000);
+        let frame = test_frame();
         frame_register(frame); // rc=1
         frame_incref(frame); // rc=2 (forked)
         assert_eq!(frame_refcount(frame), 2);
@@ -230,5 +152,6 @@ mod tests {
 
         assert!(!frame_decref(frame)); // rc=1, still referenced
         assert!(frame_decref(frame)); // rc=0, freeable
+        return_test_frame(frame);
     }
 }

--- a/kernel/src/memory/process_memory.rs
+++ b/kernel/src/memory/process_memory.rs
@@ -2619,18 +2619,25 @@ pub fn map_user_stack_to_process(
 /// * `process_page_table` - The process's page table to map into
 /// * `user_stack_bottom` - Userspace virtual address for stack bottom
 /// * `user_stack_top` - Userspace virtual address for stack top (SP points here)
-/// * `phys_bottom` - Physical address of the stack bottom
+/// * `frames` - Physical frames backing the stack, in ascending virtual-page
+///   order (page `i` maps to `frames[i]`). The frames need not be physically
+///   contiguous; each one is the exact frame the stack allocator reserved and
+///   registered as an external leaf, so the leaf-custody gate accepts them.
 #[cfg(target_arch = "aarch64")]
 pub fn map_user_stack_to_process_with_phys(
     process_page_table: &mut ProcessPageTable,
     user_stack_bottom: VirtAddr,
     user_stack_top: VirtAddr,
-    phys_bottom: u64,
+    frames: &[PhysFrame],
 ) -> Result<(), &'static str> {
-    use crate::memory::arch_stub::{Page, PageTableFlags, PhysAddr, PhysFrame, Size4KiB};
+    use crate::memory::arch_stub::{Page, PageTableFlags, Size4KiB};
 
     let stack_size = user_stack_top.as_u64() - user_stack_bottom.as_u64();
     let num_pages = stack_size / 4096;
+
+    if (frames.len() as u64) < num_pages {
+        return Err("user stack frame list shorter than stack page count");
+    }
 
     let flags =
         PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE;
@@ -2638,23 +2645,22 @@ pub fn map_user_stack_to_process_with_phys(
     for i in 0..num_pages {
         let page_offset = i * 4096;
         let user_vaddr = VirtAddr::new(user_stack_bottom.as_u64() + page_offset);
-        let phys_addr = PhysAddr::new(phys_bottom + page_offset);
         let page = Page::<Size4KiB>::containing_address(user_vaddr);
-        let frame = PhysFrame::<Size4KiB>::containing_address(phys_addr);
+        let frame = frames[i as usize];
 
         match process_page_table.map_page(page, frame, flags) {
             Ok(()) => {
                 log::trace!(
                     "Mapped user stack page {:#x} -> frame {:#x}",
                     user_vaddr.as_u64(),
-                    phys_addr.as_u64()
+                    frame.start_address().as_u64()
                 );
             }
             Err(e) => {
                 log::error!(
                     "Failed to map page {:#x} -> {:#x}: {}",
                     user_vaddr.as_u64(),
-                    phys_addr.as_u64(),
+                    frame.start_address().as_u64(),
                     e
                 );
                 return Err("Failed to map user stack page");

--- a/kernel/src/memory/process_memory.rs
+++ b/kernel/src/memory/process_memory.rs
@@ -9,9 +9,12 @@ use crate::memory::arch_stub::{
 };
 #[cfg(target_arch = "aarch64")]
 use crate::memory::frame_allocator::allocate_frame;
-use crate::memory::frame_allocator::{allocate_frame_leased, FrameLease};
 #[cfg(target_arch = "aarch64")]
-use crate::memory::frame_allocator::{return_lease, ReturnOutcome};
+use crate::memory::frame_allocator::return_lease;
+use crate::memory::frame_allocator::{
+    acquire_leaf_mapping, allocate_frame_leased, deallocate_leaf_frame, FrameLease,
+    LeafMappingClass, ReturnOutcome,
+};
 use crate::memory::layout::USER_STACK_REGION_END;
 #[cfg(target_arch = "x86_64")]
 use x86_64::{
@@ -90,6 +93,39 @@ pub struct ProcessPageTable {
     root_lease: FrameLease,
     /// Allocation-derived custody for every intermediate table we created.
     tables: OwnedTableFrames,
+    /// One allocation-derived custody record per user virtual page.
+    leaves: OwnedLeafFrames,
+}
+
+#[derive(Clone, Copy)]
+enum LeafMapping {
+    Owned,
+    External,
+}
+
+#[derive(Clone, Copy)]
+struct LeafRecord {
+    page: u64,
+    mapping: LeafMapping,
+}
+
+struct OwnedLeafFrames {
+    records: Vec<LeafRecord>,
+    released: bool,
+}
+
+impl OwnedLeafFrames {
+    fn new() -> Self {
+        Self {
+            records: Vec::new(),
+            released: false,
+        }
+    }
+
+    fn search(&self, page: u64) -> Result<usize, usize> {
+        self.records
+            .binary_search_by_key(&page, |record| record.page)
+    }
 }
 
 struct OwnedTableFrames {
@@ -129,6 +165,7 @@ enum Disposition {
     Retiring,
     #[cfg(target_arch = "aarch64")]
     Retired,
+    #[cfg(target_arch = "x86_64")]
     RetiredByExecWalk,
     Abandoned(AbandonReason),
 }
@@ -142,6 +179,60 @@ pub(crate) enum RetireProgress {
 
 #[cfg(target_arch = "aarch64")]
 pub(crate) const RETIRE_FRAME_BUDGET: u32 = 64;
+
+/// Owns an aarch64 address space until exec publishes it in a Process row.
+/// Failure drops release leaves first, then tables and the root. This needs no
+/// hardware-liveness proof because the table has never been installed in TTBR0.
+#[cfg(target_arch = "aarch64")]
+pub(crate) struct UnpublishedPageTable {
+    page_table: Option<alloc::boxed::Box<ProcessPageTable>>,
+    pid: u64,
+}
+
+#[cfg(target_arch = "aarch64")]
+impl UnpublishedPageTable {
+    pub(crate) fn new(page_table: ProcessPageTable, pid: u64) -> Self {
+        Self {
+            page_table: Some(alloc::boxed::Box::new(page_table)),
+            pid,
+        }
+    }
+
+    pub(crate) fn as_mut(&mut self) -> &mut ProcessPageTable {
+        self.page_table.as_deref_mut().expect("unpublished table")
+    }
+
+    pub(crate) fn publish(mut self) -> alloc::boxed::Box<ProcessPageTable> {
+        self.page_table.take().expect("unpublished table")
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+impl core::ops::Deref for UnpublishedPageTable {
+    type Target = ProcessPageTable;
+
+    fn deref(&self) -> &Self::Target {
+        self.page_table.as_deref().expect("unpublished table")
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+impl core::ops::DerefMut for UnpublishedPageTable {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut()
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+impl Drop for UnpublishedPageTable {
+    fn drop(&mut self) {
+        if let Some(page_table) = self.page_table.as_deref_mut() {
+            page_table.release_mapped_leaves();
+            let mut budget = u32::MAX;
+            let _ = page_table.retire_bounded(self.pid, &mut budget);
+        }
+    }
+}
 
 #[derive(Clone, Copy)]
 pub(crate) enum AbandonReason {
@@ -214,6 +305,7 @@ impl ProcessPageTable {
             mapper,
             root_lease,
             tables: OwnedTableFrames::new(),
+            leaves: OwnedLeafFrames::new(),
         };
 
         log::debug!("ARM64: ProcessPageTable created successfully");
@@ -943,6 +1035,7 @@ impl ProcessPageTable {
             mapper,
             root_lease,
             tables,
+            leaves: OwnedLeafFrames::new(),
         };
 
         // With global kernel page tables, all kernel stacks are automatically visible
@@ -1089,11 +1182,20 @@ impl ProcessPageTable {
                 );
                 return Err("Cannot map kernel addresses as user-accessible");
             }
+            let user_mapping = flags.contains(PageTableFlags::USER_ACCESSIBLE);
 
             // CRITICAL FIX: Check if page is already mapped before attempting to map
             // This handles the case where L3 tables are shared between processes
             if let Ok(existing_frame) = self.mapper.translate_page(page) {
                 if existing_frame == frame {
+                    if user_mapping {
+                        let Ok(_) = self.leaves.search(page_addr) else {
+                            crate::trace_count!(
+                                crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED
+                            );
+                            return Err("Mapped user page has no leaf custody record");
+                        };
+                    }
                     // Page is already mapped to the correct frame, skip
                     log::trace!(
                         "Page {:#x} already mapped to frame {:#x}, skipping",
@@ -1113,6 +1215,38 @@ impl ProcessPageTable {
                 }
             }
 
+            let leaf_insert = if user_mapping {
+                match self.leaves.search(page_addr) {
+                    Ok(_) => {
+                        crate::trace_count!(
+                            crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED
+                        );
+                        return Err("Leaf custody record exists without a mapped descriptor");
+                    }
+                    Err(index) => {
+                        self.leaves
+                            .records
+                            .try_reserve(1)
+                            .map_err(|_| "Failed to reserve leaf custody")?;
+                        let mapping = match acquire_leaf_mapping(frame) {
+                            Ok(LeafMappingClass::Owned) => LeafMapping::Owned,
+                            Ok(LeafMappingClass::External) => LeafMapping::External,
+                            Err(error) => return Err(error),
+                        };
+                        self.leaves.records.insert(
+                            index,
+                            LeafRecord {
+                                page: page_addr,
+                                mapping,
+                            },
+                        );
+                        Some((index, mapping))
+                    }
+                }
+            } else {
+                None
+            };
+
             // Page is not mapped, proceed with mapping
             // CRITICAL FIX: Use map_to_with_table_flags to ensure USER_ACCESSIBLE
             // is set on intermediate page tables (PML4, PDPT, PD) not just the final PT entry
@@ -1124,14 +1258,17 @@ impl ProcessPageTable {
                 PageTableFlags::PRESENT | PageTableFlags::WRITABLE
             };
 
-            let Self { mapper, tables, .. } = self;
-            match mapper.map_to_with_table_flags(
-                page,
-                frame,
-                flags,
-                table_flags,
-                &mut TableRecorder(tables),
-            ) {
+            let map_result = {
+                let Self { mapper, tables, .. } = self;
+                mapper.map_to_with_table_flags(
+                    page,
+                    frame,
+                    flags,
+                    table_flags,
+                    &mut TableRecorder(tables),
+                )
+            };
+            match map_result {
                 Ok(flush) => {
                     // CRITICAL: Do NOT flush TLB immediately!
                     // This is a common mistake that differs from how real OSes work.
@@ -1147,10 +1284,23 @@ impl ProcessPageTable {
                     // In the future, we could collect these and batch flush if needed
                     let _ = flush; // Explicitly ignore the flush
 
+                    if leaf_insert.is_some() {
+                        self.leaves.released = false;
+                        crate::trace_count!(
+                            crate::tracing::providers::teardown::LEAF_MAPPINGS_RECORDED
+                        );
+                    }
+
                     log::trace!("mapper.map_to succeeded, TLB flush deferred");
                     Ok(())
                 }
                 Err(e) => {
+                    if let Some((index, mapping)) = leaf_insert {
+                        self.leaves.records.remove(index);
+                        if let LeafMapping::Owned = mapping {
+                            let _ = crate::memory::frame_metadata::frame_decref(frame);
+                        }
+                    }
                     // Enhanced error logging to understand map_to failures
                     #[cfg(not(target_arch = "x86_64"))]
                     use crate::memory::arch_stub::mapper::MapToError;
@@ -1185,13 +1335,58 @@ impl ProcessPageTable {
         &mut self,
         page: Page<Size4KiB>,
     ) -> Result<PhysFrame<Size4KiB>, &'static str> {
+        let page_addr = page.start_address().as_u64();
+        let record_index = self.leaves.search(page_addr).map_err(|_| {
+            crate::trace_count!(crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED);
+            "Mapped user page has no releasable leaf custody"
+        })?;
+        let record = self.leaves.records[record_index];
         let (frame, flush) = self
             .mapper
             .unmap(page)
             .map_err(|_| "Failed to unmap page")?;
         // Don't flush immediately - same reasoning as map_page
         let _ = flush;
+        self.leaves.records.remove(record_index);
+        Self::release_leaf_record(record, frame);
         Ok(frame)
+    }
+
+    fn release_leaf_record(record: LeafRecord, frame: PhysFrame) {
+        crate::trace_count!(crate::tracing::providers::teardown::LEAF_MAPPINGS_RELEASED);
+        if let LeafMapping::Owned = record.mapping {
+            if crate::memory::frame_metadata::frame_decref(frame)
+                && deallocate_leaf_frame(frame) == ReturnOutcome::Returned
+            {
+                crate::trace_count!(crate::tracing::providers::teardown::LEAF_FRAMES_RETURNED);
+            }
+        }
+    }
+
+    /// Release mapped user leaves exactly once while the caller owns a dead or
+    /// never-published address space. The record proves custody of the virtual
+    /// mapping; its current descriptor supplies the frame identity so a CoW
+    /// replacement does not change the record's ownership key.
+    pub(crate) fn release_mapped_leaves(&mut self) {
+        if self.leaves.released {
+            return;
+        }
+        let records = &self.leaves.records;
+        let _ = self.walk_mapped_pages(|virt_addr, phys_addr, flags| {
+            if !flags.contains(PageTableFlags::USER_ACCESSIBLE) {
+                return;
+            }
+            let page = virt_addr.as_u64() & !0xfff;
+            let frame = PhysFrame::containing_address(phys_addr);
+            match records.binary_search_by_key(&page, |record| record.page) {
+                Ok(index) => Self::release_leaf_record(records[index], frame),
+                Err(_) => {
+                    crate::trace_count!(crate::tracing::providers::teardown::LEAF_CUSTODY_REFUSED);
+                }
+            }
+        });
+        self.leaves.records.clear();
+        self.leaves.released = true;
     }
 
     /// Update the flags of an already-mapped page
@@ -1518,9 +1713,11 @@ impl ProcessPageTable {
         let end_page = Page::<Size4KiB>::containing_address(end_addr);
 
         for page in Page::range_inclusive(start_page, end_page) {
-            // Try to unmap the page - it's OK if it's not mapped
-            match self.mapper.unmap(page) {
-                Ok((frame, _flush)) => {
+            if self.mapper.translate_page(page).is_err() {
+                continue;
+            }
+            match self.unmap_page(page) {
+                Ok(frame) => {
                     // Don't flush immediately - the page table switch will handle it
                     log::trace!(
                         "Unmapped page {:#x} (was mapped to frame {:#x})",
@@ -1528,10 +1725,7 @@ impl ProcessPageTable {
                         frame.start_address().as_u64()
                     );
                 }
-                Err(_) => {
-                    // Page wasn't mapped, that's fine
-                    log::trace!("Page {:#x} was not mapped", page.start_address().as_u64());
-                }
+                Err(_) => return Err("Mapped user page could not release leaf custody"),
             }
         }
 
@@ -1574,7 +1768,7 @@ impl ProcessPageTable {
                 self.tables.disposition = Disposition::Retiring;
             }
             Disposition::Retiring => {}
-            Disposition::RetiredByExecWalk | Disposition::Abandoned(_) => {
+            Disposition::Abandoned(_) => {
                 return RetireProgress::Complete;
             }
         }
@@ -1595,7 +1789,8 @@ impl ProcessPageTable {
                         ReturnOutcome::RefusedDoubleRelease
                         | ReturnOutcome::RefusedStale
                         | ReturnOutcome::RefusedNeverAllocated
-                        | ReturnOutcome::RefusedUntracked => {}
+                        | ReturnOutcome::RefusedUntracked
+                        | ReturnOutcome::RefusedLiveLeaf => {}
                     }
                     self.tables.disposition = Disposition::Retired;
                     crate::tracing::providers::teardown::record_pt_root_retired(pid);
@@ -1612,7 +1807,8 @@ impl ProcessPageTable {
                 ReturnOutcome::RefusedDoubleRelease
                 | ReturnOutcome::RefusedStale
                 | ReturnOutcome::RefusedNeverAllocated
-                | ReturnOutcome::RefusedUntracked => {}
+                | ReturnOutcome::RefusedUntracked
+                | ReturnOutcome::RefusedLiveLeaf => {}
             }
         }
 
@@ -1629,7 +1825,7 @@ impl ProcessPageTable {
     ///
     /// Call this on the OLD page table after installing the new one during exec().
     #[cfg(target_arch = "x86_64")]
-    pub fn cleanup_for_exec(mut self) {
+    pub(crate) fn cleanup_for_exec(mut self) {
         use crate::memory::frame_allocator::deallocate_frame;
         use crate::memory::frame_metadata::frame_decref;
         use alloc::vec::Vec;
@@ -1803,151 +1999,13 @@ impl ProcessPageTable {
         );
     }
 
-    /// Clean up page table resources during exec() (ARM64 version)
-    ///
-    /// ARM64 uses different page table naming (L0/L1/L2/L3) but same structure.
+    /// Release a superseded ARM64 address space from allocation-derived leaf
+    /// and table custody. The caller supplies the shared retirement budget so
+    /// old exec roots remain resumable with the ordinary exit pipeline.
     #[cfg(target_arch = "aarch64")]
-    pub fn cleanup_for_exec(mut self) {
-        use crate::memory::frame_allocator::deallocate_frame;
-        use crate::memory::frame_metadata::frame_decref;
-        use alloc::vec::Vec;
-
-        self.tables.disposition = Disposition::RetiredByExecWalk;
-        crate::trace_count_add!(
-            crate::tracing::providers::teardown::PT_EXEC_WALK_LEASES_UNRETURNED,
-            self.tables.leases.len() as u64
-        );
-
-        let phys_offset = crate::memory::physical_memory_offset();
-        let mut user_frames_freed = 0u64;
-        let mut user_frames_still_shared = 0u64;
-        let mut table_frames_freed = 0u64;
-
-        // Collect page table structure frames to free after walking
-        let mut l1_frames: Vec<PhysFrame> = Vec::new();
-        let mut l2_frames: Vec<PhysFrame> = Vec::new();
-        let mut l3_frames: Vec<PhysFrame> = Vec::new();
-
-        unsafe {
-            // Get the L0 table (TTBR0 - userspace only on ARM64)
-            let l0_virt = phys_offset + self.level_4_frame.start_address().as_u64();
-            let l0_table = &*(l0_virt.as_ptr() as *const PageTable);
-
-            // Walk all L0 entries (all are userspace on ARM64 TTBR0)
-            for l0_idx in 0..512usize {
-                let l0_entry = &l0_table[l0_idx];
-                if l0_entry.is_unused() || !l0_entry.flags().contains(PageTableFlags::PRESENT) {
-                    continue;
-                }
-
-                // Get L1 table and mark for cleanup
-                let l1_phys = l0_entry.addr();
-                let l1_frame = PhysFrame::containing_address(l1_phys);
-                l1_frames.push(l1_frame);
-
-                let l1_virt = phys_offset + l1_phys.as_u64();
-                let l1_table = &*(l1_virt.as_ptr() as *const PageTable);
-
-                for l1_idx in 0..512usize {
-                    let l1_entry = &l1_table[l1_idx];
-                    if l1_entry.is_unused() || !l1_entry.flags().contains(PageTableFlags::PRESENT) {
-                        continue;
-                    }
-
-                    // Check for 1GB block (huge page equivalent)
-                    if l1_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
-                        let frame = PhysFrame::containing_address(l1_entry.addr());
-                        if frame_decref(frame) {
-                            deallocate_frame(frame);
-                            user_frames_freed += 1;
-                        } else {
-                            user_frames_still_shared += 1;
-                        }
-                        continue;
-                    }
-
-                    // Get L2 table and mark for cleanup
-                    let l2_phys = l1_entry.addr();
-                    let l2_frame = PhysFrame::containing_address(l2_phys);
-                    l2_frames.push(l2_frame);
-
-                    let l2_virt = phys_offset + l2_phys.as_u64();
-                    let l2_table = &*(l2_virt.as_ptr() as *const PageTable);
-
-                    for l2_idx in 0..512usize {
-                        let l2_entry = &l2_table[l2_idx];
-                        if l2_entry.is_unused()
-                            || !l2_entry.flags().contains(PageTableFlags::PRESENT)
-                        {
-                            continue;
-                        }
-
-                        // Check for 2MB block
-                        if l2_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
-                            let frame = PhysFrame::containing_address(l2_entry.addr());
-                            if frame_decref(frame) {
-                                deallocate_frame(frame);
-                                user_frames_freed += 1;
-                            } else {
-                                user_frames_still_shared += 1;
-                            }
-                            continue;
-                        }
-
-                        // Get L3 table and mark for cleanup
-                        let l3_phys = l2_entry.addr();
-                        let l3_frame = PhysFrame::containing_address(l3_phys);
-                        l3_frames.push(l3_frame);
-
-                        let l3_virt = phys_offset + l3_phys.as_u64();
-                        let l3_table = &*(l3_virt.as_ptr() as *const PageTable);
-
-                        for l3_idx in 0..512usize {
-                            let l3_entry = &l3_table[l3_idx];
-                            if l3_entry.is_unused()
-                                || !l3_entry.flags().contains(PageTableFlags::PRESENT)
-                            {
-                                continue;
-                            }
-
-                            // 4KB page
-                            let frame = PhysFrame::containing_address(l3_entry.addr());
-                            if frame_decref(frame) {
-                                deallocate_frame(frame);
-                                user_frames_freed += 1;
-                            } else {
-                                user_frames_still_shared += 1;
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Free page table structure frames (L3 first, then L2, then L1)
-            for frame in l3_frames {
-                deallocate_frame(frame);
-                table_frames_freed += 1;
-            }
-            for frame in l2_frames {
-                deallocate_frame(frame);
-                table_frames_freed += 1;
-            }
-            for frame in l1_frames {
-                deallocate_frame(frame);
-                table_frames_freed += 1;
-            }
-
-            // Free the L0 frame itself
-            deallocate_frame(self.level_4_frame);
-            table_frames_freed += 1;
-        }
-
-        log::info!(
-            "cleanup_for_exec [ARM64]: freed {} user frames, {} still shared, {} table frames",
-            user_frames_freed,
-            user_frames_still_shared,
-            table_frames_freed
-        );
+    pub(crate) fn cleanup_for_exec(&mut self, pid: u64, budget: &mut u32) -> RetireProgress {
+        self.release_mapped_leaves();
+        self.retire_bounded(pid, budget)
     }
 }
 
@@ -1965,6 +2023,7 @@ impl Drop for ProcessPageTable {
             }
             #[cfg(target_arch = "aarch64")]
             Disposition::Retired => {}
+            #[cfg(target_arch = "x86_64")]
             Disposition::RetiredByExecWalk => {}
             Disposition::Abandoned(reason) => match reason {
                 AbandonReason::NoProofPipeline
@@ -1986,6 +2045,78 @@ fn disposition_gate_counters() -> [u64; 6] {
         teardown::PT_ROOT_DROPPED_UNDECIDED.aggregate(),
         teardown::PT_EXEC_WALK_LEASES_UNRETURNED.aggregate(),
     ]
+}
+
+#[cfg(all(feature = "boot_tests", target_arch = "aarch64"))]
+fn corrupt_executable_fixture() -> [u8; 180] {
+    use crate::arch_impl::aarch64::elf::{
+        flags, Elf64Header, Elf64ProgramHeader, SegmentType, ELFDATA2LSB, ELFCLASS64, ELF_MAGIC,
+        EM_AARCH64,
+    };
+
+    let header = Elf64Header {
+        magic: ELF_MAGIC,
+        class: ELFCLASS64,
+        data: ELFDATA2LSB,
+        version: 1,
+        osabi: 0,
+        abiversion: 0,
+        _pad: [0; 7],
+        elf_type: 2,
+        machine: EM_AARCH64,
+        version2: 1,
+        entry: 0x20_0000,
+        phoff: 64,
+        shoff: 0,
+        flags: 0,
+        ehsize: 64,
+        phentsize: 56,
+        phnum: 2,
+        shentsize: 0,
+        shnum: 0,
+        shstrndx: 0,
+    };
+    let executable = Elf64ProgramHeader {
+        p_type: SegmentType::Load as u32,
+        p_flags: flags::PF_R | flags::PF_X,
+        p_offset: 176,
+        p_vaddr: 0x20_0000,
+        p_paddr: 0,
+        p_filesz: 4,
+        p_memsz: 4096,
+        p_align: 4096,
+    };
+    let corrupt = Elf64ProgramHeader {
+        p_type: SegmentType::Load as u32,
+        p_flags: flags::PF_R | flags::PF_X,
+        p_offset: 180,
+        p_vaddr: 0x40_0000,
+        p_paddr: 0,
+        p_filesz: 4,
+        p_memsz: 4096,
+        p_align: 4096,
+    };
+
+    let mut bytes = [0u8; 180];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            &header as *const Elf64Header as *const u8,
+            bytes.as_mut_ptr(),
+            core::mem::size_of::<Elf64Header>(),
+        );
+        core::ptr::copy_nonoverlapping(
+            &executable as *const Elf64ProgramHeader as *const u8,
+            bytes.as_mut_ptr().add(64),
+            core::mem::size_of::<Elf64ProgramHeader>(),
+        );
+        core::ptr::copy_nonoverlapping(
+            &corrupt as *const Elf64ProgramHeader as *const u8,
+            bytes.as_mut_ptr().add(120),
+            core::mem::size_of::<Elf64ProgramHeader>(),
+        );
+    }
+    bytes[176..180].copy_from_slice(&[0x1f, 0x20, 0x03, 0xd5]);
+    bytes
 }
 
 /// O2/G-H: drive the real classified-abandon and non-freeing Drop paths.
@@ -2025,6 +2156,72 @@ pub fn page_table_custody_disposition_gate_test() -> crate::test_framework::regi
             || crate::memory::frame_allocator::free_list_len_for_gate() != free_before + 1
         {
             return TestResult::Fail("E: retirement contention was not isolated and repaired");
+        }
+
+        let used_before = {
+            let stats = crate::memory::frame_allocator::memory_stats();
+            stats.allocated_frames.saturating_sub(
+                crate::memory::frame_allocator::free_list_len_for_gate(),
+            )
+        };
+        let leaf_recorded_before = teardown::LEAF_MAPPINGS_RECORDED.aggregate();
+        let leaf_released_before = teardown::LEAF_MAPPINGS_RELEASED.aggregate();
+        let leaf_returned_before = teardown::LEAF_FRAMES_RETURNED.aggregate();
+        let tables_returned_before = teardown::PT_TABLE_FRAMES_RETURNED.aggregate();
+        let roots_retired_before = teardown::PT_ROOTS_RETIRED.aggregate();
+        let live_refusals_before = teardown::FRAME_RETURN_REFUSED_LIVE_LEAF.aggregate();
+        let custody_refusals_before = teardown::LEAF_CUSTODY_REFUSED.aggregate();
+        let unregistered_before = teardown::LEAF_DECREF_UNREGISTERED.aggregate();
+
+        let page_table = match ProcessPageTable::new() {
+            Ok(page_table) => page_table,
+            Err(_) => return TestResult::Fail("F4: unpublished page-table construction failed"),
+        };
+        let unpublished_pid = u64::MAX - 2;
+        let mut unpublished = UnpublishedPageTable::new(page_table, unpublished_pid);
+        let corrupt_elf = corrupt_executable_fixture();
+        let failed_load = crate::arch_impl::aarch64::elf::load_elf_into_page_table(
+            &corrupt_elf,
+            unpublished.as_mut(),
+        );
+        match failed_load {
+            Err("Segment data out of bounds") => {}
+            _ => {
+                return TestResult::Fail(
+                    "F4: corrupt executable did not fail after its first mapping",
+                )
+            }
+        }
+        drop(unpublished);
+
+        let used_after = {
+            let stats = crate::memory::frame_allocator::memory_stats();
+            stats.allocated_frames.saturating_sub(
+                crate::memory::frame_allocator::free_list_len_for_gate(),
+            )
+        };
+        crate::serial_println!(
+            "[EXEC_FAILED_RELEASE_ORACLE:aarch64:used_before={}:used_after={}:leaf_recorded={}:leaf_released={}:leaf_returned={}:tables_returned={}:roots_retired={}:live_refused={}]",
+            used_before,
+            used_after,
+            teardown::LEAF_MAPPINGS_RECORDED.aggregate() - leaf_recorded_before,
+            teardown::LEAF_MAPPINGS_RELEASED.aggregate() - leaf_released_before,
+            teardown::LEAF_FRAMES_RETURNED.aggregate() - leaf_returned_before,
+            teardown::PT_TABLE_FRAMES_RETURNED.aggregate() - tables_returned_before,
+            teardown::PT_ROOTS_RETIRED.aggregate() - roots_retired_before,
+            teardown::FRAME_RETURN_REFUSED_LIVE_LEAF.aggregate() - live_refusals_before,
+        );
+        if used_after != used_before
+            || teardown::LEAF_MAPPINGS_RECORDED.aggregate() != leaf_recorded_before + 1
+            || teardown::LEAF_MAPPINGS_RELEASED.aggregate() != leaf_released_before + 1
+            || teardown::LEAF_FRAMES_RETURNED.aggregate() != leaf_returned_before + 1
+            || teardown::PT_TABLE_FRAMES_RETURNED.aggregate() != tables_returned_before + 4
+            || teardown::PT_ROOTS_RETIRED.aggregate() != roots_retired_before + 1
+            || teardown::FRAME_RETURN_REFUSED_LIVE_LEAF.aggregate() != live_refusals_before
+            || teardown::LEAF_CUSTODY_REFUSED.aggregate() != custody_refusals_before
+            || teardown::LEAF_DECREF_UNREGISTERED.aggregate() != unregistered_before
+        {
+            return TestResult::Fail("F4: failed exec did not release unpublished custody exactly");
         }
     }
 

--- a/kernel/src/memory/stack.rs
+++ b/kernel/src/memory/stack.rs
@@ -235,6 +235,10 @@ impl GuardedStack {
             let frame = crate::memory::frame_allocator::allocate_frame().ok_or("out of memory")?;
             log::trace!("map_stack_pages: allocate_frame() returned successfully");
 
+            if privilege == ThreadPrivilege::User {
+                crate::memory::frame_allocator::register_external_leaf_frame(frame)?;
+            }
+
             log::trace!(
                 "map_stack_pages: Allocated frame {:#x} for page {:#x}",
                 frame.start_address(),
@@ -332,6 +336,9 @@ pub fn allocate_stack_with_privilege(
 
     for i in 0..stack_pages {
         let frame = allocate_frame().ok_or("out of memory for stack")?;
+        if privilege == ThreadPrivilege::User {
+            crate::memory::frame_allocator::register_external_leaf_frame(frame)?;
+        }
         let phys = frame.start_address().as_u64();
 
         if i == 0 {

--- a/kernel/src/memory/stack.rs
+++ b/kernel/src/memory/stack.rs
@@ -2,7 +2,9 @@
 use crate::memory::arch_stub::ThreadPrivilege;
 #[cfg(not(target_arch = "x86_64"))]
 #[allow(unused_imports)] // Stubs - only OffsetPageTable and VirtAddr used on ARM64
-use crate::memory::arch_stub::{Mapper, OffsetPageTable, Page, PageTableFlags, Size4KiB, VirtAddr};
+use crate::memory::arch_stub::{
+    Mapper, OffsetPageTable, Page, PageTableFlags, PhysFrame, Size4KiB, VirtAddr,
+};
 use crate::memory::layout::{
     PERCPU_STACK_REGION_BASE, PERCPU_STACK_REGION_SIZE, USER_STACK_REGION_END,
     USER_STACK_REGION_START,
@@ -32,6 +34,13 @@ pub struct GuardedStack {
     /// Privilege level of the stack
     #[allow(dead_code)]
     privilege: ThreadPrivilege,
+    /// Physical frames backing the stack, in ascending virtual-page order
+    /// (ARM64 only). The user mapping binds page `i` to `frames[i]`, so the
+    /// stack works correctly whether or not the frames are physically
+    /// contiguous. Every frame here is individually registered as an external
+    /// leaf frame, so it exactly matches the set the user page table maps.
+    #[cfg(target_arch = "aarch64")]
+    frames: alloc::vec::Vec<PhysFrame>,
 }
 
 impl GuardedStack {
@@ -87,6 +96,11 @@ impl GuardedStack {
             stack_top,
             stack_size,
             privilege,
+            // This constructor is the x86_64 mapper path; the ARM64 user-stack
+            // path builds its GuardedStack in `allocate_stack_with_privilege`
+            // with the real frame list. Kept valid for the shared struct shape.
+            #[cfg(target_arch = "aarch64")]
+            frames: alloc::vec::Vec::new(),
         })
     }
 
@@ -126,6 +140,14 @@ impl GuardedStack {
     /// Get the size of the usable stack area
     pub fn size(&self) -> usize {
         self.stack_size
+    }
+
+    /// Physical frames backing this stack, in ascending virtual-page order
+    /// (ARM64). Page `i` of the user stack maps to `frames()[i]`; no physical
+    /// contiguity is assumed.
+    #[cfg(target_arch = "aarch64")]
+    pub fn frames(&self) -> &[PhysFrame] {
+        &self.frames
     }
 
     /// Find free virtual address space for stack allocation
@@ -329,10 +351,16 @@ pub fn allocate_stack_with_privilege(
     // CRITICAL: No logging in stack allocation path - timer interrupt + logger lock = deadlock
     // This function is called during process creation which may have interrupts enabled
 
-    // Allocate physical frames for the stack
-    // We track all frames and verify they're contiguous
+    // Allocate physical frames for the stack.
+    //
+    // The frames are NOT required to be physically contiguous: each one is
+    // recorded in `frames` in ascending virtual-page order and the user page
+    // table binds page `i` to `frames[i]`. This avoids the latent corruption
+    // that arose when the free list handed back a non-ascending run and the
+    // mapper derived a bogus contiguous [bottom, top) span (issue #470 PR-2).
     let mut first_frame_phys: Option<u64> = None;
     let mut prev_frame_phys: Option<u64> = None;
+    let mut frames: alloc::vec::Vec<PhysFrame> = alloc::vec::Vec::with_capacity(stack_pages);
 
     for i in 0..stack_pages {
         let frame = allocate_frame().ok_or("out of memory for stack")?;
@@ -340,12 +368,11 @@ pub fn allocate_stack_with_privilege(
             crate::memory::frame_allocator::register_external_leaf_frame(frame)?;
         }
         let phys = frame.start_address().as_u64();
+        frames.push(frame);
 
         if i == 0 {
             first_frame_phys = Some(phys);
         }
-        // Note: We don't log non-contiguous frames here - just accept them
-        // For simple stacks this works fine even if frames aren't contiguous
         prev_frame_phys = Some(phys);
 
         // Zero the frame via HHDM
@@ -371,6 +398,7 @@ pub fn allocate_stack_with_privilege(
         stack_top,
         stack_size: size,
         privilege,
+        frames,
     })
 }
 

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -10,7 +10,6 @@
 //!    as fallback and for testing.
 
 use crate::memory::frame_allocator::allocate_frame;
-use crate::memory::frame_metadata::frame_incref;
 use crate::memory::process_memory::{make_cow_flags, ProcessPageTable};
 use crate::memory::vma::{MmapFlags, Vma};
 use crate::process::Process;
@@ -210,7 +209,6 @@ pub fn setup_cow_pages_with_vmas(
                 cow_error = Some("Failed to share MAP_SHARED page");
                 continue;
             }
-            frame_incref(frame);
             pages_shared += 1;
             continue;
         }
@@ -239,9 +237,6 @@ pub fn setup_cow_pages_with_vmas(
                 cow_error = Some("Failed to map CoW page in child");
                 continue;
             }
-
-            // Increment reference count (frame is now shared)
-            frame_incref(frame);
         } else {
             // Read-only page (e.g., code) - share directly without CoW flag
             // These pages can never be written, so no fault handling needed
@@ -249,9 +244,6 @@ pub fn setup_cow_pages_with_vmas(
                 cow_error = Some("Failed to share read-only page");
                 continue;
             }
-
-            // Still track reference for cleanup when process exits
-            frame_incref(frame);
         }
 
         pages_shared += 1;

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -96,11 +96,14 @@ impl ProcessManager {
             core::ptr::write_bytes(kernel_virt.as_mut_ptr::<u8>(), 0, TLS_PAGE_SIZE);
         }
 
-        page_table.map_page(
+        if let Err(error) = page_table.map_page(
             tls_page,
             frame,
             PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE,
-        )?;
+        ) {
+            let _ = crate::memory::frame_allocator::deallocate_leaf_frame(frame);
+            return Err(error);
+        }
 
         Ok(VirtAddr::new(
             tls_page.start_address().as_u64() + TLS_TP_OFFSET,
@@ -3108,9 +3111,10 @@ impl ProcessManager {
             pid.as_u64()
         );
 
-        let mut new_page_table = Box::new(
+        let mut new_page_table = crate::memory::process_memory::UnpublishedPageTable::new(
             crate::memory::process_memory::ProcessPageTable::new()
                 .map_err(|_| "Failed to create new page table for exec")?,
+            pid.as_u64(),
         );
 
         new_page_table.clear_user_entries();
@@ -3165,13 +3169,16 @@ impl ProcessManager {
             let frame = crate::memory::frame_allocator::allocate_frame()
                 .ok_or("Failed to allocate frame for exec stack")?;
 
-            new_page_table.map_page(
+            if let Err(error) = new_page_table.map_page(
                 page,
                 frame,
                 PageTableFlags::PRESENT
                     | PageTableFlags::WRITABLE
                     | PageTableFlags::USER_ACCESSIBLE,
-            )?;
+            ) {
+                let _ = crate::memory::frame_allocator::deallocate_leaf_frame(frame);
+                return Err(error);
+            }
         }
         let initial_tpidr_el0 = Self::map_initial_arm64_tls(new_page_table.as_mut(), stack_top)?;
 
@@ -3232,7 +3239,7 @@ impl ProcessManager {
         // Close FD_CLOEXEC file descriptors per POSIX
         process.fd_table.close_cloexec();
 
-        process.page_table = Some(new_page_table);
+        process.page_table = Some(new_page_table.publish());
         process.stack = Some(Box::new(new_stack));
         process.user_stack_top = user_stack_top;
         process.user_stack_bottom = user_stack_top - USER_STACK_SIZE as u64;
@@ -3362,24 +3369,41 @@ impl ProcessManager {
             );
         }
 
-        // Get the existing process
-        let process = self.processes.get_mut(&pid).ok_or("Process not found")?;
-
-        // Drain any pending old page tables from previous exec() calls.
-        process.drain_old_page_tables();
-
         // For now, assume non-current processes are not actively running
         let is_scheduled = false;
 
-        // Get the main thread (we need to preserve its ID)
-        let main_thread = process
-            .main_thread
-            .as_ref()
-            .ok_or("Process has no main thread")?;
-        let thread_id = main_thread.id;
+        // Keep the live table installed until every fallible construction step
+        // has succeeded. A failed exec must leave TTBR0 custody unchanged.
+        let (thread_id, old_cr3, thread_group_id) = {
+            let process = self.processes.get(&pid).ok_or("Process not found")?;
+            let old_cr3 = process.cr3_value();
+            let thread_group_id = process.thread_group_id.unwrap_or(pid.as_u64());
+            let main_thread = process
+                .main_thread
+                .as_ref()
+                .ok_or("Process has no main thread")?;
+            (main_thread.id, old_cr3, thread_group_id)
+        };
 
-        // Store old page table for proper cleanup
-        let old_page_table = process.page_table.take();
+        if let Some(old_cr3) = old_cr3 {
+            if let Some((sibling_pid, sibling_thread_id)) =
+                self.find_live_clone_vm_sibling_holding_cr3(pid, thread_group_id, old_cr3)
+            {
+                log::warn!(
+                    "exec_process [ARM64]: rejecting exec for PID {} while CLONE_VM sibling PID {} thread {} still holds inherited CR3 {:#x}",
+                    pid.as_u64(),
+                    sibling_pid.as_u64(),
+                    sibling_thread_id,
+                    old_cr3
+                );
+                return Err("exec blocked while CLONE_VM sibling shares old address space");
+            }
+        }
+
+        {
+            let process = self.processes.get_mut(&pid).ok_or("Process not found")?;
+            process.drain_old_page_tables();
+        }
 
         log::info!(
             "exec_process [ARM64]: Preserving thread ID {} for process {}",
@@ -3389,9 +3413,10 @@ impl ProcessManager {
 
         // Create a new page table for the new program
         log::info!("exec_process [ARM64]: Creating new page table...");
-        let mut new_page_table = Box::new(
+        let mut new_page_table = crate::memory::process_memory::UnpublishedPageTable::new(
             crate::memory::process_memory::ProcessPageTable::new()
                 .map_err(|_| "Failed to create new page table for exec")?,
+            pid.as_u64(),
         );
         log::info!("exec_process [ARM64]: New page table created successfully");
 
@@ -3461,13 +3486,16 @@ impl ProcessManager {
                 .ok_or("Failed to allocate frame for exec stack")?;
 
             // Map into the NEW process page table with user-accessible permissions
-            new_page_table.map_page(
+            if let Err(error) = new_page_table.map_page(
                 page,
                 frame,
                 PageTableFlags::PRESENT
                     | PageTableFlags::WRITABLE
                     | PageTableFlags::USER_ACCESSIBLE,
-            )?;
+            ) {
+                let _ = crate::memory::frame_allocator::deallocate_leaf_frame(frame);
+                return Err(error);
+            }
         }
         let initial_tpidr_el0 = Self::map_initial_arm64_tls(new_page_table.as_mut(), stack_top)?;
 
@@ -3483,6 +3511,14 @@ impl ProcessManager {
             new_entry_point,
             stack_top.as_u64()
         );
+
+        // All fallible construction is complete; only now supersede the live
+        // address space and transfer the unpublished table into the Process.
+        let process = self
+            .processes
+            .get_mut(&pid)
+            .ok_or("Process not found during update")?;
+        let old_page_table = process.page_table.take();
 
         // Update the process with new program data
         if let Some(name) = program_name {
@@ -3509,7 +3545,7 @@ impl ProcessManager {
         );
 
         // Replace the page table with the new one containing the loaded program
-        process.page_table = Some(new_page_table);
+        process.page_table = Some(new_page_table.publish());
 
         // Replace the stack
         process.stack = Some(Box::new(new_stack));

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -520,7 +520,7 @@ impl ProcessManager {
                 page_table,
                 VirtAddr::new(user_stack_bottom),
                 VirtAddr::new(user_stack_top),
-                stack_phys_bottom,
+                process.stack.as_deref().ok_or("user stack frames unavailable")?.frames(),
             )
             .map_err(|e| {
                 crate::serial_println!(
@@ -670,12 +670,6 @@ impl ProcessManager {
             stack::allocate_stack_with_privilege(USER_STACK_SIZE, StackPrivilege::User)
                 .map_err(|_| "Failed to allocate user stack")?;
 
-        // Extract physical address from HHDM address
-        let kernel_stack_top = kernel_stack.top().as_u64();
-        let hhdm_base = crate::arch_impl::aarch64::constants::HHDM_BASE;
-        let stack_phys_top = kernel_stack_top - hhdm_base;
-        let stack_phys_bottom = stack_phys_top - USER_STACK_SIZE as u64;
-
         // Calculate userspace stack addresses
         let user_stack_top = USER_STACK_REGION_START;
         let user_stack_bottom = user_stack_top - USER_STACK_SIZE as u64;
@@ -697,7 +691,7 @@ impl ProcessManager {
                 page_table,
                 VirtAddr::new(user_stack_bottom),
                 VirtAddr::new(user_stack_top),
-                stack_phys_bottom,
+                process.stack.as_deref().ok_or("user stack frames unavailable")?.frames(),
             )
             .map_err(|e| {
                 log::error!(

--- a/kernel/src/process/process.rs
+++ b/kernel/src/process/process.rs
@@ -563,49 +563,9 @@ impl Process {
     /// Walks all user pages in the process's page table and decrements their
     /// reference counts. Frames that are no longer shared (refcount reaches 0)
     /// are returned to the frame allocator for reuse.
-    #[cfg(target_arch = "x86_64")]
     pub(crate) fn cleanup_cow_frames(&mut self) {
-        use crate::memory::frame_allocator::deallocate_frame;
-        use crate::memory::frame_metadata::frame_decref;
-        use x86_64::structures::paging::{PageTableFlags, PhysFrame};
-
-        // Get the page table for this process
-        let page_table = match self.page_table.as_ref() {
-            Some(pt) => pt,
-            None => return,
-        };
-
-        // Walk all user pages and decrement refcounts
-        let _ = page_table.walk_mapped_pages(|_virt_addr, phys_addr, flags| {
-            // Only process user-accessible pages
-            if !flags.contains(PageTableFlags::USER_ACCESSIBLE) {
-                return;
-            }
-
-            let frame = PhysFrame::containing_address(phys_addr);
-
-            // Decrement reference count.
-            // Returns true if the frame should be freed:
-            // - Tracked frame whose refcount reached 0 (was shared, now sole owner exiting)
-            // - Untracked frame (private to this process, never shared via CoW)
-            // Returns false if still shared (refcount > 0 after decrement).
-            if frame_decref(frame) {
-                deallocate_frame(frame);
-            }
-        });
-    }
-
-    /// Clean up Copy-on-Write frame references when process exits (ARM64)
-    ///
-    /// Walks all user pages in the process's page table and decrements their
-    /// reference counts. Frames that are no longer shared (refcount reaches 0)
-    /// are returned to the frame allocator for reuse.
-    ///
-    /// CRITICAL: No logging — may run under PM lock.
-    #[cfg(not(target_arch = "x86_64"))]
-    pub(crate) fn cleanup_cow_frames(&mut self) {
-        if let Some(page_table) = self.page_table.as_ref() {
-            cleanup_cow_page_table(page_table);
+        if let Some(page_table) = self.page_table.as_mut() {
+            page_table.release_mapped_leaves();
         }
     }
 
@@ -614,10 +574,33 @@ impl Process {
     /// This is safe to call once CR3 has definitely switched away from the old
     /// page table (e.g., at the start of the next exec, or during process exit).
     /// Each old page table has its user-space frames freed via `cleanup_for_exec()`.
+    #[cfg(target_arch = "x86_64")]
     pub fn drain_old_page_tables(&mut self) {
         for old_pt in self.pending_old_page_tables.drain(..) {
             old_pt.cleanup_for_exec();
         }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub(crate) fn drain_old_page_tables_bounded(&mut self, budget: &mut u32) -> bool {
+        while *budget > 0 {
+            let Some(old_page_table) = self.pending_old_page_tables.last_mut() else {
+                return true;
+            };
+            if old_page_table.cleanup_for_exec(self.id.as_u64(), budget)
+                != crate::memory::process_memory::RetireProgress::Complete
+            {
+                return false;
+            }
+            self.pending_old_page_tables.pop();
+        }
+        self.pending_old_page_tables.is_empty()
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub fn drain_old_page_tables(&mut self) {
+        let mut budget = crate::memory::process_memory::RETIRE_FRAME_BUDGET;
+        let _ = self.drain_old_page_tables_bounded(&mut budget);
     }
 
     /// Check if process is terminated
@@ -676,26 +659,4 @@ impl Process {
     pub fn vma_list_mut(&mut self) -> &mut alloc::vec::Vec<crate::memory::vma::Vma> {
         &mut self.vmas
     }
-}
-
-/// Release the user-frame references reachable from an AArch64 process root.
-///
-/// Deferred exit reclamation owns the page table after removing it from the
-/// process table, so this operation accepts the page table directly.
-#[cfg(target_arch = "aarch64")]
-pub(crate) fn cleanup_cow_page_table(page_table: &ProcessPageTable) {
-    use crate::memory::arch_stub::{PageTableFlags, PhysFrame};
-    use crate::memory::frame_allocator::deallocate_frame;
-    use crate::memory::frame_metadata::frame_decref;
-
-    let _ = page_table.walk_mapped_pages(|_virt_addr, phys_addr, flags| {
-        if !flags.contains(PageTableFlags::USER_ACCESSIBLE) {
-            return;
-        }
-
-        let frame = PhysFrame::containing_address(phys_addr);
-        if frame_decref(frame) {
-            deallocate_frame(frame);
-        }
-    });
 }

--- a/kernel/src/syscall/graphics.rs
+++ b/kernel/src/syscall/graphics.rs
@@ -2031,16 +2031,6 @@ fn handle_resize_window_buffer(cmd: &FbDrawCmd) -> SyscallResult {
     );
     process.vmas.push(vma);
 
-    // Deallocate old physical frames
-    for &old_phys in &old_phys_addrs {
-        use crate::memory::arch_stub::PhysAddr;
-        crate::memory::frame_allocator::deallocate_frame(crate::memory::arch_stub::PhysFrame::<
-            Size4KiB,
-        >::containing_address(
-            PhysAddr::new(old_phys)
-        ));
-    }
-
     // Update registry
     {
         let mut reg = WINDOW_REGISTRY.lock();
@@ -2220,6 +2210,15 @@ fn handle_map_compositor_texture(cmd: &FbDrawCmd) -> SyscallResult {
             None => return SyscallResult::Err(super::ErrorCode::InvalidArgument as u64),
         }
     };
+
+    if crate::memory::frame_allocator::register_external_leaf_span(
+        crate::memory::arch_stub::PhysAddr::new(phys_base),
+        (num_pages as u64) * PAGE_SIZE,
+    )
+    .is_err()
+    {
+        return SyscallResult::Err(super::ErrorCode::InvalidArgument as u64);
+    }
 
     // Get current process
     let current_thread_id = match get_current_thread_id() {

--- a/kernel/src/syscall/memory.rs
+++ b/kernel/src/syscall/memory.rs
@@ -215,11 +215,9 @@ pub fn sys_brk(addr: u64) -> SyscallResult {
         let mut pages_unmapped = 0u32;
         for page in Page::range_inclusive(start_page, end_page) {
             match page_table.unmap_page(page) {
-                Ok(frame) => {
+                Ok(_) => {
                     // Flush TLB for this page
                     flush_tlb(page.start_address());
-                    // Free the physical frame
-                    crate::memory::frame_allocator::deallocate_frame(frame);
                     pages_unmapped += 1;
                 }
                 Err(e) => {

--- a/kernel/src/syscall/memory_common.rs
+++ b/kernel/src/syscall/memory_common.rs
@@ -91,14 +91,12 @@ pub fn cleanup_mapped_pages(
         mapped_pages.len()
     );
 
-    for (page, frame) in mapped_pages.iter() {
+    for (page, _) in mapped_pages.iter() {
         // Unmap the page
         match page_table.unmap_page(*page) {
             Ok(_) => {
                 // Flush TLB
                 flush_tlb(page.start_address());
-                // Free the frame
-                crate::memory::frame_allocator::deallocate_frame(*frame);
             }
             Err(e) => {
                 log::error!(
@@ -106,8 +104,6 @@ pub fn cleanup_mapped_pages(
                     page.start_address().as_u64(),
                     e
                 );
-                // Still try to free the frame
-                crate::memory::frame_allocator::deallocate_frame(*frame);
             }
         }
     }

--- a/kernel/src/syscall/mmap.rs
+++ b/kernel/src/syscall/mmap.rs
@@ -477,11 +477,9 @@ pub fn sys_munmap(addr: u64, length: u64) -> SyscallResult {
     let mut pages_unmapped = 0u32;
     for page in Page::range_inclusive(start_page, end_page) {
         match page_table.unmap_page(page) {
-            Ok(frame) => {
+            Ok(_) => {
                 // Flush TLB for this page
                 flush_tlb(page.start_address());
-                // Free the physical frame
-                crate::memory::frame_allocator::deallocate_frame(frame);
                 pages_unmapped += 1;
             }
             Err(e) => {

--- a/kernel/src/task/process_task.rs
+++ b/kernel/src/task/process_task.rs
@@ -77,7 +77,6 @@ pub(crate) struct PendingProcessReclaim {
     last_pass: u32,
     proof_failures: u8,
     parked: Option<ParkRecord>,
-    leaves_released: bool,
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -181,20 +180,24 @@ impl PendingProcessReclaim {
     fn reclaim_bounded(&mut self) -> crate::memory::process_memory::RetireProgress {
         use crate::memory::process_memory::{RetireProgress, RETIRE_FRAME_BUDGET};
 
-        if !self.leaves_released {
-            if let Some(page_table) = self.page_table.as_ref() {
-                crate::process::process::cleanup_cow_page_table(page_table);
+        let mut budget = RETIRE_FRAME_BUDGET;
+        while budget > 0 {
+            let Some(old_page_table) = self.old_page_tables.last_mut() else {
+                break;
+            };
+            if old_page_table.cleanup_for_exec(self.pid, &mut budget) != RetireProgress::Complete {
+                return RetireProgress::Budgeted;
             }
-            for old_page_table in self.old_page_tables.drain(..) {
-                old_page_table.cleanup_for_exec();
-            }
-            self.leaves_released = true;
+            self.old_page_tables.pop();
+        }
+        if !self.old_page_tables.is_empty() {
+            return RetireProgress::Budgeted;
         }
 
         let Some(page_table) = self.page_table.as_mut() else {
             return RetireProgress::Complete;
         };
-        let mut budget = RETIRE_FRAME_BUDGET;
+        page_table.release_mapped_leaves();
         let progress = page_table.retire_bounded(self.pid, &mut budget);
         if progress == RetireProgress::Complete {
             self.page_table = None;
@@ -373,7 +376,6 @@ pub(crate) fn defer_process_resources(
         last_pass: 0,
         proof_failures: 0,
         parked: None,
-        leaves_released: false,
     }
 }
 
@@ -1045,7 +1047,6 @@ fn boot_test_reclaim(pid: u64) -> PendingProcessReclaim {
         last_pass: 0,
         proof_failures: 0,
         parked: None,
-        leaves_released: false,
     }
 }
 
@@ -1069,10 +1070,9 @@ fn boot_oversized_page_table(
             deallocate_frame(frame);
             return Err("oversized sentinel mapping failed");
         }
-        let leaf = page_table
+        page_table
             .unmap_page(page)
             .map_err(|_| "oversized sentinel unmap failed")?;
-        deallocate_frame(leaf);
     }
     Ok(page_table)
 }

--- a/kernel/src/tracing/providers/teardown.rs
+++ b/kernel/src/tracing/providers/teardown.rs
@@ -431,6 +431,21 @@ counter!(
     "Duplicate frame allocations refused"
 );
 counter!(FRAME_LOST_CONTENDED, "Frame returns lost to contention");
+counter!(
+    FRAME_RETURN_REFUSED_LIVE_LEAF,
+    "Returns of frames with live leaf mappings refused"
+);
+counter!(LEAF_MAPPINGS_RECORDED, "Process leaf mappings recorded");
+counter!(LEAF_MAPPINGS_RELEASED, "Process leaf mappings released");
+counter!(LEAF_FRAMES_RETURNED, "Process leaf frames returned");
+counter!(
+    LEAF_DECREF_UNREGISTERED,
+    "Unregistered process leaf decrements refused"
+);
+counter!(
+    LEAF_CUSTODY_REFUSED,
+    "Process leaf custody classifications refused"
+);
 counter!(PT_TABLE_FRAMES_RECORDED, "Process table frames recorded");
 counter!(
     PT_ROOT_ABANDONED_NO_PROOF,
@@ -497,7 +512,7 @@ counter!(
     "Fatal group signals dropped for init"
 );
 
-pub const COUNTER_COUNT: usize = 64;
+pub const COUNTER_COUNT: usize = 70;
 
 /// The registration and normal-context reader inventory. Keeping one inventory
 /// makes a write-only counter structurally impossible without changing the P0
@@ -542,6 +557,12 @@ pub static COUNTERS: [&TraceCounter; COUNTER_COUNT] = [
     &FRAME_RETURN_REFUSED_UNTRACKED,
     &FRAME_DUPLICATE_ALLOC_REFUSED,
     &FRAME_LOST_CONTENDED,
+    &FRAME_RETURN_REFUSED_LIVE_LEAF,
+    &LEAF_MAPPINGS_RECORDED,
+    &LEAF_MAPPINGS_RELEASED,
+    &LEAF_FRAMES_RETURNED,
+    &LEAF_DECREF_UNREGISTERED,
+    &LEAF_CUSTODY_REFUSED,
     &PT_TABLE_FRAMES_RECORDED,
     &PT_ROOT_ABANDONED_NO_PROOF,
     &PT_ROOT_ABANDONED_NO_ARCH,
@@ -1233,6 +1254,9 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     let roots_retired_before = PT_ROOTS_RETIRED.aggregate();
     let table_frames_returned_before = PT_TABLE_FRAMES_RETURNED.aggregate();
     let table_frames_lost_before = PT_RETIRE_FRAMES_LOST.aggregate();
+    let leaf_mappings_recorded_before = LEAF_MAPPINGS_RECORDED.aggregate();
+    let leaf_mappings_released_before = LEAF_MAPPINGS_RELEASED.aggregate();
+    let leaf_frames_returned_before = LEAF_FRAMES_RETURNED.aggregate();
     let dropped_undecided_before = PT_ROOT_DROPPED_UNDECIDED.aggregate();
     let dropped_mid_retire_before = PT_ROOT_DROPPED_MID_RETIRE.aggregate();
     let budget_requeued_before = PT_RETIRE_BUDGET_REQUEUED.aggregate();
@@ -1243,6 +1267,9 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         FRAME_RETURN_REFUSED_NEVER_ALLOCATED.aggregate(),
         FRAME_RETURN_REFUSED_UNTRACKED.aggregate(),
         FRAME_DUPLICATE_ALLOC_REFUSED.aggregate(),
+        FRAME_RETURN_REFUSED_LIVE_LEAF.aggregate(),
+        LEAF_DECREF_UNREGISTERED.aggregate(),
+        LEAF_CUSTODY_REFUSED.aggregate(),
     ];
     // The nine labels mirror PLAN P2's disjoint adapted-site table. The exact
     // source ratchets below prove which concrete callers use each custody
@@ -1367,6 +1394,19 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
     let table_frames_lost_delta = PT_RETIRE_FRAMES_LOST
         .aggregate()
         .saturating_sub(table_frames_lost_before);
+    let leaf_mappings_recorded_delta = LEAF_MAPPINGS_RECORDED
+        .aggregate()
+        .saturating_sub(leaf_mappings_recorded_before);
+    let leaf_mappings_released_delta = LEAF_MAPPINGS_RELEASED
+        .aggregate()
+        .saturating_sub(leaf_mappings_released_before);
+    let leaf_frames_returned_delta = LEAF_FRAMES_RETURNED
+        .aggregate()
+        .saturating_sub(leaf_frames_returned_before);
+    let live_leaf_refused_delta = FRAME_RETURN_REFUSED_LIVE_LEAF
+        .aggregate()
+        .saturating_sub(refusal_counters_before[5]);
+    let expected_leaves = (RETIRE_SENTINEL_VAS.len() * pairing_child_pids.len()) as u64;
     crate::serial_println!(
         "[PT_RETIRE_ORACLE:aarch64:cycles=64:used_before={}:used_after={}:expected_tables={}:roots={}:returned={}:lost={}]",
         allocator_used_before,
@@ -1376,8 +1416,24 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         table_frames_returned_delta,
         table_frames_lost_delta
     );
+    crate::serial_println!(
+        "[PT_LEAF_ORACLE:aarch64:cycles=64:expected={}:recorded={}:released={}:returned={}:live_refused={}:used_before={}:used_after={}]",
+        expected_leaves,
+        leaf_mappings_recorded_delta,
+        leaf_mappings_released_delta,
+        leaf_frames_returned_delta,
+        live_leaf_refused_delta,
+        allocator_used_before,
+        allocator_used_after
+    );
     if allocator_used_after != allocator_used_before {
         return TestResult::Fail("retire leak oracle did not return frame accounting to baseline");
+    }
+    if leaf_mappings_recorded_delta != expected_leaves
+        || leaf_mappings_released_delta != expected_leaves
+        || leaf_frames_returned_delta != expected_leaves
+    {
+        return TestResult::Fail("leaf leak oracle committed-effect accounting was not exact");
     }
     if teardown_entry_exit_delta < 64 {
         return TestResult::Fail("TEARDOWN_ENTRY_EXIT workload delta did not reach 64");
@@ -1442,6 +1498,9 @@ pub fn fork_exit_defer_reclaim_pairing_test() -> crate::test_framework::registry
         FRAME_RETURN_REFUSED_NEVER_ALLOCATED.aggregate(),
         FRAME_RETURN_REFUSED_UNTRACKED.aggregate(),
         FRAME_DUPLICATE_ALLOC_REFUSED.aggregate(),
+        FRAME_RETURN_REFUSED_LIVE_LEAF.aggregate(),
+        LEAF_DECREF_UNREGISTERED.aggregate(),
+        LEAF_CUSTODY_REFUSED.aggregate(),
     ];
     if refusal_counters_after != refusal_counters_before {
         return TestResult::Fail("retire cohort triggered an unexpected frame refusal");

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -1247,13 +1247,13 @@ let _same_line = "needle"; let _real = needle();
 
 const TERMINATE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/interrupts/context_switch.rs", 1017),
-    ("kernel/src/process/manager.rs", 1175),
+    ("kernel/src/process/manager.rs", 1169),
     ("kernel/src/signal/delivery.rs", 225),
     ("kernel/src/signal/delivery.rs", 260),
 ];
 const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 522)];
 const PRODUCTION_INIT_PID_SITES: &[(&str, usize)] = &[
-    ("kernel/src/process/manager.rs", 1192),
+    ("kernel/src/process/manager.rs", 1186),
     ("kernel/src/task/process_task.rs", 482),
     ("kernel/src/task/process_task.rs", 554),
 ];
@@ -1271,7 +1271,7 @@ const QUARANTINE_CALLS: &[(&str, usize)] = &[
 ];
 const KERNEL_STACK_MUTATIONS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/syscall_entry.rs", 961),
-    ("kernel/src/process/manager.rs", 1861),
+    ("kernel/src/process/manager.rs", 1855),
     ("kernel/src/syscall/clone.rs", 252),
 ];
 const RECLAIM_ENQUEUE_CALLS: &[(&str, usize)] = &[
@@ -1360,7 +1360,7 @@ const PROCESS_PAGE_TABLE_ABANDON_SITES: &[(&str, usize, &str)] = &[
     ),
     (
         "kernel/src/process/manager.rs",
-        1154,
+        1148,
         "AbandonReason::AlreadyTerminated",
     ),
 ];
@@ -1383,11 +1383,11 @@ const PROCESS_PAGE_TABLE_CONSTRUCTORS: &[(&str, usize)] = &[
     ("kernel/src/process/manager.rs", 147),
     ("kernel/src/process/manager.rs", 402),
     ("kernel/src/process/manager.rs", 626),
-    ("kernel/src/process/manager.rs", 2245),
-    ("kernel/src/process/manager.rs", 2511),
-    ("kernel/src/process/manager.rs", 2839),
-    ("kernel/src/process/manager.rs", 3115),
-    ("kernel/src/process/manager.rs", 3417),
+    ("kernel/src/process/manager.rs", 2239),
+    ("kernel/src/process/manager.rs", 2505),
+    ("kernel/src/process/manager.rs", 2833),
+    ("kernel/src/process/manager.rs", 3109),
+    ("kernel/src/process/manager.rs", 3411),
     ("kernel/src/syscall/handlers.rs", 1822),
     ("kernel/src/tracing/providers/teardown.rs", 1167),
     ("kernel/src/tracing/providers/teardown.rs", 1211),
@@ -2904,7 +2904,7 @@ fn phase_one_retirement_fence_and_lock_domains_are_structural() {
             line.contains("note_process_row_removed()")
                 && !line.contains("fn note_process_row_removed")
         }),
-        &[("kernel/src/process/manager.rs", 1107)],
+        &[("kernel/src/process/manager.rs", 1101)],
         "ROW_REMOVAL_EPOCH bump sites",
     );
     assert!(function_body(manager, "remove_process").contains("self.processes.remove(&pid)"));

--- a/tests/teardown_structure.rs
+++ b/tests/teardown_structure.rs
@@ -1247,15 +1247,15 @@ let _same_line = "needle"; let _real = needle();
 
 const TERMINATE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/interrupts/context_switch.rs", 1017),
-    ("kernel/src/process/manager.rs", 1172),
+    ("kernel/src/process/manager.rs", 1175),
     ("kernel/src/signal/delivery.rs", 225),
     ("kernel/src/signal/delivery.rs", 260),
 ];
-const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 520)];
+const TERMINATE_MINIMAL_CALLS: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 522)];
 const PRODUCTION_INIT_PID_SITES: &[(&str, usize)] = &[
-    ("kernel/src/process/manager.rs", 1189),
-    ("kernel/src/task/process_task.rs", 480),
-    ("kernel/src/task/process_task.rs", 552),
+    ("kernel/src/process/manager.rs", 1192),
+    ("kernel/src/task/process_task.rs", 482),
+    ("kernel/src/task/process_task.rs", 554),
 ];
 const TEST_INIT_PID_SITES: &[(&str, usize)] = &[
     ("kernel/src/test_userspace.rs", 84),
@@ -1271,21 +1271,21 @@ const QUARANTINE_CALLS: &[(&str, usize)] = &[
 ];
 const KERNEL_STACK_MUTATIONS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/syscall_entry.rs", 961),
-    ("kernel/src/process/manager.rs", 1858),
+    ("kernel/src/process/manager.rs", 1861),
     ("kernel/src/syscall/clone.rs", 252),
 ];
 const RECLAIM_ENQUEUE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 53),
     ("kernel/src/process/mod.rs", 280),
-    ("kernel/src/task/process_task.rs", 594),
+    ("kernel/src/task/process_task.rs", 596),
 ];
 const EXIT_PROCESS_AND_RETIRE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/exception.rs", 824),
     ("kernel/src/arch_impl/aarch64/exception.rs", 1187),
     ("kernel/src/arch_impl/aarch64/exception.rs", 1273),
     ("kernel/src/arch_impl/aarch64/exception.rs", 1371),
-    ("kernel/src/interrupts.rs", 1440),
-    ("kernel/src/interrupts.rs", 1751),
+    ("kernel/src/interrupts.rs", 1442),
+    ("kernel/src/interrupts.rs", 1753),
     ("kernel/src/process/mod.rs", 413),
     ("kernel/src/syscall/signal.rs", 172),
 ];
@@ -1295,7 +1295,7 @@ const EXIT_PROCESS_BY_PID_CALLS: &[(&str, usize)] = &[
     ("kernel/src/process/mod.rs", 418),
 ];
 const EXIT_PROCESS_FOR_TEARDOWN_TEST_CALLS: &[(&str, usize)] =
-    &[("kernel/src/tracing/providers/teardown.rs", 1310)];
+    &[("kernel/src/tracing/providers/teardown.rs", 1337)];
 const BLOCKING_PRIMITIVES: &[(&str, usize)] = &[
     ("kernel/src/task/scheduler.rs", 1973),
     ("kernel/src/task/scheduler.rs", 2187),
@@ -1312,26 +1312,20 @@ const RAW_SCHEDULER_LOCK_SITES: &[(&str, usize)] = &[
     ("kernel/src/task/scheduler.rs", 288),
 ];
 const PROCESS_MEMORY_FRAME_RETURNS: &[(&str, usize)] = &[
-    ("kernel/src/memory/process_memory.rs", 1693),
-    ("kernel/src/memory/process_memory.rs", 1732),
-    ("kernel/src/memory/process_memory.rs", 1769),
-    ("kernel/src/memory/process_memory.rs", 1781),
-    ("kernel/src/memory/process_memory.rs", 1785),
-    ("kernel/src/memory/process_memory.rs", 1789),
-    ("kernel/src/memory/process_memory.rs", 1794),
-    ("kernel/src/memory/process_memory.rs", 1861),
     ("kernel/src/memory/process_memory.rs", 1889),
-    ("kernel/src/memory/process_memory.rs", 1916),
     ("kernel/src/memory/process_memory.rs", 1928),
-    ("kernel/src/memory/process_memory.rs", 1932),
-    ("kernel/src/memory/process_memory.rs", 1936),
-    ("kernel/src/memory/process_memory.rs", 1941),
+    ("kernel/src/memory/process_memory.rs", 1965),
+    ("kernel/src/memory/process_memory.rs", 1977),
+    ("kernel/src/memory/process_memory.rs", 1981),
+    ("kernel/src/memory/process_memory.rs", 1985),
+    ("kernel/src/memory/process_memory.rs", 1990),
 ];
-const RETURN_LEASE_DEFINITION: (&str, usize) = ("kernel/src/memory/frame_allocator.rs", 672);
+const RETURN_LEASE_DEFINITION: (&str, usize) = ("kernel/src/memory/frame_allocator.rs", 924);
 const RETURN_LEASE_PRODUCTION_CALLS: &[(&str, usize)] = &[
-    ("kernel/src/memory/frame_allocator.rs", 760),
-    ("kernel/src/memory/process_memory.rs", 1585),
-    ("kernel/src/memory/process_memory.rs", 1587),
+    ("kernel/src/memory/frame_allocator.rs", 1005),
+    ("kernel/src/memory/frame_allocator.rs", 1024),
+    ("kernel/src/memory/process_memory.rs", 1779),
+    ("kernel/src/memory/process_memory.rs", 1781),
 ];
 const RETURN_LEASE_BOOT_FIXTURE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/memory/frame_allocator_tests.rs", 45),
@@ -1345,62 +1339,65 @@ const RETURN_LEASE_BOOT_FIXTURE_CALLS: &[(&str, usize)] = &[
     ("kernel/src/memory/frame_allocator_tests.rs", 284),
 ];
 const TABLE_RECORDER_SITES: &[(&str, usize)] = &[
-    ("kernel/src/memory/process_memory.rs", 1133),
-    ("kernel/src/memory/process_memory.rs", 1244),
+    ("kernel/src/memory/process_memory.rs", 1268),
+    ("kernel/src/memory/process_memory.rs", 1439),
 ];
 const PROCESS_PAGE_TABLE_ABANDON_SITES: &[(&str, usize, &str)] = &[
     (
         "kernel/src/task/process_task.rs",
-        309,
+        312,
         "AbandonReason::NoProofPipeline",
     ),
     (
         "kernel/src/task/process_task.rs",
-        311,
+        314,
         "AbandonReason::NoArchPipeline",
     ),
     (
         "kernel/src/task/process_task.rs",
-        494,
+        496,
         "AbandonReason::AlreadyTerminated",
     ),
     (
         "kernel/src/process/manager.rs",
-        1151,
+        1154,
         "AbandonReason::AlreadyTerminated",
     ),
 ];
 const PROCESS_PAGE_TABLE_RETIRE_SITES: &[(&str, usize)] = &[
     ("kernel/src/memory/frame_allocator_tests.rs", 41),
-    ("kernel/src/task/process_task.rs", 198),
+    ("kernel/src/memory/process_memory.rs", 232),
+    ("kernel/src/memory/process_memory.rs", 2008),
+    ("kernel/src/task/process_task.rs", 201),
     ("kernel/src/task/process_task.rs", 1491),
     ("kernel/src/task/process_task.rs", 1509),
     ("kernel/src/task/process_task.rs", 1517),
 ];
-const PENDING_RECLAIM_BOUNDED_SITES: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 956)];
+const PENDING_RECLAIM_BOUNDED_SITES: &[(&str, usize)] = &[("kernel/src/task/process_task.rs", 958)];
 const FRAME_LEDGER_INIT_CALLS: &[(&str, usize)] = &[
     ("kernel/src/main_aarch64.rs", 493),
     ("kernel/src/memory/mod.rs", 137),
 ];
 const PROCESS_PAGE_TABLE_CONSTRUCTORS: &[(&str, usize)] = &[
     ("kernel/src/arch_impl/aarch64/syscall_entry.rs", 937),
-    ("kernel/src/process/manager.rs", 144),
-    ("kernel/src/process/manager.rs", 399),
-    ("kernel/src/process/manager.rs", 623),
-    ("kernel/src/process/manager.rs", 2242),
-    ("kernel/src/process/manager.rs", 2508),
-    ("kernel/src/process/manager.rs", 2836),
-    ("kernel/src/process/manager.rs", 3112),
-    ("kernel/src/process/manager.rs", 3393),
+    ("kernel/src/process/manager.rs", 147),
+    ("kernel/src/process/manager.rs", 402),
+    ("kernel/src/process/manager.rs", 626),
+    ("kernel/src/process/manager.rs", 2245),
+    ("kernel/src/process/manager.rs", 2511),
+    ("kernel/src/process/manager.rs", 2839),
+    ("kernel/src/process/manager.rs", 3115),
+    ("kernel/src/process/manager.rs", 3417),
     ("kernel/src/syscall/handlers.rs", 1822),
-    ("kernel/src/tracing/providers/teardown.rs", 1146),
-    ("kernel/src/tracing/providers/teardown.rs", 1190),
-    ("kernel/src/tracing/providers/teardown.rs", 1263),
-    ("kernel/src/memory/process_memory.rs", 2005),
-    ("kernel/src/memory/process_memory.rs", 2031),
-    ("kernel/src/memory/process_memory.rs", 2048),
-    ("kernel/src/memory/process_memory.rs", 2069),
-    ("kernel/src/task/process_task.rs", 1059),
+    ("kernel/src/tracing/providers/teardown.rs", 1167),
+    ("kernel/src/tracing/providers/teardown.rs", 1211),
+    ("kernel/src/tracing/providers/teardown.rs", 1290),
+    ("kernel/src/memory/process_memory.rs", 2136),
+    ("kernel/src/memory/process_memory.rs", 2176),
+    ("kernel/src/memory/process_memory.rs", 2228),
+    ("kernel/src/memory/process_memory.rs", 2245),
+    ("kernel/src/memory/process_memory.rs", 2266),
+    ("kernel/src/task/process_task.rs", 1060),
     ("kernel/src/task/process_task.rs", 1504),
 ];
 
@@ -1651,12 +1648,15 @@ fn validate_frame_return_choke_point(sources: &[(String, String)]) -> Result<(),
 
 fn validate_frame_ledger_hot_paths(sources: &[(String, String)]) -> Result<(), ()> {
     let allocator = source(sources, "kernel/src/memory/frame_allocator.rs");
-    const ROOTS: [&str; 5] = [
+    const ROOTS: [&str; 8] = [
         "frame_ordinal",
         "get",
         "claim_frame",
         "counted",
         "return_lease",
+        "acquire_leaf_mapping",
+        "decref_leaf_mapping",
+        "deallocate_leaf_frame",
     ];
     let bodies = module_function_bodies(allocator);
     let reached = transitively_called_functions(allocator, &ROOTS);
@@ -1724,7 +1724,7 @@ fn validate_frame_ledger_bounded_boot_allocation(sources: &[(String, String)]) -
         && init.contains("while chunk_start < frontier")
         && init.contains(".ensure_chunk(chunk_start)")
         && init.contains("advertised_frames.min(MAX_TRACKED_FRAMES)")
-        && init.contains("NEXT_FREE_FRAME.load(Ordering::Acquire),\n        frontier_snapshot")
+        && init.contains("assert_eq!(NEXT_FREE_FRAME.load(Ordering::Acquire), frontier_snapshot)")
         && !init.contains("(0..total_frames)")
         && !init.contains("reserve_exact(total_frames)")
         && ledger_init.contains("try_reserve_exact(chunk_count)")
@@ -1951,7 +1951,9 @@ fn validate_frame_ledger_runtime_oracles(sources: &[(String, String)]) -> Result
         )
         && counted.contains("ReturnOutcome::LostContended => teardown::FRAME_LOST_CONTENDED.increment()")
         && claim.contains("FRAME_DUPLICATE_ALLOC_REFUSED.increment()")
-        && claim.contains("return Err(ClaimError::Duplicate);")
+        && claim.contains(
+            "ST_ALLOCATED => {\n                crate::tracing::providers::teardown::FRAME_DUPLICATE_ALLOC_REFUSED.increment();\n                return Err(ClaimError::Duplicate);",
+        )
         && gate.contains(DUPLICATE_CLEANUP)
         && gate.contains(DUPLICATE_OWNER_ASSERTION)
         && gate.contains("let free_guard = FREE_FRAMES.lock();")
@@ -2089,13 +2091,14 @@ fn validate_workqueue_progress_wait(registry: &str) -> Result<(), ()> {
 }
 
 fn validate_frame_ledger_counter_inventory(provider: &str) -> Result<(), ()> {
-    const EXPECTED: [&str; 6] = [
+    const EXPECTED: [&str; 7] = [
         "FRAME_RETURN_REFUSED_DOUBLE",
         "FRAME_RETURN_REFUSED_STALE",
         "FRAME_RETURN_REFUSED_NEVER_ALLOCATED",
         "FRAME_RETURN_REFUSED_UNTRACKED",
         "FRAME_DUPLICATE_ALLOC_REFUSED",
         "FRAME_LOST_CONTENDED",
+        "FRAME_RETURN_REFUSED_LIVE_LEAF",
     ];
     let expected: BTreeSet<_> = EXPECTED.into_iter().map(str::to_owned).collect();
     let declared: BTreeSet<_> = provider
@@ -2125,7 +2128,7 @@ fn validate_frame_ledger_counter_inventory(provider: &str) -> Result<(), ()> {
         && EXPECTED
             .iter()
             .all(|counter| inventory.contains(&format!("&{counter},")))
-        && provider.contains("pub const COUNTER_COUNT: usize = 64;"))
+        && provider.contains("pub const COUNTER_COUNT: usize = 70;"))
     .then_some(())
     .ok_or(())
 }
@@ -2167,7 +2170,10 @@ fn validate_process_table_recorder(sources: &[(String, String)]) -> Result<(), (
 
 fn validate_process_page_table_drop_is_non_freeing(sources: &[(String, String)]) -> Result<(), ()> {
     let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
-    let drop_body = function_body(process_memory, "drop");
+    let process_drop = process_memory
+        .find("impl Drop for ProcessPageTable")
+        .ok_or(())?;
+    let drop_body = function_body(&process_memory[process_drop..], "drop");
     (drop_body.contains("Disposition::Undecided")
         && drop_body.contains("trace_count!")
         && drop_body.contains("PT_ROOT_DROPPED_UNDECIDED")
@@ -2211,11 +2217,18 @@ fn validate_process_page_table_dispositions(sources: &[(String, String)]) -> Res
     let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
     let bodies = module_function_bodies(process_memory);
     let cleanup_bodies = bodies.get("cleanup_for_exec").ok_or(())?;
-    (cleanup_bodies.len() == 2
-        && cleanup_bodies.iter().all(|body| {
-            body.matches("Disposition::RetiredByExecWalk").count() == 1
-                && body.matches("PT_EXEC_WALK_LEASES_UNRETURNED").count() == 1
-        }))
+    let legacy = cleanup_bodies.iter().filter(|body| {
+        body.contains("Disposition::RetiredByExecWalk")
+            && body.contains("PT_EXEC_WALK_LEASES_UNRETURNED")
+    });
+    let custody = cleanup_bodies.iter().filter(|body| {
+        body.contains("self.release_mapped_leaves();")
+            && body.contains("self.retire_bounded(pid, budget)")
+            && !body.contains("RetiredByExecWalk")
+            && !body.contains("Vec::new")
+            && !body.contains("log::")
+    });
+    (cleanup_bodies.len() == 2 && legacy.count() == 1 && custody.count() == 1)
     .then_some(())
     .ok_or(())
 }
@@ -2286,7 +2299,7 @@ fn validate_process_page_table_counter_inventory(sources: &[(String, String)]) -
         || !EXPECTED
             .iter()
             .all(|counter| inventory.contains(&format!("&{counter},")))
-        || !provider.contains("pub const COUNTER_COUNT: usize = 64;")
+        || !provider.contains("pub const COUNTER_COUNT: usize = 70;")
     {
         return Err(());
     }
@@ -2300,7 +2313,10 @@ fn validate_process_page_table_counter_inventory(sources: &[(String, String)]) -
     let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
     let record = function_body(process_memory, "record");
     let abandon = function_body(process_memory, "abandon");
-    let drop_body = function_body(process_memory, "drop");
+    let process_drop = process_memory
+        .find("impl Drop for ProcessPageTable")
+        .ok_or(())?;
+    let drop_body = function_body(&process_memory[process_drop..], "drop");
     if !process_memory.contains("pub(crate) fn retire_bounded") {
         return Err(());
     }
@@ -2322,7 +2338,9 @@ fn validate_process_page_table_counter_inventory(sources: &[(String, String)]) -
         && cleanup_bodies.len() == 2
         && cleanup_bodies
             .iter()
-            .all(|body| body.contains("PT_EXEC_WALK_LEASES_UNRETURNED")))
+            .filter(|body| body.contains("PT_EXEC_WALK_LEASES_UNRETURNED"))
+            .count()
+            == 1)
     .then_some(())
     .ok_or(())
 }
@@ -2338,9 +2356,18 @@ fn validate_process_page_table_exit_paths_are_minimal(
     if !task.contains("fn reclaim_bounded(&mut self)") {
         return Err(());
     }
+    let process_drop = process_memory
+        .find("impl Drop for ProcessPageTable")
+        .ok_or(())?;
+    let unpublished_drop = process_memory
+        .find("impl Drop for UnpublishedPageTable")
+        .ok_or(())?;
     for body in [
         function_body(process_memory, "abandon"),
-        function_body(process_memory, "drop"),
+        function_body(&process_memory[process_drop..], "drop"),
+        function_body(&process_memory[unpublished_drop..], "drop"),
+        function_body(process_memory, "release_leaf_record"),
+        function_body(process_memory, "release_mapped_leaves"),
         function_body(process_memory, "retire_bounded"),
         function_body(task, "reclaim_bounded"),
     ] {
@@ -2356,6 +2383,150 @@ fn validate_process_page_table_exit_paths_are_minimal(
         ] {
             if body.contains(forbidden) {
                 eprintln!("R7 page-table exit path gained {forbidden}");
+                return Err(());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_leaf_custody(sources: &[(String, String)]) -> Result<(), ()> {
+    let process_memory = source(sources, "kernel/src/memory/process_memory.rs");
+    let allocator = source(sources, "kernel/src/memory/frame_allocator.rs");
+    let metadata = source(sources, "kernel/src/memory/frame_metadata.rs");
+    let fork = source(sources, "kernel/src/process/fork.rs");
+    let interrupts = source(sources, "kernel/src/interrupts.rs");
+    let arm_exception = source(sources, "kernel/src/arch_impl/aarch64/exception.rs");
+    let stack = source(sources, "kernel/src/memory/stack.rs");
+    let graphics = source(sources, "kernel/src/syscall/graphics.rs");
+    let manager = source(sources, "kernel/src/process/manager.rs");
+    let arm_elf = source(sources, "kernel/src/arch_impl/aarch64/elf.rs");
+
+    let map = function_body(process_memory, "map_page");
+    let reserve = map.find(".try_reserve(1)").ok_or(())?;
+    let acquire = map.find("acquire_leaf_mapping(frame)").ok_or(())?;
+    let insert = map.find("self.leaves.records.insert(").ok_or(())?;
+    let publish = map.find("mapper.map_to_with_table_flags(").ok_or(())?;
+    let committed = map.find("LEAF_MAPPINGS_RECORDED").ok_or(())?;
+    if !(reserve < acquire && acquire < insert && insert < publish && publish < committed)
+        || !map.contains("self.leaves.records.remove(index);")
+        || !map.contains("frame_decref(frame)")
+    {
+        return Err(());
+    }
+
+    let unmap = function_body(process_memory, "unmap_page");
+    let release = function_body(process_memory, "release_leaf_record");
+    let drain = function_body(process_memory, "release_mapped_leaves");
+    if !process_memory.contains("struct LeafRecord")
+        || !process_memory.contains("page: u64")
+        || !process_memory.contains("binary_search_by_key(&page")
+        || !unmap.contains("self.leaves.search(page_addr)")
+        || !unmap.contains("Self::release_leaf_record(record, frame)")
+        || !release.contains("frame_decref(frame)")
+        || !release.contains("deallocate_leaf_frame(frame) == ReturnOutcome::Returned")
+        || !drain.contains("self.walk_mapped_pages(")
+        || !drain.contains("records.binary_search_by_key(&page")
+        || !drain.contains("self.leaves.records.clear();")
+        || !drain.contains("self.leaves.released = true;")
+    {
+        return Err(());
+    }
+
+    let decref = function_body(allocator, "decref_leaf_mapping");
+    let returned = function_body(allocator, "return_lease");
+    if !decref.contains("if refs == 0 {")
+        || !decref.contains("LEAF_DECREF_UNREGISTERED")
+        || !decref.contains("return false;")
+        || decref.contains("return true;")
+        || !returned.contains("if slot.leaf_refs.load(Ordering::Acquire) != 0 {")
+        || !returned.contains("ReturnOutcome::RefusedLiveLeaf")
+        || !metadata.contains("decref_leaf_mapping(frame)")
+    {
+        return Err(());
+    }
+
+    for converted in [fork, interrupts, arm_exception] {
+        let mask = code_mask(converted);
+        if !code_offsets(converted, &mask, "frame_register(").is_empty()
+            || !code_offsets(converted, &mask, "frame_incref(").is_empty()
+        {
+            return Err(());
+        }
+    }
+    if stack.matches("register_external_leaf_frame(frame)?;").count() != 2
+        || !graphics.contains("register_external_leaf_span(")
+    {
+        return Err(());
+    }
+
+    let unpublished = process_memory
+        .find("impl Drop for UnpublishedPageTable")
+        .ok_or(())?;
+    let unpublished_drop = function_body(&process_memory[unpublished..], "drop");
+    if unpublished_drop.find("page_table.release_mapped_leaves();").ok_or(())?
+        > unpublished_drop
+            .find("page_table.retire_bounded(self.pid, &mut budget)")
+            .ok_or(())?
+        || !arm_elf.contains("deallocate_leaf_frame(new_frame)")
+    {
+        return Err(());
+    }
+    let exec_bodies = module_function_bodies(manager);
+    let mut arm_execs = Vec::new();
+    for name in ["exec_process", "exec_process_with_argv"] {
+        for body in exec_bodies.get(name).into_iter().flatten() {
+            if body.contains("[ARM64]") {
+                arm_execs.push(*body);
+            }
+        }
+    }
+    if arm_execs.len() != 2 {
+        return Err(());
+    }
+    for body in arm_execs {
+        let guard = body.find("UnpublishedPageTable::new(").ok_or(())?;
+        let load = body.find("load_elf_into_page_table(").ok_or(())?;
+        let supersede = body.find("process.page_table.take()").ok_or(())?;
+        let publish = body.find("new_page_table.publish()").ok_or(())?;
+        if !(guard < load && load < supersede && supersede < publish)
+            || body.matches("UnpublishedPageTable::new(").count() != 1
+            || body.matches("new_page_table.publish()").count() != 1
+        {
+            return Err(());
+        }
+    }
+
+    let gate = function_body(process_memory, "page_table_custody_disposition_gate_test");
+    for required in [
+        "corrupt_executable_fixture()",
+        "Err(\"Segment data out of bounds\")",
+        "drop(unpublished);",
+        "used_after != used_before",
+        "LEAF_MAPPINGS_RECORDED.aggregate() != leaf_recorded_before + 1",
+        "LEAF_MAPPINGS_RELEASED.aggregate() != leaf_released_before + 1",
+        "LEAF_FRAMES_RETURNED.aggregate() != leaf_returned_before + 1",
+        "PT_TABLE_FRAMES_RETURNED.aggregate() != tables_returned_before + 4",
+        "PT_ROOTS_RETIRED.aggregate() != roots_retired_before + 1",
+        "[EXEC_FAILED_RELEASE_ORACLE:aarch64:",
+    ] {
+        if !gate.contains(required) {
+            return Err(());
+        }
+    }
+
+    for body in [release, drain, decref, function_body(allocator, "deallocate_leaf_frame")] {
+        for forbidden in [
+            "log::",
+            "serial_println!",
+            "format!",
+            "vec!",
+            "Vec::",
+            "alloc::",
+            "reserve(",
+            "try_reserve(",
+        ] {
+            if body.contains(forbidden) {
                 return Err(());
             }
         }
@@ -2382,6 +2553,12 @@ fn validate_pr1c_retirement_oracles(sources: &[(String, String)]) -> Result<(), 
         "PT_ROOT_ABANDONED_NO_ARCH",
         "saturating_sub(no_arch_before)",
         "[PT_RETIRE_ORACLE:aarch64:cycles=64:",
+        "[PT_LEAF_ORACLE:aarch64:cycles=64:",
+        "let expected_leaves = (RETIRE_SENTINEL_VAS.len() * pairing_child_pids.len()) as u64;",
+        "leaf_mappings_recorded_delta != expected_leaves",
+        "leaf_mappings_released_delta != expected_leaves",
+        "leaf_frames_returned_delta != expected_leaves",
+        "leaf leak oracle committed-effect accounting was not exact",
     ] {
         if !gate.contains(required) {
             return Err(());
@@ -2409,7 +2586,7 @@ fn validate_process_page_table_runtime_oracle(sources: &[(String, String)]) -> R
         || !gate.contains("no_arch.abandon(AbandonReason::NoArchPipeline);")
         || !gate.contains("after_no_arch[2] != after_drop[2] + 1")
         || !gate.contains("PT_TABLE_FRAMES_RETURNED.aggregate()")
-        || gate.matches("free_list_len_for_gate()").count() != 7
+        || gate.matches("free_list_len_for_gate()").count() != 9
         || gate.contains("&& false")
         || gate.contains("|| true")
     {
@@ -2472,6 +2649,8 @@ fn process_page_table_custody_ratchets_are_exact() {
         .expect("R6 process page-table counter inventory changed");
     validate_process_page_table_exit_paths_are_minimal(&sources)
         .expect("R7 process page-table exit path gained log/format/heap work");
+    validate_leaf_custody(&sources)
+        .expect("PR-2 virtual-page leaf custody or fail-closed release changed");
     validate_process_page_table_runtime_oracle(&sources)
         .expect("O2/G-H process page-table runtime oracle became vacuous");
     validate_pr1c_retirement_oracles(&sources)
@@ -2507,6 +2686,7 @@ fn frame_ledger_return_and_initialization_ratchets_are_exact() {
         "FRAME_RETURN_REFUSED_UNTRACKED",
         "FRAME_DUPLICATE_ALLOC_REFUSED",
         "FRAME_LOST_CONTENDED",
+        "FRAME_RETURN_REFUSED_LIVE_LEAF",
     ] {
         assert_eq!(
             provider.matches(&format!("counter!({counter},")).count()
@@ -2525,7 +2705,7 @@ fn frame_ledger_return_and_initialization_ratchets_are_exact() {
             "counter became conditional: {counter}"
         );
     }
-    assert!(provider.contains("pub const COUNTER_COUNT: usize = 64;"));
+    assert!(provider.contains("pub const COUNTER_COUNT: usize = 70;"));
 }
 
 #[test]
@@ -2607,7 +2787,7 @@ fn v3_structural_closures_are_exact() {
     );
     assert_exact(
         sites_matching(&sources, |line| line.contains("btrt::on_process_exit(")),
-        &[("kernel/src/task/process_task.rs", 621)],
+        &[("kernel/src/task/process_task.rs", 623)],
         "btrt::on_process_exit callers",
     );
 
@@ -2724,7 +2904,7 @@ fn phase_one_retirement_fence_and_lock_domains_are_structural() {
             line.contains("note_process_row_removed()")
                 && !line.contains("fn note_process_row_removed")
         }),
-        &[("kernel/src/process/manager.rs", 1104)],
+        &[("kernel/src/process/manager.rs", 1107)],
         "ROW_REMOVAL_EPOCH bump sites",
     );
     assert!(function_body(manager, "remove_process").contains("self.processes.remove(&pid)"));
@@ -2782,7 +2962,7 @@ fn all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates() {
         .filter_map(|rest| rest.strip_suffix(','))
         .map(str::to_owned)
         .collect();
-    assert_eq!(declarations.len(), 64);
+    assert_eq!(declarations.len(), 70);
     assert_eq!(
         readers, declarations,
         "every counter must have an inventory reader"
@@ -3477,8 +3657,8 @@ fn deliberately_broken_variants_fail_the_ratchet() {
 
     // R4: ProcessPageTable's Drop can count but can never return a frame.
     let freeing_drop = process_memory.replacen(
-        "fn drop(&mut self) {",
-        "fn drop(&mut self) { crate::memory::frame_allocator::deallocate_frame(self.level_4_frame);",
+        "impl Drop for ProcessPageTable {\n    fn drop(&mut self) {",
+        "impl Drop for ProcessPageTable {\n    fn drop(&mut self) { crate::memory::frame_allocator::deallocate_frame(self.level_4_frame);",
         1,
     );
     let freeing_drop = with_replaced_source(
@@ -3587,8 +3767,8 @@ fn deliberately_broken_variants_fail_the_ratchet() {
     );
     assert!(validate_process_page_table_exit_paths_are_minimal(&logged_abandon).is_err());
     let allocating_drop = process_memory.replacen(
-        "fn drop(&mut self) {",
-        "fn drop(&mut self) { let _unexpected = Vec::<u8>::new();",
+        "impl Drop for ProcessPageTable {\n    fn drop(&mut self) {",
+        "impl Drop for ProcessPageTable {\n    fn drop(&mut self) { let _unexpected = Vec::<u8>::new();",
         1,
     );
     let allocating_drop = with_replaced_source(
@@ -3614,6 +3794,77 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         logged_retire,
     );
     assert!(validate_process_page_table_exit_paths_are_minimal(&logged_retire).is_err());
+
+    // PR-2: virtual-page records precede descriptor publication, decref is
+    // fail-closed, and a live leaf can never enter the reuse pool.
+    let no_leaf_reserve = process_memory.replacen(".try_reserve(1)", ".try_reserve(0)", 1);
+    let no_leaf_reserve = with_replaced_source(
+        &sources,
+        "kernel/src/memory/process_memory.rs",
+        no_leaf_reserve,
+    );
+    assert!(validate_leaf_custody(&no_leaf_reserve).is_err());
+    let post_publish_record = process_memory.replacen(
+        "let mapping = match acquire_leaf_mapping(frame)",
+        "let mapping = match classify_after_descriptor(frame)",
+        1,
+    );
+    let post_publish_record = with_replaced_source(
+        &sources,
+        "kernel/src/memory/process_memory.rs",
+        post_publish_record,
+    );
+    assert!(validate_leaf_custody(&post_publish_record).is_err());
+    let fail_open_decref = allocator.replacen(
+        "if refs == 0 {",
+        "if refs == 0 { return true; } if false {",
+        1,
+    );
+    let fail_open_decref = with_replaced_source(
+        &sources,
+        "kernel/src/memory/frame_allocator.rs",
+        fail_open_decref,
+    );
+    assert!(validate_leaf_custody(&fail_open_decref).is_err());
+    let live_leaf_return = allocator.replacen(
+        "ST_ALLOCATED => {\n                if slot.leaf_refs.load(Ordering::Acquire) != 0 {",
+        "ST_ALLOCATED => {\n                if slot.leaf_refs.load(Ordering::Acquire) != 0 && false {",
+        1,
+    );
+    let live_leaf_return = with_replaced_source(
+        &sources,
+        "kernel/src/memory/frame_allocator.rs",
+        live_leaf_return,
+    );
+    assert!(validate_leaf_custody(&live_leaf_return).is_err());
+    let logged_leaf_release = process_memory.replacen(
+        "fn release_leaf_record(record: LeafRecord, frame: PhysFrame) {",
+        "fn release_leaf_record(record: LeafRecord, frame: PhysFrame) { log::info!(\"leaf\");",
+        1,
+    );
+    let logged_leaf_release = with_replaced_source(
+        &sources,
+        "kernel/src/memory/process_memory.rs",
+        logged_leaf_release,
+    );
+    assert!(validate_leaf_custody(&logged_leaf_release).is_err());
+    let restored_fork_incref = with_replaced_source(
+        &sources,
+        "kernel/src/process/fork.rs",
+        format!("{}\nfn synthetic_leaf_bypass(frame: PhysFrame) {{ frame_incref(frame); }}", source(&sources, "kernel/src/process/fork.rs")),
+    );
+    assert!(validate_leaf_custody(&restored_fork_incref).is_err());
+    let early_exec_supersede = source(&sources, "kernel/src/process/manager.rs").replacen(
+        "crate::memory::process_memory::UnpublishedPageTable::new(",
+        "crate::memory::process_memory::ProcessPageTable::new_unchecked(",
+        1,
+    );
+    let early_exec_supersede = with_replaced_source(
+        &sources,
+        "kernel/src/process/manager.rs",
+        early_exec_supersede,
+    );
+    assert!(validate_leaf_custody(&early_exec_supersede).is_err());
 
     // O2/G-H: weaken either exact counter assertion and the named validator fails.
     for (needle, replacement) in [
@@ -3967,8 +4218,8 @@ fn deliberately_broken_variants_fail_the_ratchet() {
     );
     assert!(validate_frame_ledger_hot_paths(&growing_return).is_err());
     let logged_get = allocator.replacen(
-        "fn get(&self, index: usize) -> Option<&AtomicU32> {",
-        "fn get(&self, index: usize) -> Option<&AtomicU32> { log::warn!(\"ledger get {}\", index);",
+        "fn get(&self, index: usize) -> Option<&FrameLedgerSlot> {",
+        "fn get(&self, index: usize) -> Option<&FrameLedgerSlot> { log::warn!(\"ledger get {}\", index);",
         1,
     );
     let logged_get =
@@ -4087,8 +4338,11 @@ fn deliberately_broken_variants_fail_the_ratchet() {
         stale_miscounted,
     );
     assert!(validate_frame_ledger_runtime_oracles(&stale_miscounted).is_err());
-    let escaped_duplicate =
-        allocator.replacen("return Err(ClaimError::Duplicate);", "return Ok(None);", 1);
+    let escaped_duplicate = allocator.replacen(
+        "crate::tracing::providers::teardown::FRAME_DUPLICATE_ALLOC_REFUSED.increment();\n                return Err(ClaimError::Duplicate);",
+        "crate::tracing::providers::teardown::FRAME_DUPLICATE_ALLOC_REFUSED.increment();\n                return Ok(None);",
+        1,
+    );
     let escaped_duplicate = with_replaced_source(
         &sources,
         "kernel/src/memory/frame_allocator.rs",
@@ -4096,8 +4350,8 @@ fn deliberately_broken_variants_fail_the_ratchet() {
     );
     assert!(validate_frame_ledger_runtime_oracles(&escaped_duplicate).is_err());
     let broken_bounds = allocator.replacen(
-        "\n    None\n}\n\nfn seed_free_frame",
-        "\n    Some(0)\n}\n\nfn seed_free_frame",
+        "\n    None\n}\n\nfn frame_in_external_leaf_span",
+        "\n    Some(0)\n}\n\nfn frame_in_external_leaf_span",
         1,
     );
     let broken_bounds = with_replaced_source(


### PR DESCRIPTION
## Summary

aarch64 leaf-frame custody, wired end-to-end through fork/CoW/external-conversion
and the exec path, plus a latent user-stack contiguity fix main was silently
carrying. This is F4 of the #470 leaf-frame custody campaign (DESIGN-470-v2).

- **Leaf custody from allocator state.** `frame_allocator.rs` / `frame_metadata.rs`
  now track leaf-frame ownership as first-class allocator state (not just
  bookkeeping bolted onto process teardown), wired through fork, CoW, and the
  owned→`External` conversion path.
- **`frame_decref` fails closed.** Decref on a frame whose custody state doesn't
  support it is now a hard failure rather than a silent no-op — the class of bug
  that let #470/#528-style over-frees happen quietly is now structurally caught.
- **aarch64 `cleanup_for_exec` → `retire_bounded` + `walk_mapped_pages` decref.**
  The exec path now walks the previous address space's mapped pages and retires
  (bounded) + decrefs their leaves through the same custody machinery, instead of
  the ad hoc handling it had before.
- **Failed-exec release.** A process that fails partway through `exec()` now
  releases the frames it had already mapped for the new image, instead of leaking
  them.
- **aarch64 user-stack contiguity fix** (`kernel/src/memory/stack.rs`): user-stack
  allocation now maps each frame individually so the mapped virtual range always
  matches the frames actually allocated for it. This repairs a **pre-existing
  latent stack-corruption class main was silently carrying** (a mismatch between
  what was allocated and what was mapped), found and fixed as part of getting the
  custody accounting to balance exactly.

### Honest trade: over-free eliminated, small residual leak introduced

Borrowed/external user-stack frames are now marked `External` and are **never
decref'd** through the normal owned-frame path — `GuardedStack::Drop` is currently a
no-op for them. This deliberately trades the #470/#528 **over-free/corruption**
class (main's structural bug: freeing kernel-HHDM-live stack frames still owned by
someone else) for a **safe, bounded, per-exit leak** (frames that go unreclaimed
until an owner-side reclamation path exists). This is not free — it is a known,
tracked, intentional trade per DESIGN-470-v2 §1.6, not an oversight. Owner-side
reclamation of these `External` frames is tracked as a follow-up in #546, along with
a smaller `try_lock()`-vs-blocking-`Mutex` hardening note for the CoW fault path.

## Proof (mutation-first)

- **Wired custody:** 92/92 (frame ledger + custody records tracked on every path
  exercised)
- **Leaf custody oracles:** 192/192/192 across the three oracle passes
- **`retire_bounded`:** `lost=0` — every retired leaf accounted for
- **Failed-exec release:** balanced (frames mapped during a failed exec are fully
  released, no leak, no over-free)
- **Mutation testing:** stub-out the fix → oracle **FAILS** (proves the oracle is
  live, not vacuous); reintroduce an over-free → oracle **fails closed**
  (`live_refused=192`, i.e. every one of the 192 illegal frees is caught and
  refused); restore the real fix → oracle **PASSES** again

## Gate results

- **aarch64 clean-gate:** 300 runs, 0 faults
- **aarch64 starved-gate:** 100 runs, 0 faults
- **x86 build:** clean, 0 warnings
- **Parallels (real ARM64 hardware):** 3/3 boots green

### Known pre-existing condition (does not gate this PR)

x86 boot-to-completion has a **known, pre-existing, intermittent TCP-recv hang**,
now tracked in #545: a thread blocked in `recv()` on a loopback TCP socket is never
rescheduled because the general kernel idle loop doesn't drain the pending-packet
loopback queue (only the special single-test idle loops do). Confirmed
reproducible on `main` at `a38ce4a4b2e4f1008f5421a0726067c97e954f46` (3/3), with an
identical signature to what this branch occasionally shows — this branch is
actually *less* prone to it in local runs (2/3 pass). The mechanism is entirely in
the TCP-recv wakeup/scheduler path and this PR does not touch it. See #545 for the
full RCA and proposed fix (add `drain_loopback_queue()` to `idle_thread_fn`).

## Diff size (honest disclosure)

17 files changed, 1285 insertions(+), 570 deletions(-) — concentrated in
`kernel/src/memory/{frame_allocator,frame_metadata,process_memory,stack}.rs`,
`kernel/src/process/{manager,process}.rs`, and `tests/teardown_structure.rs` (the
oracle/proof harness itself is ~414 of those lines).

## Closes

Closes #470 (aarch64 F4 exec-path leaves). Note: #470 was already closed by the
earlier PR-1a/PR-1b/PR-1c merges in this campaign (frame ledger, custody record,
aarch64 root retirement); this PR completes the remaining aarch64 F4 exec-path-leaf
scope of that campaign. Remaining #470 work (x86 free path, PR-3) is tracked
separately and gated on operator approval since it touches Tier-2
`context_switch.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
