### PR TITLE
docs: preserve #470 custody design docs recovered from transcripts

### DIFF
--- a/docs/planning/470-custody/DESIGN-470-v2.md
+++ b/docs/planning/470-custody/DESIGN-470-v2.md
@@ -1,0 +1,544 @@
+# DESIGN-470-v2 — allocation-derived custody with allocator-generation authority
+
+**Issue:** #470 (F3: root/PML4 + intermediate-table leak on every process exit; F4: aarch64 exec-path leak)
+**Baseline:** `main` @ `363eb912` (post-#528, post-#531/#532). Every file:line below was re-verified against this commit.
+**Supersedes:** design-A-custody.md, design-B-oracle.md, design-C-minimal.md, and branch `fix/470-process-root-reclaim`.
+
+---
+
+## 0. Provenance: how the judges were resolved
+
+The two judges split on the nominal winner and converged on the artifact.
+
+| | Judge 1 | Judge 2 |
+|---|---|---|
+| Ranking | **A** > C > B | **B** > A > C |
+| Reason for #1 | A is the only design that frees at exactly one proof-discharged site *and* fits the size law | B is the only design covering all 23 properties (generation authority, page-keyed leaves, bounded release) |
+| Reason B/C rejected | B's PR-1 is the 3rd PR and closes no part of #470; est. not credible | C frees roots at 3 sites with no liveness proof — leak→UAF regression |
+| Graft recommendation | Graft **B's ledger-init discipline, generation upgrade, counter-with-live-arm rule, budget/refusal separation** into A; graft **C's exec-disposition fix** | Graft **A's `retire`/`abandon`/non-freeing `Drop`, A's narrow table-only recorder as the first slice**; graft **C's committed-effect accounting and honest-residual ledger** |
+
+Both graft lists describe the same document. This design is therefore **Design A's structure — one custody record per address space, one freeing function, one proof-discharged call site, PR-1 split at a behaviour-preserving seam — with Design B's allocator authority model (per-frame generation + state, allocation-time duplicate detection, explicitly budgeted release, virtual-page-keyed leaf specification) grafted at the allocator choke point, and Design C's exec disposition fix, committed-effect accounting, and residual-disclosure discipline grafted throughout.**
+
+Every constraint that either judge scored **VIOLATED**, **PARTIAL**, or **UNADDRESSED** against the base design is resolved in §10; nothing is carried forward unresolved.
+
+### 0.1 Three factual corrections to the input designs (verified on `363eb912`)
+
+1. **Design C's x86 allocation inventory is wrong, and Judge 1's verification table repeated the error.** `process_memory.rs:801,:820,:839,:886,:905,:924` are inside a block comment opened at `:767` and closed at `:949` — dead text, not conditional kernel-stack/IST PDPT allocations. The only live direct x86 table allocation in `new()` is the fresh PML4[0] PDPT at `:601-602`. Judge 2 is correct. PR-3's x86 inventory in §8 is corrected accordingly.
+2. **The `already_terminated` drop in `manager.rs` is at `:1150`, not `:1151`** (Design A cites `:1151`).
+3. **Three dead direct table allocators exist and are unratcheted by all three designs:** `deep_copy_pml4_entry`/`deep_copy_l3_entry`/`deep_copy_l2_entry` allocate intermediate tables at `process_memory.rs:105`, `:170`, `:251` under `#[allow(dead_code)]` with no callers. They bypass any recorder. PR-1b **deletes** them (subtractive) and ratchet R2 keeps them gone.
+
+---
+
+## 1. The custody model
+
+### 1.1 Frame classes on current main
+
+| Class | What / where | Owner | Freed today | Freed by this design |
+|---|---|---|---|---|
+| **Root** | `ProcessPageTable::level_4_frame` (`process_memory.rs:78-85`), allocated `:303` (aarch64 L0) / `:380` (x86 PML4) | the `ProcessPageTable` value, exclusively | exec walk only (`:1845` x86, `:1986` aarch64); **leaked on every ordinary exit** | `retire_bounded()`, exclusively (aarch64, PR-1c) |
+| **Intermediate table** | aarch64 L1/L2/L3 via `arch_stub.rs:1055-1092` `get_or_create_table_inner`; x86 PDPT/PD/PT via the `x86_64` crate mapper; plus x86's PML4[0] PDPT at `:601-602` | same value, exclusively | exec walk only (`:1832-1840`, `:1973-1981`); **leaked on every ordinary exit** | `retire_bounded()`, from the custody record |
+| **Leaf (user data)** | 4 KiB/2 MiB frames at the bottom | the refcount registry (`frame_metadata.rs`); an address space holds a *reference* | `cleanup_cow_frames` (`process/process.rs:567` x86, `:606` aarch64 → `cleanup_cow_page_table:686`) on exit; the exec walk | **unchanged in PR-1**; PR-2 converts (§1.6) |
+| **Kernel-shared table** | x86 master PML4[256..512] copied by `set_addr`; aarch64 TTBR1 side | the kernel | never (correct) | never — structurally: never allocated by us, never recorded |
+
+**The load-bearing structural fact for PR-1:** on the exit path, leaves are already released before the root is dropped. `release_process_resources` (`process_task.rs:285`) runs `cleanup_cow_frames()` at `:289`, `drain_old_page_tables()` at `:290`, then `drop(process.page_table.take())` at `:291`. The deferred path does the same: `PendingProcessReclaim::reclaim` (`process_task.rs:179`) → `cleanup_cow_page_table` at `:181` → `cleanup_for_exec` for old roots at `:184` → `drop(self.page_table.take())` at `:186`. **#470-F3 therefore leaks only root + intermediate tables — the two classes with exclusive custody.** PR-1 frees zero leaves and inherits zero leaf-custody obligations.
+
+### 1.2 Layer 1 — the frame ledger (allocator authority)
+
+*(Design B's model, sized and initialized the way Design A's cost discipline requires. This is the layer that answers C15/C22 and Judge 2's stale-authority objection to a one-bit design.)*
+
+The allocator already has an index space: `BootInfoFrameAllocator::get_usable_frame(n)` (`frame_allocator.rs:98`) maps a **usable-frame ordinal** to a `PhysFrame`, and `NEXT_FREE_FRAME: AtomicUsize` (`:42`) is the sequential frontier in that ordinal space. The ledger reuses it — no new address map, no sparse-region hazard.
+
+```rust
+// kernel/src/memory/frame_allocator.rs
+/// One u32 per usable frame: state in bits 0..2, generation in bits 2..32.
+/// Indexed by the allocator's own usable-frame ordinal.
+static FRAME_LEDGER: spin::Once<&'static [AtomicU32]> = spin::Once::new();
+
+const ST_NEVER: u32 = 0;      // above the frontier, never handed out
+const ST_ALLOCATED: u32 = 1;  // outstanding
+const ST_FREE: u32 = 2;       // returned, reusable
+
+/// Unforgeable return authority. No public constructor; produced only by
+/// `allocate_frame_leased()`; `Copy` so a lease can be stored in a record.
+#[derive(Clone, Copy)]
+pub struct FrameLease { frame: PhysFrame, index: u32, generation: u32 }
+
+pub enum ReturnOutcome { Returned, LostContended, RefusedDoubleRelease, RefusedStale, RefusedUntracked }
+```
+
+**Operations, all O(1) except the ordinal lookup, which is O(regions ≤ 128) and typically 1–4 iterations — the same cost class the sequential allocator already pays:**
+
+- `allocate_frame_leased() -> Option<FrameLease>`: calls the existing `allocate_frame()` (`:298`), computes the ordinal, then CAS `ST_FREE|ST_NEVER → ST_ALLOCATED` with `generation += 1`. **If the observed state is already `ST_ALLOCATED`, the allocator has handed out a live frame twice**: count `FRAME_DUPLICATE_ALLOC_REFUSED`, do **not** hand the frame to the caller (it is dropped from the free pool, not leaked into a second owner), retry once; a second failure returns `None` with a sticky `AllocatorCorrupt` reason that `map_page` surfaces as `MapError::AllocatorCorrupt`, never as OOM. **This is C22, caught at allocation, before the mapper can zero a frame that is a live table elsewhere** — the defect Judge 2 found in Design A's record-and-proceed answer.
+- `return_lease(lease) -> ReturnOutcome`: one indexed load; requires `ST_ALLOCATED` **and** `generation == lease.generation`; transitions to `ST_FREE`, then pushes onto `FREE_FRAMES` under the existing `try_lock` (`:338`). Refusals: `ST_FREE` → `RefusedDoubleRelease`; generation mismatch → `RefusedStale` (stale authority after reuse — what a one-bit design cannot catch); no ordinal → `RefusedUntracked`. **A refusal leaks one frame; it never corrupts.** `return_lease` contains no log/format/heap (ratchet R7).
+- `deallocate_frame(frame)` (existing signature, `:328`, all other callers) keeps its behaviour and its pre-existing logging, but routes its push through the same ledger transition using the ledger's own generation. It therefore gains the double-release guard for every caller on both arches, without gaining staleness detection (it has no lease). **One choke point, two wrappers** — ratchet R1 proves that every `FREE_FRAMES … push` in the tree lies inside `return_lease`'s span.
+
+**Initialization (this is where Design A was not implementable).** aarch64 calls `frame_allocator::init_aarch64` at `main_aarch64.rs:491` **before** `init_aarch64_heap()` at `:492`, so a heap-backed table cannot be sized in `init`. The ledger is built by an explicit `init_frame_ledger()` called **immediately after heap init**, at a quiescent single-threaded boot point:
+
+- aarch64: `main_aarch64.rs:492`, on the line after `init_aarch64_heap()`.
+- x86: `kernel/src/memory/mod.rs`, after `heap::init` (`:130` / `:135`) and before slab init (`:138`).
+
+Seeding is exact, not heuristic, because the allocator's whole state is readable at that instant: ordinals `< NEXT_FREE_FRAME` → `ST_ALLOCATED(gen 1)`; every frame currently in `FREE_FRAMES` → `ST_FREE(gen 1)`; ordinals `≥ NEXT_FREE_FRAME` → `ST_NEVER`. Pre-ledger bootstrap frames are therefore correctly `ST_ALLOCATED` and a double release of one is caught. Ratchet R9 pins the two init call sites and proves every `ProcessPageTable` constructor is downstream of them.
+
+**Cost:** 4 bytes per usable frame = **512 KiB for 512 MiB of RAM (0.1%)**, one heap allocation at boot. (Design B's ≥24 B/frame variant — Judge 1's B-2 objection — is not adopted: class/refcount/owner stay out of the ledger; refcounts remain in `frame_metadata.rs`.)
+
+### 1.3 Layer 2 — the address-space custody record
+
+*(Design A's core, unchanged in shape; the record now holds leases instead of raw frames.)*
+
+```rust
+// kernel/src/memory/process_memory.rs
+pub struct ProcessPageTable {
+    level_4_frame: PhysFrame,          // unchanged; still the hardware-facing field
+    mapper: OffsetPageTable<'static>,
+    root_lease: FrameLease,            // NEW — return authority for level_4_frame
+    tables: OwnedTableFrames,          // NEW
+}
+
+struct OwnedTableFrames {
+    leases: Vec<FrameLease>,
+    disposition: Disposition,
+}
+
+/// The ONLY `FrameAllocator` a process mapper is ever given.
+struct TableRecorder<'a>(&'a mut OwnedTableFrames);
+
+unsafe impl FrameAllocator<Size4KiB> for TableRecorder<'_> {
+    fn allocate_frame(&mut self) -> Option<PhysFrame> {
+        let lease = crate::memory::frame_allocator::allocate_frame_leased()?;
+        self.0.leases.push(lease);          // record, no dedup, no policy, no failure mode
+        Some(lease.frame)
+    }
+}
+```
+
+**Why the record is complete, on both arches, by construction:**
+
+- aarch64: `get_or_create_table_inner` (`arch_stub.rs:1055-1092`) is the only creator of an aarch64 intermediate table and takes its frame from the caller-supplied allocator at `:1068`; it is reached only from `map_to`/`map_to_with_table_flags`.
+- x86: the `x86_64` crate's `map_to_with_table_flags` uses the supplied allocator identically.
+- Exactly **two** live sites hand an allocator to a process mapper: `map_page` (`process_memory.rs:1251-1257`, the `&mut GlobalFrameAllocator` at `:1256`) and `update_page_flags` (`:1360-1367`, at `:1366`). Both become `&mut TableRecorder(tables)` via `let Self { mapper, tables, .. } = self;`.
+- The two escape hatches — `ProcessPageTable::mapper()` (`:1565`) and `::allocate_stack()` (`:1571`) — are `#[allow(dead_code)]` with zero callers (`grep -rn "\.mapper()" kernel/src` finds only `paging::get_mapper()` on the kernel table). **PR-1b deletes both.** The three dead `deep_copy_*` helpers (`:105`, `:170`, `:251`) are deleted with them (§0.1).
+- Roots allocated outside the mapper are leased at their own sites: `:303` (aarch64 L0), `:380` (x86 PML4) → `root_lease`; x86's conditional PML4[0] PDPT (`:601-602`) → `tables.leases.push(...)` on the following line. **This is C2 fixed at the source: a conditional allocation produces a conditional record automatically, because the record is written where the allocation happens.** No second place has to know a count.
+
+**Why the record never goes stale:** no `unmap` path frees an intermediate table — aarch64 `arch_stub.rs:1210-1261` only clears the L3 entry and returns the leaf; `unmap_user_pages` (`:1644`) and `clear_user_entries` (`:1614`) unlink without freeing. A recorded lease stays a live table of this hierarchy from record to retire. **No purge path is needed, which is why C16 is structurally vacuous here: there is no key.** The record is a field, moved with the value into `PendingProcessReclaim.page_table` (`process_task.rs:71`) and `pending_old_page_tables` (`process/process.rs:275`).
+
+### 1.4 Layer 3 — dispositions: `retire_bounded` / `abandon` / non-freeing `Drop`
+
+```rust
+enum Disposition {
+    Undecided,
+    Retiring,                       // budget exhausted mid-retirement; requeued
+    Retired,                        // all leases returned or refused; root returned
+    RetiredByExecWalk,              // consumed by the pre-existing cleanup_for_exec walk
+    Abandoned(AbandonReason),
+}
+
+enum AbandonReason {
+    NoProofPipeline,     // aarch64 non-deferred exit — PR-2 target
+    NoArchPipeline,      // x86 — no liveness proof exists yet — PR-3 target
+    AlreadyTerminated,   // terminate() already walked this hierarchy
+}
+
+pub(crate) enum RetireProgress { Complete, Budgeted }
+
+const RETIRE_FRAME_BUDGET: u32 = 64;
+
+impl ProcessPageTable {
+    /// The ONLY function that returns a process table frame.
+    /// Resumable: pops leases until the budget is spent; the root goes LAST.
+    pub(crate) fn retire_bounded(&mut self, pid: u64, budget: &mut u32) -> RetireProgress {
+        self.tables.disposition = Disposition::Retiring;
+        while *budget > 0 {
+            *budget -= 1;
+            match self.tables.leases.pop() {
+                Some(lease) => self.account(pid, return_lease(lease)),
+                None => {
+                    self.account(pid, return_lease(self.root_lease));
+                    self.tables.disposition = Disposition::Retired;
+                    return RetireProgress::Complete;
+                }
+            }
+        }
+        RetireProgress::Budgeted
+    }
+
+    /// Explicit, counted leak. Byte-for-byte main's runtime behaviour plus one counter.
+    pub(crate) fn abandon(mut self, reason: AbandonReason) { /* set disposition + trace_count! */ }
+}
+
+impl Drop for ProcessPageTable {
+    fn drop(&mut self) {
+        match self.tables.disposition {
+            Disposition::Undecided => trace_count!(PT_ROOT_DROPPED_UNDECIDED),   // CI-asserted 0
+            Disposition::Retiring  => trace_count!(PT_ROOT_DROPPED_MID_RETIRE),  // CI-asserted 0
+            _ => {}
+        }
+        // NEVER frees. A drop that reaches here leaks exactly as main does today.
+    }
+}
+```
+
+Four properties, each load-bearing:
+
+1. **One freeing function, resumable, root last.** `pop()` (not `drain`) makes partial progress durable with no iterator state to persist. The root is returned only when the table list is empty, so a requeued receipt still owns a root frame that is still `ST_ALLOCATED` — the liveness question its re-proof asks is unchanged.
+2. **`Drop` refuses to free.** The failure mode of a forgotten disposition is the leak main already has, never a free. Because it cannot free, `Drop` needs no liveness proof, and "the backstop cannot free" is a checkable span assertion (R4).
+3. **`abandon` makes the residual visible in production.** Each reason has its own unconditional counter (§4). The counters are the encoded to-do list for PR-2/PR-3.
+4. **`RetiredByExecWalk` closes the exec false-positive.** Both `cleanup_for_exec` bodies (`process_memory.rs:1689` x86, `:1861` aarch64) consume `self` and free the root by walking; PR-1b sets `self.tables.disposition = Disposition::RetiredByExecWalk` in each body before the implicit drop. **Without this, `PT_ROOT_DROPPED_UNDECIDED == 0` false-fires on every exec-superseded root on any real boot** (`bsh` execs constantly) — Judge 1's A-1 and Judge 2's finding 5, grafted from Design C. Their `owned_tables` leases are dropped unreturned, which is the pre-existing exec leak, now *measured* by `PT_EXEC_WALK_LEASES_UNRETURNED` and closed by PR-2.
+
+### 1.5 Custody transfer, end to end
+
+**Creation** → `new()` leases the root (`:303`/`:380`) and, on x86, the PML4[0] PDPT (`:601-602`); `disposition = Undecided`.
+**Growth** → every `map_page` (`:1189`) / `update_page_flags` (`:1324`) that needs a table node takes it from `TableRecorder`.
+**Handoff** → `Process.page_table: Option<Box<ProcessPageTable>>` (`process/process.rs:224`); the record rides inside the `Box`.
+**Exec supersede** → `manager.rs:2489`, `:2939`, `:3210`, `:3380` `take()` the outgoing root into `pending_old_page_tables` (`process/process.rs:275`); the new root starts an empty record. PR-1 changes nothing here except the disposition set inside `cleanup_for_exec`.
+**Fork** → the child's `ProcessPageTable::new()` is built outside PM (`syscall_entry.rs:936`) and `setup_cow_pages_with_vmas` maps parent frames via `child_page_table.map_page`, increfing each leaf (`fork.rs:213`, `:244`, `:254`). **Table custody is never inherited or shared** — which is why the branch's +68 lines in `fork.rs` are dropped entirely.
+**Exit** — three dispositions on main, and what each becomes:
+
+| Site (verified) | main today | this design | Liveness evidence |
+|---|---|---|---|
+| `process_task.rs:186` — `PendingProcessReclaim::reclaim`, downstream of the full `RootProof` | `drop(self.page_table.take())` → leak | **`retire_bounded()`** | epoch fence + local TTBR0 + every captured CPU's saved/next shadow (`process_task.rs:118-177`) + scheduler cached roots (`:911`) + live/creating rows (`:917`), all discharged at `:905-935` with **no lock held** |
+| `process_task.rs:291` — `release_process_resources` | `drop(process.page_table.take())` → leak | `abandon(NoProofPipeline)` aarch64 / `abandon(NoArchPipeline)` x86 | only the online-shadow mask was consulted (`:297-318`) — **not** a proof. `manager.rs:1152-1156` states the repo's own reason: fault exits always defer because grace covers hardware TTBR0 lag |
+| `process_task.rs:471`, `manager.rs:1150` — `already_terminated` | `drop(process.page_table.take())` → leak | `abandon(AlreadyTerminated)` | **none of any kind** |
+
+**Only the first site frees.** Design C's decision to retire at all four is the leak→use-after-free regression both judges flagged (Judge 1 C-1, Judge 2 §"L2/L3/L4 are memory-unsafe"); it is rejected here, and ratchet R3 pins the single `retire_bounded` call site so it cannot creep.
+
+### 1.6 Leaf custody — specified now, implemented in PR-2
+
+C14 is the finding that forced a design change, and C17 requires the key to distinguish *mappings*, not frames. The specification (Design B's model, motivated by Design A's live-defect finding):
+
+**The defect that proves the model is needed.** `frame_decref`'s untracked arm (`frame_metadata.rs:~100-115`) ends `true` — "not tracked ⇒ private ⇒ safe to free". Two live paths hand it kernel-owned frames: `map_user_stack_to_process` (`process_memory.rs:2152`) maps frames translated out of the kernel table, and `map_user_stack_to_process_with_phys` (`:2318`, called from `manager.rs:516` and `:693`) maps caller-supplied kernel-allocated stack physical addresses `USER_ACCESSIBLE`. `cleanup_cow_frames` walks user pages, finds them untracked, gets `true`, and frees a kernel stack frame. **This is a live over-free on main, not a hypothetical.**
+
+**The model (PR-2):**
+- Ownership is derived from **allocator state**, never from a caller-supplied enum: after `map_to` succeeds, the page-table code classifies the frame from the ledger — `ST_ALLOCATED` + unassigned → this mapping takes the first reference; `ST_ALLOCATED` + already assigned → validated shared/alias reference (fork, CoW, two VAs); registered external span → `External`, never decref'd; free/stale/out-of-region → mapping fails with a precise refusal counter. A caller cannot construct the authority type.
+- Custody is keyed by **virtual page**, in a sorted `Vec<LeafRecord { page: VirtPage, mapping: LeafMapping }>` local to the `ProcessPageTable`. **One frame mapped at two VAs yields two records and two balanced references** — C17, which a frame-refcount-only model cannot express (Judge 2's VIOLATED on Design A). `unmap_page(page)` consumes the exact record; the physical frame returns only at refcount zero.
+- **Ordering is reserve → publish descriptor → commit** (Judge 2's B-1): the record is reserved before the descriptor becomes visible and rolled back on map failure, so preemption can never expose a mapping with no custody.
+- `frame_decref`'s untracked arm flips to **fail-closed** (refuse, count `LEAF_DECREF_UNREGISTERED`, leak) only *after* the introduction sites are converted: `interrupts.rs:801`, `:915`, `:1037`, `exception.rs:2150` (`frame_register`), `fork.rs:213`/`:244`/`:254` (`frame_incref`), `process_memory.rs:2271`, and the two borrowed-stack sites `:2152`/`:2318`.
+
+**PR-1 implements none of this and frees zero leaves**, so no leaf-ownership decision exists in PR-1 to get wrong — a claim made checkable by R1, not asserted.
+
+### 1.7 Invariants
+
+| # | Invariant | Why it holds |
+|---|---|---|
+| I1 | A lease in `tables.leases` was issued by the allocator to *this* value's mapper | `push` occurs only inside `TableRecorder::allocate_frame`; R2 proves `TableRecorder` is the only allocator a process mapper receives |
+| I2 | A frame is leased to at most one owner at a time | ledger CAS `Free|Never → Allocated`; a violation is the duplicate case, refused at allocation (§1.2) |
+| I3 | A recorded table stays a live table of this hierarchy until retirement | no unmap path frees a table (`arch_stub.rs:1210-1261`); nothing else writes `tables` |
+| I4 | Each lease is returned at most once, and the root exactly once and last | `pop()` removes on use; the root is returned only on the empty-list branch; `Disposition::Retired` is terminal |
+| I5 | A stale or duplicate return is refused, not executed | ledger generation + state check in `return_lease` (both arches, all callers) |
+| I6 | A duplicate allocator return never reaches a mapper | detected at allocation; the frame is withheld and `MapError::AllocatorCorrupt` is returned (never OOM) |
+| I7 | A root that is not provably dead is never freed | `retire_bounded` is called from exactly one site downstream of the merged `RootProof`; R3 freezes it |
+| I8 | A root that is never retired leaks and is counted | `Drop` counts `Undecided`/`Retiring`; `abandon` counts by reason; the exec walk counts unreturned leases |
+| I9 | No accounting result can suppress a correct free | refusals are per-lease; there is no gate, no balance precondition, and the root is attempted regardless of a refused table (C2) |
+| I10 | Partial retirement is resumable and re-proved | budget exhaustion requeues the receipt intact; the next pass re-runs the full proof before continuing |
+
+---
+
+## 2. Drain-path cost budget
+
+Drain entry points: `context_switch.rs:4454` (top of `schedule_from_kernel`, before `disable_interrupts()`) and `syscall_entry.rs:932`. Both are normal context, interrupts enabled, no PM/SCHEDULER held.
+
+| Resource | On this path **today** | **Added** by PR-1c | Note |
+|---|---|---|---|
+| Logging / formatting | `log::trace!` (`frame_allocator.rs:339`) and `log::warn!` (`:331`, `:348`) per leaf free, via `cleanup_cow_page_table` (`process/process.rs:698`) and `cleanup_for_exec` (`process_task.rs:184`); `log::info!` in the aarch64 exec walk | **0** | table returns go through `return_lease`, a **log-free** primitive; R7 asserts no `log::`/`format!` in its span or in `retire_bounded`. This is the honest version of Design A's "zero added logging" (Judge 1's C3 PARTIAL) — made literally true rather than argued |
+| Heap allocation | 3 `Vec::new()` per old root in `cleanup_for_exec` (`:1872-1874`) | **0** | `tables.leases` grows at `map_page` time |
+| Heap deallocation | `Box<ProcessPageTable>` + those `Vec`s | **+1** (the leases buffer, freed in the same drop sequence as the `Box` that already frees there) | disclosed, not hidden |
+| Stack | `cleanup_for_exec` locals | **+0 bytes** | no fixed buffer anywhere (C12) |
+| Descriptor reads | up to 512·(1+512+512²) per old root in the exec walk | **0** | there is no walk |
+| Frame returns | leaves only | **≤ 64 per drain selection** (`RETIRE_FRAME_BUDGET`), T+1 total across passes | explicit budget (C11) |
+| Per-frame validation | none | **O(1)** indexed load + compare; ordinal lookup O(regions ≤ 128), typically 1–4 | replaces the branch's O(T²·512) |
+| Locks | `FREE_FRAMES.try_lock` per free | +≤64 `try_lock`s per selection, same primitive | no new lock, no blocking acquire |
+
+**Budget arithmetic.** A typical `bsh` address space allocates 3–9 tables; the budget never engages. A process mapping 1 GiB of 4 KiB pages allocates ~514 tables — that is the case the budget exists for: ≤64 returns per selection at roughly one indexed atomic + one `try_lock` + one push each, then requeue. Requeue reuses the existing refusal arm verbatim (`PENDING_PROCESS_RECLAIMS.lock().push(reclaim)` at `process_task.rs:929-931`) and the existing `last_pass` bounded-pass rule prevents re-selection within the same pass, so no livelock shape is added.
+
+**One accounting correction (Design C's graft, Judge 2's critique of Design A):** `record_table_frames_reclaimed(count + 1)` counted *attempts*. Here `PT_TABLE_FRAMES_RETURNED` increments only on `ReturnOutcome::Returned`; `PT_RETIRE_FRAMES_LOST` increments on `LostContended`; refusals go to their own ledger counters. The per-PID equality (§3.2) is therefore an equality over **committed effects**, and it cannot pass while frames were silently not returned.
+
+**Pre-existing residual, named:** the leaf walk and the exec walk already on this path remain unbounded in PR-1. PR-1 does not worsen them; PR-2 deletes the aarch64 exec walk (removing 3 `Vec`s and a `log::info!` from the drain) and PR-3/PR-4 the x86 one.
+
+### 2.1 #527 non-widening proof
+
+#527 is the latent PM→SCHEDULER inversion (`manager.rs:3281`, `:3573` — `with_thread_mut` under PM; hierarchy at `scheduler.rs:13-14`), latent only because the reverse edge is `try_lock`-only. This design: touches neither exec entry point (`syscall_entry.rs:1179-1197`, `handlers.rs:2377-2385`) nor `manager.rs:3281`/`:3573`; adds no blocking acquire; the only new lock op anywhere is `FREE_FRAMES.try_lock` inside `return_lease`. The two `abandon` calls under PM (`process_task.rs:471`, `manager.rs:1150`) perform an atomic counter increment and nothing else — no allocation, no second lock. Ratchet R8 pins the `with_thread_mut(` site set; the existing `validate_blocking_primitives`/`RAW_SCHEDULER_LOCK_SITES` ratchets (`tests/teardown_structure.rs:308`, `:319`, `:376`) re-check it.
+
+---
+
+## 3. The oracle suite
+
+Design rule (Design B's, adopted verbatim): **a counter lands only in the PR that gives it a live production arm, and every refusal counter has a same-PR injection or a real blocker exercise.** This structurally prevents C18's dead-counter finding.
+
+### 3.1 Counters — unconditional, both architectures
+
+All declared with `counter!` (`teardown.rs:336+`) → `define_trace_counter!`, added to `COUNTERS` (`:449`) with `COUNTER_COUNT` (`:444`) updated in the same commit, exposed via `snapshot()` (`:510`) and `/proc/trace/counters`. **None carries `cfg(target_arch)` or `cfg(feature)`** — C13 and C19 answered structurally.
+
+| PR | Counter | Fires when | Healthy | Live arm in the same PR |
+|---|---|---|---|---|
+| 1a | `FRAME_RETURN_REFUSED_DOUBLE` | return of a frame already `ST_FREE` | 0 | O2/A injection |
+| 1a | `FRAME_RETURN_REFUSED_STALE` | lease generation ≠ ledger generation | 0 | O2/B injection |
+| 1a | `FRAME_RETURN_REFUSED_UNTRACKED` | frame outside every usable region | 0 | O2/C injection |
+| 1a | `FRAME_DUPLICATE_ALLOC_REFUSED` | allocation popped an `ST_ALLOCATED` frame | 0 | O2/D injection |
+| 1a | `FRAME_LOST_CONTENDED` | `FREE_FRAMES.try_lock` failed (`:345-352`) | small | O2/E holds the real lock |
+| 1b | `PT_TABLE_FRAMES_RECORDED` | each `TableRecorder` push | grows | cohort O1 |
+| 1b | `PT_ROOT_ABANDONED_NO_PROOF` | `abandon(NoProofPipeline)` | **>0 until PR-2** | every aarch64 non-deferred exit |
+| 1b | `PT_ROOT_ABANDONED_NO_ARCH` | `abandon(NoArchPipeline)` | **>0 until PR-3** | every x86 exit — C21's detection surface |
+| 1b | `PT_ROOT_ABANDONED_TERMINATED` | `abandon(AlreadyTerminated)` | 0 today (see note) | O2/G direct producer |
+| 1b | `PT_ROOT_DROPPED_UNDECIDED` | `Drop` with `Undecided` | **0**, CI-asserted | O2/H drops an undisposed table |
+| 1b | `PT_EXEC_WALK_LEASES_UNRETURNED` | leases dropped by `cleanup_for_exec` | >0 until PR-2 | every exec |
+| 1c | `PT_ROOTS_RETIRED` | each completed `retire_bounded` | grows | cohort O1 |
+| 1c | `PT_TABLE_FRAMES_RETURNED` | `ReturnOutcome::Returned` inside retirement | grows | cohort O1 |
+| 1c | `PT_RETIRE_FRAMES_LOST` | `LostContended` inside retirement | 0 | O2/E |
+| 1c | `PT_ROOT_DROPPED_MID_RETIRE` | `Drop` with `Retiring` | **0**, CI-asserted | O2/I |
+| 1c | `PT_RETIRE_BUDGET_REQUEUED` | budget exhausted, receipt requeued | 0 typical | O2/F builds >64 tables |
+
+`COUNTER_COUNT`: 47 → 52 (1a) → 58 (1b) → 63 (1c). The identity `PT_ROOTS_RETIRED + Σ abandons + PT_ROOT_DROPPED_UNDECIDED + PT_ROOT_DROPPED_MID_RETIRE == roots destroyed` is production-checkable and is why `abandon` takes a reason.
+
+*Note on `PT_ROOT_ABANDONED_TERMINATED`:* Judge 2 established that in the current cohort a repeat `handle_thread_exit` finds `page_table == None` (`manager.rs:1142-1165`), so the arm may legitimately never fire in production. It is therefore **not presented as proof of anything**: the site is pinned structurally by R5, its healthy value is 0 with the reason stated, and its live producer is a direct call in O2/G. That is the honest reading of C18 — no arm claims evidence it does not have.
+
+### 3.2 O1 — the standing cohort (extends `fork_exit_defer_reclaim_pairing_test`)
+
+Main's harness is already right: `teardown.rs:918`, 64 forked children across 9 adapted-site classes, per-PID slots (`BootTestPidCountSlot`, `:518`), strict per-PID scoring at `:1143-1157`, Acquire fence before scoring. **C4 is already closed on main** — the branch's `BootTestRootCounts` is redundant. Four additions:
+
+1. **Anti-vacuity, computed not hard-coded.** Cohort roots are built by `ProcessPageTable::new()` at `:946`, `:1006`, `:1067` with no mappings, so table counts would be trivially satisfiable. Before each child exits, map three pages in three *distinct* L1 subtrees (`0x0000_0000_0040_0000`, `0x0000_0080_0040_0000`, `0x0000_0100_0040_0000`), forcing 3×(L1+L2+L3)=9 table frames. The expected value is derived by the test from the VAs it chose: `expected_tables = distinct_l1_subtrees * 3`. **No IRQ mask** — #528 is fixed, and masking the corruption class under test is exactly what C10 forbids.
+2. **Four new per-PID fields** on the existing slot (`:518-530`): `table_frames_recorded`, `table_frames_returned`, `table_frames_lost`, `roots_retired`, written through the existing `record_boot_test_pid_count` (`:578`) / read through `boot_test_pid_counts` (`:660`, widened past its current `(defer, reclaim)` tuple).
+3. **Per-PID equalities, never sums** (C4; the fix for Design C's `>= 4` floor, which Judge 2 scored VIOLATED):
+   ```
+   defer_count            == 1                      (existing)
+   reclaim_count          == 1                      (existing)
+   roots_retired          == 1
+   table_frames_recorded  == expected_tables        (anti-vacuity floor, test-derived)
+   table_frames_returned  == table_frames_recorded + 1   (+1 = root; committed effects only)
+   table_frames_lost      == 0
+   ```
+4. **Global floors both directions over the cohort window:** `PT_ROOT_DROPPED_UNDECIDED` delta == 0, `PT_ROOT_DROPPED_MID_RETIRE` delta == 0, `PT_ROOTS_RETIRED` delta == number of deferred children.
+
+Judge 2's finding 6 (the class-1 immediate-release fixture sits outside the tracked PID array, and no tracked root witnesses `abandon`) is resolved two ways: the immediate-release root's PID is registered in the tracked array so `abandon(NoProofPipeline)` has a per-PID witness, and every remaining disposition gets a direct producer in O2 rather than a contorted cohort fixture.
+
+### 3.3 O2 — the standing injection gate (`Arch::Any`, both architectures, nothing masked)
+
+New `frame_custody_refusal_gate_test`, registered beside `deferred_fault_ring_overflow_injection` (`test_framework/registry.rs:5357-5363`), `TestStage::EarlyBoot`. Every sub-case asserts the counter that must fire **and** the counters that must not, then restores a clean state and asserts a healthy operation still succeeds (so no counter latches and no refusal is sticky).
+
+| # | Injection | Must fire | Must NOT fire |
+|---|---|---|---|
+| A | lease a frame, `return_lease` twice | `FRAME_RETURN_REFUSED_DOUBLE` += 1 | first return `Returned`; frame appears exactly once in `FREE_FRAMES` |
+| B | return a lease whose generation was bumped by a re-allocation of the same frame | `FRAME_RETURN_REFUSED_STALE` += 1 | the current owner's frame stays `ST_ALLOCATED` |
+| C | `return_lease` on a synthesized out-of-region frame | `FRAME_RETURN_REFUSED_UNTRACKED` += 1 | nothing enters `FREE_FRAMES` |
+| D | push a still-`ST_ALLOCATED` frame onto `FREE_FRAMES` (test-only hook), then allocate | `FRAME_DUPLICATE_ALLOC_REFUSED` += 1; `map_page` returns `MapError::AllocatorCorrupt` | **no OOM is reported**; the live owner's ledger entry is unchanged (C22 in both directions) |
+| E | hold `FREE_FRAMES` on this CPU across a retirement (real `try_lock` failure, real production path) | `FRAME_LOST_CONTENDED`, `PT_RETIRE_FRAMES_LOST` == tables+1 | `PT_TABLE_FRAMES_RETURNED` += 0 — and this is reported as *loss*, never as corruption (Design B's budget/contention-vs-refusal separation, r2-F13) |
+| F | build a table with >64 recorded leases, retire | `PT_RETIRE_BUDGET_REQUEUED` ≥ 1; completion after N passes with `returned == recorded + 1` | no refusal counter — **an oversized address space is never labelled corrupt** |
+| G | `abandon(AlreadyTerminated)` on a constructed table | `PT_ROOT_ABANDONED_TERMINATED` += 1 | no frame returned |
+| H | drop a constructed table with `Undecided` | `PT_ROOT_DROPPED_UNDECIDED` += 1 | `PT_TABLE_FRAMES_RETURNED` += 0 — the backstop counts, never frees |
+| I | interrupt a retirement at the budget and drop the object | `PT_ROOT_DROPPED_MID_RETIRE` += 1 | no double return of an already-popped lease |
+| J | call `retire_bounded` again after `Complete` | all deltas 0 | idempotence |
+
+Sub-cases A–E drive the **real production primitives** with real state, not a simulated flag; E in particular is the most authentic refusal in any of the three designs (Judge 1's praise for Design C's O2/B) and is preserved here.
+
+### 3.4 O3 — cross-architecture non-vacuity (C19)
+
+The same test, both arches, inverted expectations: after a real process exit, x86 asserts `PT_TABLE_FRAMES_RETURNED` delta == 0 **and** `PT_ROOT_ABANDONED_NO_ARCH` delta == 1 (the residual leak is *measured*); aarch64 asserts `PT_TABLE_FRAMES_RETURNED` delta ≥ 4 **and** `PT_ROOT_ABANDONED_NO_ARCH` == 0. Neither direction is compile-time vacuous; no `cfg(not(aarch64))` assertion exists anywhere in the suite.
+
+### 3.5 Mutation matrix
+
+C7 demanded four designated mutations, two of which the branch never recorded. Six of them become **standing negative ratchets** inside the existing `deliberately_broken_variants_fail_the_ratchet` test (`tests/teardown_structure.rs:1285`) via `with_replaced_source` (`:91`), so they run on every `cargo test --test teardown_structure` and cannot go stale; two require a boot and are recorded as serial excerpts in both directions.
+
+| ID | Mutation | Must fail |
+|---|---|---|
+| M1 (structural) | add a `return_lease`/`deallocate_frame` call outside `retire_bounded` in `process_memory.rs` | R1 (span membership — the count-equality evasion of C6 does not work) |
+| M2 (structural) | restore a bare `drop(process.page_table.take())` at any adapted site, including `drop({ … })` and `core::mem::drop(…)` | R5 (site set + literal reason) |
+| M3 (structural) | pass `&mut GlobalFrameAllocator` to the mapper again | R2 |
+| M4 (structural) | make `Drop` free instead of count | R4 |
+| M5 (structural) | put a `log::info!` in `retire_bounded` or `return_lease` | R7 |
+| M6 (structural) | move the ledger init call after the first process constructor | R9 |
+| M7 (**runtime**) | stub the root return out of `retire_bounded` | O1 per-PID `returned == recorded + 1` fails **for the first affected PID**, not a cohort sum |
+| M8 (**runtime**) | remove the cohort's three sentinel mappings | O1 anti-vacuity floor `recorded == expected_tables` collapses to 0 — **the mutation C7 says proves the floor is not satisfiable by a hollow hierarchy** |
+
+**On the retired mutation.** C7 designated "delete the L1 loop from the aarch64 walk" as the headline anti-vacuity evidence. That mutation has no subject here: the walk is gone. M8 replaces it and is strictly stronger — the floor is computed by the test from the VAs it chose, so a hollow hierarchy cannot satisfy it. This substitution is stated in the PR body rather than silently made (Judge 1 scored Design A's version PARTIAL for exactly the omission of that statement).
+
+---
+
+## 4. Structural ratchets (`tests/teardown_structure.rs`)
+
+Main's harness already provides what C5/C6 asked for and the branch failed to use: `sites_matching` → `BTreeSet<(path,line)>` (`:48`), `assert_exact` (`:70`), `validate_exact` (`:74`), `with_synthetic_source` (`:80`), `with_replaced_source` (`:91`), `function_body` — a lexically scoped byte span with comment/string awareness (`:116`, self-tested at `:237`).
+
+| ID | Property (invariant) | Expression |
+|---|---|---|
+| **R1** | One physical-return choke point (I4, C6) | every `FREE_FRAMES` … `push(` occurrence in `kernel/src/memory/frame_allocator.rs` ⊆ `function_body(src,"return_lease")`; and `sites_matching(deallocate_frame(\|return_lease()` in `process_memory.rs` ⊆ `function_body(src,"retire_bounded")` ∪ the frozen pre-existing exec-walk set `{1744,1783,1820,1832,1836,1840,1845,1906,1934,1961,1973,1977,1981,1986}` via `assert_exact`. **Span membership, never counts.** |
+| **R2** | The recorder cannot be bypassed (I1) | `GlobalFrameAllocator` occurrences in `process_memory.rs` == ∅; `assert_exact` on the two `TableRecorder` construction sites; source contains neither `pub fn mapper(` nor `pub fn allocate_stack(` nor `fn deep_copy_pml4_entry` / `deep_copy_l3_entry` / `deep_copy_l2_entry` |
+| **R3** | Freeing happens only downstream of the merged proof (I7, C23) | `assert_exact(sites_matching(".retire_bounded("), &[("kernel/src/task/process_task.rs", <line in reclaim_bounded>)])` |
+| **R4** | The backstop cannot free (I8) | `function_body` of `impl Drop for ProcessPageTable` contains `trace_count!` and contains none of `deallocate_frame`, `return_lease`, `retire_bounded` |
+| **R5** | Every non-freeing disposition is explicit (C5) | `assert_exact` on the `abandon(` sites `{process_task.rs:291, :471, manager.rs:1150}` each with its literal reason; and each `cleanup_for_exec` body (`process_memory.rs:1689`, `:1861`) contains exactly one `Disposition::RetiredByExecWalk`; and the structural set of `drop(...)` expressions whose argument subtree contains `.page_table.take()` is **empty** outside that pinned set — normalized over blocks, parens and `core::mem::drop` |
+| **R6** | Counter inventory stays complete and readable (C13) | `declarations.len()` equality (`:655`, 47 → 63) and the existing readers==declarations equality (`:651`) |
+| **R7** | The drain stays minimal (C3) | `function_body` of `retire_bounded`, `return_lease`, `reclaim_bounded` contains none of `log::`, `serial_println!`, `format!`, `vec!`, `Vec::new`, `Vec::with_capacity`, `alloc::` |
+| **R8** | #527 not widened | pinned exact `with_thread_mut(` site set, unchanged |
+| **R9** | Ledger exists before the first process root (B's discipline; fixes A's init-order defect) | `assert_exact` on `init_frame_ledger()` call sites `{memory/mod.rs:<post-heap>, main_aarch64.rs:492}`; every `ProcessPageTable::new` body's first `allocate_frame_leased()` is preceded by `ensure_frame_ledger()` in the same span |
+
+Each ratchet ships with a negative variant built by `with_replaced_source` asserting `validate_exact(...).is_err()`, using a *syntactically different* forbidden form (block-wrapped drop, qualified `core::mem::drop`, an outside free swapped for an inside free, a constructor moved to another impl) so the ratchet is proven to recognize spans and semantics rather than today's spelling.
+
+---
+
+## 5. x86 parity — verified, not assumed
+
+**What changes on x86 in PR-1:** the ledger and its guard (shared file, both arches); `ProcessPageTable` gains `root_lease`/`tables`; `new()` leases the PML4 (`:380`) and the PML4[0] PDPT (`:601-602`); `map_page`/`update_page_flags` pass `TableRecorder`; `release_process_resources` calls `abandon(NoArchPipeline)`; both `cleanup_for_exec` bodies set `RetiredByExecWalk`; all counters and O2/O3 compile and run.
+
+**What does not change on x86: not one frame is freed differently.** `cleanup_for_exec`'s x86 walk (`:1689-1855`) is untouched; `cleanup_cow_frames` (`process/process.rs:567`) is untouched; there is no `retire_bounded` call in x86-reachable code (R3 pins the single site inside `#[cfg(target_arch = "aarch64")]` code). x86 keeps leaking roots exactly as main does — now counted by `PT_ROOT_ABANDONED_NO_ARCH`, which is the detection surface C21 demanded.
+
+**Why the kernel-shared upper half is safe under custody:** x86 `new()` installs master PML4[256..512] by `set_addr` without allocating; those frames are never leased, so `retire_bounded` cannot reach them when PR-3 enables it. Custody makes structural what main achieves with a `USER_ACCESSIBLE` filter (`:1718`, `:1755`) — the heuristic C2 showed can desync. If a user mapping ever lands under a kernel-shared L3, the recorder simply does not record that L3 (we did not allocate it) while recording the PD/PT beneath it (we did) — exactly right, and the case that broke the branch's counting model.
+
+**Compile-time consequence to check first (Design C's catch):** adding `Drop` to `ProcessPageTable` forbids partial moves of the value. Both `cleanup_for_exec` bodies take `self` and read the `Copy` field `level_4_frame` (`:1845`, `:1986`); that stays legal, but the x86 build is the proof, and it is the first command in the acceptance record.
+
+**Verification record required in every PR body** (all x86 work runs on beast per CLAUDE.md): `cargo build --release --features testing,external_test_bins --bin qemu-uefi` grepped for `^(warning|error)` → empty; `./docker/qemu/run-boot-parallel.sh 3` green; kthread 3/3 green; O2 and O3's x86 assertions executed in the x86 test build. Same test, same file, both arches — the cheapest possible proof that the one shared mechanism behaves identically.
+
+**PR-3's x86 liveness proof (scope stated now, so parity is not assumed):** x86 is a one-CPU scheduler configuration on main (`scheduler.rs:606-610`), so there is no remote-hardware-root claim; on exit, custody is queued rather than released while CR3 may still name the dying root; a fixed-budget drain runs at the next `check_need_resched_and_switch` entry before any lock, refusing if hardware CR3 has not yet moved; the proof reads actual CR3, both per-CPU shadows (`arch_impl/x86_64/percpu.rs:176-225`), all live process rows, and the selected next root. **`kernel/src/interrupts/context_switch.rs` is a Tier-2 high-scrutiny file: PR-3 requires explicit user approval before that edit** (Design B's gate, adopted — Design A's PR-3 omitted it). PR-3 also records the corrected x86 direct-allocation inventory: the fresh PML4[0] PDPT at `:601-602` only (**not** the commented-out `:801-:924`).
+
+---
+
+## 6. Post-#528 defense decision table
+
+#528 is fixed (general-regs-only kernel via `aarch64-breenix-kernel.json`, unmasked 0/60), so construction-time descriptor corruption is no longer a live producer. Independently, **this design reads no descriptor on any free path**, which retires a second and larger class of defenses. Each prior mechanism is judged on both grounds; "load-bearing" means removing it makes a custody or free proof false.
+
+| # | Prior defense (branch location) | Verdict | One-line justification |
+|---|---|---|---|
+| 1 | `page_table_with_sentinel()` IRQ mask (`teardown.rs:1125`, `:1157`, `:1261`) | **DROP the mask, KEEP the sentinel mapping** | The mask existed only for #528, and C10 forbids masking the corruption class the refusal is scored on; the *mapping* stays as the anti-vacuity witness. |
+| 2 | `structure_balance_proved` / `reclamation_preconditions_proved` gate | **DROP** | It gated freeing on a derived count; there is no derived count, and a gate whose failure mode is "quietly stop fixing the bug" is worse than none (C2). |
+| 3 | `frame_has_allocator_provenance` ("ever allocated, below frontier") | **DROP; replaced, load-bearing** | C9: it proves nothing about *this* address space; the ledger generation + the local record prove exactly that, in O(1). |
+| 4 | `free_list.contains()` membership check | **KEEP the property, REPLACE the implementation; load-bearing** | O(free-list) on the drain is r3-F4's exact objection; the O(1) ledger state+generation catches strictly more (stale authority after reuse). |
+| 5 | `deallocate_frame_proven_owned` two-tier split | **DROP** | The split is what let a caller bypass the guard (C15); one choke point, two thin wrappers, one guard. |
+| 6 | `duplicate_table_frame` re-walk per frame (O(T²·512)) | **DROP** | C11; uniqueness now comes from single-recording plus the ledger, at zero drain cost. |
+| 7 | `RetireTableFrames` 1024-entry / 8 KiB stack array | **DROP** | C12; there is no walk result to buffer and the record already lives in the existing `Box`. |
+| 8 | `LeafPolicy::{DecrefAndFree, StructureOnly}` | **DROP** | C14: caller-declared ownership with no backstop; PR-1 frees no leaf and PR-2 derives ownership from allocator state. |
+| 9 | `LeafCustody { Owned, AlreadyReleased }` threading | **DROP** | Same root cause; the exit-path leaf release is untouched, so there is nothing to parameterise. |
+| 10 | `leaf_mappings: BTreeMap<(root_addr, frame_addr), …>` | **DROP** | C16 (recyclable key, never purged) and C17 (frame-keyed) are properties of *having a side registry*; custody is a field of the owning value. |
+| 11 | `RootRetireProof` token + `superseded_by_exec()` | **DROP the token, KEEP the obligation; load-bearing** | C23: a token minted with no check presents as discharged; the obligation becomes a one-call-site positional invariant frozen by R3. |
+| 12 | `UNPROVED_ROOT_DROP_REFUSED` + non-freeing `Drop` | **KEEP, reshaped; both arches, production** | The one prior defense worth its lines: it is defense-in-depth for correctness but **load-bearing for the oracle**, and it converts the x86 residual into a measured number (C19/C21). |
+| 13 | `ProvenanceRefused` arm + its four handling sites | **DROP as built; the concept survives as the four ledger refusals** | C18: the branch's arm was unreachable; each replacement has a reachable trigger and a standing injection (O2/A–D). |
+| 14 | `ProcessTableFrames::allocate_frame` dedup-with-OOM | **DROP the dedup, KEEP the shim; replaced** | C22: duplicate detection moves *upstream* to allocation, where it can withhold the frame; the recorder has no policy and therefore no failure mode. |
+| 15 | Descriptor provenance/range preflight before descending | **DROP for PR-1; optional audit-only later** | It cannot add to or veto an allocation-derived free set; keeping it as production code (Design B) buys a walk whose only consumer is a test. |
+| 16 | `PT_NONUSER_LEAF_SEEN` as a release input | **DROP as authority; audit only** | User flags express access, not ownership; x86 intentionally shares non-user kernel hierarchy. |
+| 17 | Per-PID boot-test scoring | **KEEP as a second-line oracle** | C13's objection was that it was the *only* loud signal; behind unconditional production counters it is in its correct role. Main's version is already sound — extend, don't rewrite. |
+| 18 | String-blacklist / count-equality ratchets | **DROP** | C5/C6; replaced with exact site sets plus `function_body` span membership, which main's harness already supports. |
+| 19 | `mutation-evidence.txt` artifact | **DROP** | C7: incomplete and unenforced; six mutations become standing negative ratchets, two remain runtime evidence. |
+| 20 | Try-lock-refusal leak on `FREE_FRAMES` contention | **KEEP the behaviour, ADD the meter** | Converting it to a retry would put a spin on the drain (C3/C11); `FRAME_LOST_CONTENDED` + `PT_RETIRE_FRAMES_LOST` make the loss countable and reported as loss, never as corruption. |
+| 21 | Receipt custody, bounded pass, park/unpark | **KEEP unchanged (main's, not the branch's); load-bearing** | They solve custody escape and livelock independently of #528, and the budget requeue reuses them verbatim. |
+| 22 | Fail-loud philosophy generally | **KEEP** | Independent of #528: every refusal here leaks rather than frees, and every leak is counted. |
+
+**Net: 5 of 22 survive** (4, 12, 17, 20, 21) — three of them main's own machinery. Seventeen existed to make walk-derived freeing safe, or to paper over an authority model that did not exist.
+
+---
+
+## 7. PR plan against the size law
+
+Law (`PLAN.md:208-210`): **≤ ~230 changed non-generated lines across ≤ 5 production files**; measure with `git diff --numstat` *before* opening; over the ceiling ⇒ split at the named seam, never waive.
+
+The branch failed at 1718 insertions / 10 files. The honest consequence of adding a real authority layer is that "PR-1" is **three** merges, each independently green, each independently revertable, each closing something. This is not Design B's shape (two foundations before anything ships): **PR-1a ships a live double-free guard for every caller on both arches on day one, and PR-1b ships production visibility of the leak it will close.**
+
+### PR-1a — "frame ledger: O(1) generation-checked frame returns"
+
+| File | Change | Est. |
+|---|---|---|
+| `kernel/src/memory/frame_allocator.rs` | ledger statics, ordinal map, `init_frame_ledger` seeding, `FrameLease`, `allocate_frame_leased`, `return_lease`, duplicate-at-allocation detection, `deallocate_frame` routed through the transition | +85 / −6 |
+| `kernel/src/memory/mod.rs` | one post-heap `init_frame_ledger()` call | +2 |
+| `kernel/src/main_aarch64.rs` | same, at `:492` | +2 |
+| `kernel/src/tracing/providers/teardown.rs` | 5 counters + inventory + `COUNTER_COUNT` 47→52 | +22 |
+| **Total** | **4 production files** | **~117** |
+
+Tests: O2/A–E + R1/R9 + negatives (~90 lines, outside the production count).
+**Live effect:** every allocator caller on both architectures gains a double-release guard and a duplicate-allocation refusal, with five injection-exercised counters. **Revert:** total; restores main's allocator exactly.
+
+### PR-1b — "process page-table custody record (instrumentation only, frees nothing)"
+
+| File | Change | Est. |
+|---|---|---|
+| `kernel/src/memory/process_memory.rs` | `OwnedTableFrames`, `TableRecorder`, `Disposition`/`AbandonReason`, `abandon`, non-freeing `Drop`; lease the root at `:303`/`:380` and the x86 PDPT at `:601-602`; swap the allocator at `:1256`/`:1366`; set `RetiredByExecWalk` in both `cleanup_for_exec` bodies (`:1689`, `:1861`); **delete** `mapper()` (`:1565`), `allocate_stack()` (`:1571`) and the three dead `deep_copy_*` helpers (`:105`, `:170`, `:251`) | +105 / −64 |
+| `kernel/src/task/process_task.rs` | `:291` → `abandon(NoProofPipeline\|NoArchPipeline)`; `:471` → `abandon(AlreadyTerminated)` | +7 / −2 |
+| `kernel/src/process/manager.rs` | `:1150` → `abandon(AlreadyTerminated)` | +3 / −1 |
+| `kernel/src/tracing/providers/teardown.rs` | 6 counters + inventory + `COUNTER_COUNT` 52→58 | +26 |
+| **Total** | **4 production files** | **~208 changed (−67 of it deletions)** |
+
+Tests: O2/G–H, R2/R4/R5/R6/R7 + negatives (~110 lines).
+**Live effect:** every root drop on both arches is now classified and counted — the leak becomes a production number (`PT_ROOT_ABANDONED_*`, `PT_EXEC_WALK_LEASES_UNRETURNED`) before a single line of freeing lands. **Behaviour-preserving by construction:** no `deallocate_frame`/`return_lease` call is added anywhere, which R1 proves. **Revert:** total.
+
+### PR-1c — "aarch64: retire process roots and tables from recorded custody"
+
+| File | Change | Est. |
+|---|---|---|
+| `kernel/src/memory/process_memory.rs` | `retire_bounded` + `RetireProgress` + committed-effect accounting | +40 |
+| `kernel/src/task/process_task.rs` | `reclaim()` → `reclaim_bounded()`; `:186` `drop` → `retire_bounded`; budget/requeue arm at `:925-935`; move `record_reclaim` to the `Complete` branch; `leaves_released` flag on `PendingProcessReclaim` | +35 / −6 |
+| `kernel/src/tracing/providers/teardown.rs` | 5 counters + inventory (58→63) + 4 per-PID slot fields + cohort sentinel mappings + strict per-PID scoring | +105 |
+| **Total** | **3 production files** | **~186** |
+
+Tests: O1 extension, O2/E–F/I–J, O3, R3 + negatives, M7/M8 runtime evidence (~120 lines).
+**Live effect:** #470-F3's aarch64 half is closed. **Revert:** restores the leak, leaves 1a/1b's safe observation layer intact.
+
+**Combining seam:** if 1a and 1b together measure ≤230 changed lines across ≤5 files at `git diff --numstat`, they may merge as one PR. Do not combine 1c with anything — it is the only PR that changes what gets freed, and it must be revertable alone.
+
+**Acceptance record, every PR** (SPEC-470 §12, adapted): both aarch64 builds warning-free and error-free; `cargo test --test teardown_structure` green including all negatives and the updated `declarations.len()`; one `docker/qemu/run-aarch64-full-test.sh --boot-tests-only --rebuild` reaching `[BOOT_TESTS:PASS]`; `clean-gate.sh` 0/100 and `starved-gate.sh` 0/100 under 14 host hogs; **beast x86 build + boot 3/3 + kthread 3/3**; **Parallels 3× consecutive long-window green**, each from a force-stopped VM with a truncated serial log, reaching `bsshd: listening` with no `DATA_ABORT`, soft lockup, panic marker, or nonzero `PT_ROOT_DROPPED_*` (mandatory — #525 established that Parallels gates kernel-path merges and QEMU alone missed a deterministic boot fault); `git diff --numstat` inside the ceiling with the count quoted in the body; revert story verified by a `git revert` dry run; a plain statement of what #470 still owes. All QEMU processes killed and `pgrep` empty before reporting.
+
+### The rest of the campaign
+
+| PR | Scope | Why not earlier |
+|---|---|---|
+| **PR-2** | #470-F4 + leaf custody: virtual-page-keyed leaf records classified from allocator state (§1.6), fork/CoW/external conversion, `frame_decref` untracked arm flipped fail-closed, aarch64 `cleanup_for_exec` (`:1861`) collapsed into `retire_bounded` + a `walk_mapped_pages` decref (deleting 3 `Vec`s and a `log::info!` from the drain), failed-exec release for never-published tables. Named internal seam: (i) leaf ledger + classifier, (ii) fork/external + exec conversion. | Converting the leaf-introduction sites is a ≥5-file change on its own; flipping `frame_decref` before they are converted turns today's over-free into a mass leak. |
+| **PR-3** | x86 liveness proof + `abandon(NoArchPipeline)` → `retire_bounded` (§5). **Requires explicit user approval for the Tier-2 `interrupts/context_switch.rs` edit.** Success is trivially observable: `PT_ROOT_ABANDONED_NO_ARCH` → 0 while `PT_ROOTS_RETIRED` picks up the traffic. | No x86 root-liveness proof exists; freeing an x86 PML4 that CR3 may still name is the inversion the campaign exists to prevent. |
+| **PR-4** | Delete the x86 `cleanup_for_exec` walk (`:1689-1855`) in favour of custody + decref. | It changes x86 exec-path leaf semantics (the walk decrefs non-`USER_ACCESSIBLE` leaves that `cleanup_cow_page_table` skips); a semantic delta needs its own PR and its own evidence — exactly the mistake C21 flagged. |
+
+---
+
+## 8. Salvage from `fix/470-process-root-reclaim`
+
+The branch is based on **pre-#528 main** (merge-base `e73b2205`), before the general-regs-only kernel target. **Nothing cherry-picks cleanly; branch fresh from `363eb912`.**
+
+**Salvage (ideas, re-implemented small):**
+
+| From | What | How it lands here |
+|---|---|---|
+| `8e899680` | `ProcessTableFrames<'a>` — a mapper-local recording allocator. **The one genuinely right idea in 1718 insertions.** | `TableRecorder` (§1.3), stripped of the dedup/OOM logic C22 condemned, recording generation-bearing leases |
+| `af0b2d74` | `retire(self, …)` consuming shape | `retire_bounded(&mut self, pid, budget)` — the same custody signature, made resumable for C11 |
+| `b7bfcdee` | `UNPROVED_ROOT_DROP_REFUSED` + a `Drop` that counts and cannot free | `PT_ROOT_DROPPED_UNDECIDED`/`_MID_RETIRE`, promoted from aarch64+boot-tests-only to production, both arches (C19/C21) |
+| `4f8057ca`, `e15b60a5` | strict per-PID scoring | main has independently landed the equivalent (`teardown.rs:518-530`, `:1143-1157`) — **salvage the idea of adding table fields to the existing slot; do not port `BootTestRootCounts`** |
+| `0a1228ce`, `e8cb2c53` | the R-series ratchet ambition and mutation organisation | re-expressed with main's `sites_matching`/`function_body` span helpers so C5/C6's "counts and string blacklists" objection cannot recur |
+| branch `teardown.rs:426-517` | the `PT_*` counter naming/description convention | kept |
+
+**Discard outright** (and the reason): `8e899680`+`e15b60a5`'s entire `frame_metadata.rs` `FrameRegistry`/`leaf_mappings` rewrite (C15/C16/C17 all attach to that side registry; restores `frame_metadata.rs` to its untouched main state); all of `fork.rs` (+68 — table custody is never inherited); all of `syscall/graphics.rs` (+4 — collateral from the two-tier free split); `RootRetireProof`/`superseded_by_exec` (C23); `LeafPolicy` and `LeafCustody` (C14); `frame_has_allocator_provenance` (C9); `deallocate_frame_proven_owned` (C15); `FrameDeallocationOutcome::ProvenanceRefused` and its four arms (C18); `begin_walk_cross_check`/`record_walk_frame` (C11/C12); `RetireTableFrames` (C12); `structure_balance_proved` (C2); `page_table_with_sentinel`'s IRQ masking (C1/C10 — keep the mapping, drop the mask); the string-blacklist ratchets (C5/C6); `scratchpad/470/mutation-evidence.txt` and the `mutation-r1-*.log` artifacts (C7 — superseded by standing negative ratchets that cannot go stale).
+
+---
+
+## 9. Honest residuals
+
+1. **x86 roots and tables still leak after PR-1** — by design (§5), now *measured* (`PT_ROOT_ABANDONED_NO_ARCH`, 1 per exit). Closed by PR-3.
+2. **aarch64 non-deferred and already-terminated exits still leak** — `abandon(NoProofPipeline)` / `abandon(AlreadyTerminated)`, counted, closed by PR-2. Freeing at those sites without a proof is the regression this design refuses to ship.
+3. **The exec-supersede walks keep their pre-existing defects** — descriptor-derived frees, subtrees unlinked by `clear_user_entries` (`:1614`) invisible to the walk, `USER_ACCESSIBLE` filtering. PR-1 neither fixes nor worsens them; their dropped leases are counted by `PT_EXEC_WALK_LEASES_UNRETURNED`. Closed by PR-2/PR-4.
+4. **`FRAME_LOST_CONTENDED` frames are genuinely lost** — `deallocate_frame`'s contention path (`:345-352`) drops the frame; pre-existing, unchanged, now countable. A retry would put a spin on the drain (C3/C11).
+5. **The pre-existing leaf and exec walks on the drain path remain unbounded.** Only the work PR-1 adds is budgeted. PR-2 removes the aarch64 walk entirely.
+6. **PR-1a may go red on a pre-existing double release.** Main has never had this guard; a nonzero `FRAME_RETURN_REFUSED_DOUBLE` on the first boot is a real defect found by this work (the kernel-stack over-free in §1.6 is the prime candidate) and gets fixed in this work — not disclosed and deferred. Refusal semantics mean the discovery is a counter, not a crash.
+7. **Leaf pages under `clear_user_entries`-unlinked subtrees still leak** — the decref walk cannot reach them; pre-existing, not this leak class.
+
+---
+
+## 10. Ratification crosswalk — every constraint to the element that satisfies it
+
+Judge scores are shown as **J1/J2** against the base design (A) so that every downgrade is visibly resolved. "→" marks what this document changed to close it.
+
+| # | Property demanded | J1 / J2 on base | Satisfied by |
+|---|---|---|---|
+| **C1** | No test-only IRQ mask justifying descriptor-derived frees | SAT / SAT | No descriptor is read on any free path (§1.3); the sentinel *mask* is dropped and the *mapping* kept as the anti-vacuity witness (§6 row 1) |
+| **C2** | A miscount must never silently suppress freeing | SAT / SAT | Nothing is counted-then-gated: `retire_bounded` attempts every recorded lease independently and the root regardless (I9); the record is written at each allocation site, so a conditional allocation yields a conditional record (§1.3) |
+| **C3** | Zero added log/format/heap on context-switch- or syscall-reachable paths | **PARTIAL** / SAT | → `return_lease` is a **log-free** primitive, so the "+1 `log::trace!` per new free" gap J1 found is closed structurally, not argued; R7 asserts it; §2 prices the one added heap *de*allocation honestly |
+| **C4** | Per-object equalities, never cohort sums | SAT / SAT | Per-PID equality `returned == recorded + 1` with a test-derived floor (§3.2); Design C's `>= 4` floor (J2: VIOLATED) is rejected |
+| **C5** | Structural containment ratchets, not string blacklists | SAT / SAT | R1/R4/R5 are byte-span membership via `function_body`; R5 normalizes block-wrapped and qualified `drop` (§4) |
+| **C6** | "One freeing function" by span, not counts | SAT / SAT | R1 is `⊆ span(...)` plus a frozen exact list; no count equality exists anywhere in the suite |
+| **C7** | Every designated mutation recorded, especially anti-vacuity | **PARTIAL / PARTIAL** | → six mutations are standing negative ratchets; M8 (sentinel removal) collapses a **test-derived** floor; the retired "delete the L1 loop" mutation is *stated* as retired-with-its-subject and replaced, rather than silently substituted (§3.5) |
+| **C8** | One preflight covering the whole walk; leaves gated like tables | SAT / SAT | PR-1 has zero walks and frees zero leaves, so no second ungated walk exists (§1.1); PR-2 gives leaves the same discharged-proof + valid-lease condition (§1.6) |
+| **C9** | Provenance tied to the *specific* retiring address space | SAT / SAT | The record is a field of that address space and membership is creatable only by its own mapper's allocator (I1); the ledger adds generation so identity survives frame reuse |
+| **C10** | Refusal exercised by injection, both directions, unmasked | SAT / SAT | O2/A–F: four real refusals, real lock contention, real budget exhaustion, nothing masked, each with a must-not-fire direction and a restore-to-healthy step (§3.3) |
+| **C11** | No unbounded or superlinear hot-path work | SAT / **VIOLATED** | → explicit `RETIRE_FRAME_BUDGET = 64` with requeue through main's existing bounded-pass/park machinery; per-frame validation is O(1) (§2, §1.4). J2's blocking objection is closed by a budget, not by an argument that T is small |
+| **C12** | No large fixed stack buffers on the drain | SAT / SAT | None; the record lives in the already-existing `Box` |
+| **C13** | Loud failure in production, real PIDs, both arches | SAT / SAT | 16 unconditional counters, no `boot_tests`/arch cfg on any; per-PID boot slots demoted to a second-line oracle (§3.1) |
+| **C14** | Leaf ownership allocation-derived, not caller-declared | SAT / **PARTIAL** | → PR-1 frees no leaf, *and* the leaf model is fully specified: allocator-state classifier, private lease type, no caller-selectable policy (§1.6), landing in PR-2 where the frees are |
+| **C15** | Do not remove the double-free guard; the replacement must catch the same scenarios | SAT / **PARTIAL** | → per-frame **generation + state**, not one bit: catches double release *and* stale authority after reuse (J2's exact objection), O(1), single choke point, both arches, injection-tested (§1.2, O2/A–B) |
+| **C16** | Custody key purged on retirement; never a reassignable address | SAT / SAT | No key exists: custody is a field created, moved and destroyed with the owner; ledger indices are ordinals paired with a generation, never an ownership key |
+| **C17** | Custody must distinguish mappings by virtual page, not frame | SAT (vacuous) / **VIOLATED** | → the PR-2 leaf model keys records by **virtual page** in a page-table-local sorted vector, so one frame mapped at two VAs yields two records and two balanced references (§1.6). J2's blocking objection is closed by specification, not by calling it page-independent |
+| **C18** | No unreachable refusal arm presented as live proof | SAT / SAT | Every counter lands with a live arm in the same PR (§3.1); the one arm that may never fire in production (`ALREADY_TERMINATED`) is explicitly not presented as evidence and is pinned structurally instead |
+| **C19** | No compile-time-vacuous assertion on the target arch | SAT / SAT | O3 runs on both arches with inverted live expectations; no counter or ratchet carries an arch cfg (§3.4) |
+| **C20** | The standing cohort exercises every path the design adds | **PARTIAL / PARTIAL** | → the immediate-release fixture's PID is registered in the tracked array so `abandon(NoProofPipeline)` has a per-PID witness, and every other disposition gets a direct producer in O2/G–J (§3.2, §3.3) — J2's finding 6 closed with fixtures, not with claims |
+| **C21** | No x86 semantic change without backstop, detection and verification | SAT / **PARTIAL** | → x86 frees nothing differently (R1/R3-pinned) and gains the ledger guard, six counters, O2+O3, and a named beast record; the exec-`Drop` false alarm J2 found is closed by `RetiredByExecWalk` (§1.4, §5); the corrected x86 allocation inventory is `:601-602` only (§0.1) |
+| **C22** | Duplicate allocator return handled loudly and correctly | SAT / **VIOLATED** | → detected at **allocation**: the frame is withheld, `FRAME_DUPLICATE_ALLOC_REFUSED` fires, `map_page` returns `MapError::AllocatorCorrupt` (never OOM), and the live owner is untouched — so the mapper can no longer zero a frame that is a live table elsewhere (§1.2, O2/D) |
+| **C23** | No unconditionally minted proof token | SAT / SAT | Token deleted; the obligation is a single-call-site positional invariant downstream of the merged five-leg `RootProof`, frozen by R3 — and, unlike Design C, the three unproved sites `abandon` rather than free (§1.5) |
+
+**Also carried, from the judges' non-checklist findings:** A-2 (aarch64 ledger init ordering) → §1.2 post-heap `init_frame_ledger` + exact seeding + R9. A's linear `record` scan → removed entirely (no dedup in the recorder; uniqueness comes from the ledger). A's `record_table_frames_reclaimed(count + 1)` attempt-counting → committed-effect accounting (§2). B-1 (map-then-classify ordering) → reserve → publish → commit in §1.6. B-2 (unpriced side table) → 4 B/frame, priced in §1.2. B-3 (partially retired address space) → re-proof on every requeued pass, no proofed-typestate shortcut (I10). Judge 2's `deep_copy_*` gap → deleted in PR-1b and ratcheted by R2. Judge 2's `BuildingPageTable` `Drop`-partial-move concern → avoided: no typestate in PR-1; the `Drop`-forbids-partial-move consequence is checked by the x86 build as the first acceptance command (§5).
+
+**Nothing in C1–C23 is left unresolved, and no item requires operator input.** The one approval gate in the campaign is procedural and belongs to PR-3: editing the Tier-2 file `kernel/src/interrupts/context_switch.rs` (§5).

--- a/docs/planning/470-custody/PR4-RESCOPE.md
+++ b/docs/planning/470-custody/PR4-RESCOPE.md
@@ -1,0 +1,354 @@
+> Derived 2026-08-15 against main f611edd4; design doc recovered from transcripts.
+
+# PR-4 re-scope on today's main (f611edd4)
+
+**Decision artifact. No code changed. All line references are `main @ f611edd4`.**
+
+## Bottom line
+
+PR-4 is **still real and still worth its own PR**, but it has shrunk to one
+coherent change: *make the x86 superseded-exec root retire through custody the
+way the x86 **exit** root already does*. The Q4 receipt shift absorbed the
+*plumbing* (who holds the old roots, when they are consumed, under what proof)
+but **not the terminal action** — the 174-line descriptor walk is still the
+thing that actually frees, on every x86 exec, at four call sites.
+
+Two of the five originally-deferred items have **changed shape enough that they
+should not ride in PR-4**: the x86 `UnpublishedPageTable`/failed-exec path is a
+different semantic delta with a different oracle, and the `AlreadyTerminated`
+leak turns out to be **arch-neutral, not x86-exec-specific**, and it rests on a
+rationale that is now demonstrably obsolete.
+
+**Recommended split**
+
+| PR | Content | Rough size |
+|----|---------|-----------|
+| **PR-4** (keep) | items 1+2+3: delete the walk, route x86 old roots through `release_mapped_leaves` + `retire_bounded`, delete `RetiredByExecWalk` + `PT_EXEC_WALK_LEASES_UNRETURNED`, re-sync 4 ratchet blocks, add an **exec cohort** oracle | ~450 changed / net **−150** |
+| **PR-4b** (split out) | item 4: x86 `UnpublishedPageTable` for exec + fix the early `page_table.take()` in x86 `exec_process` + x86 F4 failed-exec oracle | ~180 |
+| **new issue** (split out) | item 5: `AlreadyTerminated` abandons recoverable table custody on **both** arches | ~30 prod + ~80 oracle |
+
+---
+
+## Per-item disposition
+
+### Item 1 — "delete the x86 `cleanup_for_exec` descriptor walk" → **STILL LIVE, unchanged, this is PR-4's core**
+
+The walk moved (it was ~1827–2000 in the PR-3-era spec) but is otherwise
+untouched: `kernel/src/memory/process_memory.rs:2021-2194`, **174 lines**.
+
+It is the *only* remaining production consumer of the pre-custody model. What it
+does today:
+
+- `process_memory.rs:2027` — stamps `Disposition::RetiredByExecWalk`
+- `process_memory.rs:2028-2031` — counts every table lease it is about to strand
+- `process_memory.rs:2049-2167` — walks L4 slots `0..256`, `frame_decref` +
+  `deallocate_frame` on every `USER_ACCESSIBLE` leaf
+- `process_memory.rs:2170-2185` — raw `deallocate_frame` on L1/L2/L3/L4 frames
+- `process_memory.rs:2188-2193` — a `log::info!` per exec
+
+The aarch64 sibling that PR-4 makes it match is five lines
+(`process_memory.rs:2199-2203`):
+
+```rust
+pub(crate) fn cleanup_for_exec(&mut self, pid: u64, budget: &mut u32) -> RetireProgress {
+    self.release_mapped_leaves();
+    self.retire_bounded(pid, budget)
+}
+```
+
+**Why the substitution is much less risky than when the design was written.**
+Both primitives are already arch-neutral and already run on x86 in production
+for the *live* root at exit — `kernel/src/task/process_task.rs:255-256`:
+
+```rust
+page_table.release_mapped_leaves();
+let progress = page_table.retire_bounded(self.pid, &mut budget);
+```
+
+PR-3 shipped that with "beast custody balance = 0". Leaf custody is recorded
+arch-neutrally in `map_page` (`process_memory.rs:1399-1418`, `1475-1480`), and
+fork populates the child through `map_page` (`kernel/src/process/fork.rs:206`,
+`:236`), so fork'd x86 children carry `LeafRecord`s too. In other words the
+substitute path is already proven to release a full, fork-derived x86 address
+space; PR-4 points it at a second class of root.
+
+**The honest semantic delta (this is what C21 wants evidenced), in both directions:**
+
+- *Custody frees what the walk leaks*: every table lease the walk strands.
+  `PT_EXEC_WALK_LEASES_UNRETURNED` (`process_memory.rs:2029`) is the live
+  production count of exactly this. Also: frames allocated into a partially
+  built hierarchy that the walk cannot reach.
+- *The walk frees what custody refuses*: any mapped leaf with no `LeafRecord`
+  (custody raises `LEAF_CUSTODY_REFUSED`, `process_memory.rs:1572`) and any
+  table frame not issued by `TableRecorder`. Post-PR-3 both should be
+  structurally zero on x86 — `ProcessPageTable::new()` explicitly refuses to
+  inherit any `USER_ACCESSIBLE` lower-half L4 entry
+  (`process_memory.rs:592-601`) and allocates its own PML4[0] PDPT, claiming it
+  as owned (`:611-630`); `TableRecorder` is the only allocator handed to the
+  mapper (`:1449`). **This is measurable before writing a line of PR-4** — see
+  the evidence plan.
+
+**Correction to the PR-3-era framing:** the walk is *not* a ledger-corrupting
+double-free today. `deallocate_frame` (`kernel/src/memory/frame_allocator.rs:1140`)
+goes through `current_lease_for_frame` → `return_lease`, so it does perform the
+`ST_ALLOCATED`→`ST_FREE` transition. But `current_lease_for_frame`
+(`frame_allocator.rs:1114-1126`) **reads the current generation out of the
+ledger** — i.e. it forges a lease. That is precisely the fail-closed
+double-release/stale guard that PR-1a exists to provide, defeated on this one
+path. The correct claim for the PR body is "the exec walk is generation-blind
+and bypasses the custody refusal discipline", not "the exec walk double-frees".
+
+### Item 2 — "route x86 `pending_old_page_tables` through `retire_bounded`" → **HALF ABSORBED by the Q4 receipt shift; the other half is PR-4**
+
+Absorbed (do not re-do):
+
+- `process_task.rs:481-489` — `defer_process_resources` now takes
+  `pending_old_page_tables` into the `PendingProcessReclaim` receipt alongside
+  the live root ("Carry superseded exec roots into the same proof-gated receipt
+  as the current root", `:473-474`).
+- `process_task.rs:244-247` — the exit-time drain is now **budgeted and
+  proof-gated**, inside `reclaim_bounded`, and correctly refuses to touch the
+  live root until the old ones are done (`:248-250`).
+
+Still live (this is PR-4):
+
+- `process_task.rs:364-385` `drain_old_page_tables_counted` — after all that
+  proof plumbing, line **382** is still `old_page_table.cleanup_for_exec();`,
+  i.e. the walk. It also charges one budget unit per *whole address space*
+  (`:381`), so a large exec'd image is an unbounded unit of work inside a
+  "bounded" drain — the aarch64 loop (`:234-243`) charges per frame. PR-4 fixes
+  the budget granularity for free by adopting the aarch64 shape.
+- `kernel/src/process/process.rs:587-592` — x86 `drain_old_page_tables` is
+  still the **unbounded, non-proof-gated** eager walk, kept alive by four
+  exec-entry callers: `manager.rs:2451`, `:2794` (x86 `exec_process` /
+  `exec_process_with_argv`) and `:3077`, `:3377` (the aarch64 equivalents,
+  which already go through custody via `process.rs:594-614`). All four run
+  **under the PM lock** (they are `ProcessManager` methods) — the same #527
+  class PR-3 flagged. PR-4 makes the x86 pair structurally identical to the
+  aarch64 pair, and the two `#[cfg]` bodies in `process.rs` collapse into one.
+
+### Item 3 — "remove `Disposition::RetiredByExecWalk` + `PT_EXEC_WALK_LEASES_UNRETURNED`" → **STILL LIVE, falls out of item 1, but drags the ratchets**
+
+Deletion sites are small and enumerable:
+
+- `process_memory.rs:214-215` (enum arm), `:1963-1964` (the `retire_bounded`
+  short-circuit that makes the walk and custody mutually exclusive),
+  `:2218-2219` (the `Drop` arm), `:2027` (the stamp)
+- `kernel/src/tracing/providers/teardown.rs:474`, `:584` (counter + registry)
+- `process_memory.rs:2229-2244` — `disposition_gate_counters()` shrinks
+  `[u64; 10]` → `[u64; 9]`; index `5` is consumed positionally at `:2417-2419`
+  and `:2437-2442`, so every index above it shifts.
+
+**The real cost is the structural ratchet in `tests/teardown_structure.rs`**,
+which currently hard-encodes the two-body split as an invariant. Four blocks
+need a deliberate, negative-control-verified re-sync:
+
+- `:1933` `PROCESS_MEMORY_FRAME_RETURNS` — `"…#[cfg(target_arch=x86_64)] fn cleanup_for_exec", 7`
+  (seven `deallocate_frame` sites) → the entry disappears entirely
+- `:1971` `PROCESS_PAGE_TABLE_RETIRE_SITES` — the aarch64-only
+  `cleanup_for_exec` anchor becomes arch-neutral
+- `:3018-3034` — the body validator that asserts `cleanup_bodies.len() == 2`
+  with **exactly one** "legacy" body containing `RetiredByExecWalk` +
+  `PT_EXEC_WALK_LEASES_UNRETURNED` and **exactly one** "custody" body
+- `:3160-3175` — the same `cleanup_bodies.len() == 2` assertion in the negative
+  control
+
+Post-PR-4 the honest replacement is: *one* `cleanup_for_exec` body, custody-shaped,
+with a negative control that FAILs if a raw `deallocate_frame` or a
+`RetiredByExecWalk`-equivalent is reintroduced anywhere in `process_memory.rs`
+outside `release_leaf_record`/`retire_bounded`. That is a *stronger* ratchet than
+today's, and it is the argument for doing this now rather than carrying the
+two-body special case forever.
+
+### Item 4 — "x86 `UnpublishedPageTable` / failed-exec release path" → **STILL LIVE, but a DIFFERENT delta. Split into PR-4b.**
+
+`UnpublishedPageTable` is `#[cfg(target_arch = "aarch64")]` at every one of its
+six impl blocks (`process_memory.rs:230, 236, 254, 263, 270`), used only at
+`manager.rs:3087` and `:3389`. x86 exec builds a raw `Box`:
+`manager.rs:2483` and `:2811`.
+
+Consequence on x86 today: any `?` between construction and publish — e.g.
+`crate::elf::load_elf_into_page_table(...)?` at `manager.rs:2525`, or
+`.ok_or("Failed to allocate frame for exec stack")?` at `:2557` — drops the new
+`Box<ProcessPageTable>` `Undecided`. `Drop` (`process_memory.rs:2209-2211`)
+only counts `PT_ROOT_DROPPED_UNDECIDED`; it cannot free. **Every failed x86 exec
+leaks the entire half-built address space** (root + tables + every leaf the ELF
+loader mapped).
+
+There is a **second, x86-`exec_process`-only defect** stacked on this:
+`manager.rs:2466` takes the old page table *before* the fallible ELF load and
+stack mapping. `exec_process_with_argv` deliberately does not — see the comment
+at `manager.rs:2900-2916` ("All fallible operations have succeeded — now it's
+safe to take the old page table") and the standing warning that early-taking
+"caused a use-after-free on exec failure". PR-1b's non-freeing `Drop` downgraded
+that from UAF to *leak + `process.page_table == None` on a live process*, but the
+asymmetry is still there and should be closed with the same change.
+
+**Why split**: this is failed-exec/never-published release, not
+superseded-exec release. Different trigger, different proof obligation (no
+hardware-liveness proof needed at all — the table was never in CR3, which is
+exactly the rationale in `process_memory.rs:227-229`), and a different oracle.
+The oracle template already exists — the aarch64 F4 block at
+`process_memory.rs:2375-2424` — but porting it needs an x86 corrupt-ELF fixture:
+`corrupt_executable_fixture()` is `#[cfg(target_arch = "aarch64")]`
+(`process_memory.rs:2249-2250`) and builds an `EM_AARCH64` header.
+
+Adjacent, do **not** fold in: `create_process` (`manager.rs:147`, `:389`,
+`:613`) and `fork_process` (`:2217`) also build raw `Box`es on **both** arches.
+That is a genuinely wider hardening item → **#556**.
+
+### Item 5 — "fix `release_mapped_leaves` under `AlreadyTerminated` abandon paths" → **STILL LIVE, but it is ARCH-NEUTRAL and its rationale is obsolete. File separately.**
+
+Two production sites, neither `#[cfg]`-gated:
+
+- `kernel/src/process/manager.rs:1127-1135` (`exit_process_locked`)
+- `kernel/src/task/process_task.rs:651-660` (`handle_thread_exit`)
+
+Both do the same three things when `already_terminated`:
+
+```rust
+if let Some(page_table) = process.page_table.take() {
+    page_table.abandon(AbandonReason::AlreadyTerminated);
+}
+drop(process.stack.take());
+process.pending_old_page_tables.clear();
+```
+
+The stated rationale is identical at both: *"Preserve the single-CoW-decref
+invariant: external `terminate()` already walked these mappings, so raw-drop
+them without another reclaim/decref path."*
+
+**That rationale no longer holds, in two independent ways:**
+
+1. `release_mapped_leaves` is already exactly-once **by construction** — it
+   early-returns on `self.leaves.released` (`process_memory.rs:1559-1561`) and
+   sets the flag at `:1577`. A second call after `terminate()` →
+   `cleanup_cow_frames()` (`process.rs:398`, `:576-580`) is a no-op. The
+   double-decref it is protecting against is structurally impossible.
+2. `retire_bounded` returns **table** leases only, never leaves. `terminate()`
+   never returns table leases. So routing the abandoned root through
+   `retire_bounded` recovers root + intermediate tables with **zero** decref
+   exposure — the two paths do not overlap at all.
+3. `pending_old_page_tables.clear()` is not covered by the rationale in any
+   case: `terminate()` only walks `self.page_table`. Those superseded exec roots
+   are dropped `Undecided` and leak **entirely** — leaves *and* tables.
+
+The fix shape is small: replace `abandon` + `clear()` with
+`defer_process_resources(process)` and return `Some(receipt)` — the proof
+pipeline already exists on this exact code path in the sibling `else` branch
+(`manager.rs:1140-1142`, `process_task.rs:671-675`), and `exit_process_locked`
+already returns `Option<RetirementReceipt>`.
+
+**Why not in PR-4**: it fires on aarch64 too, it changes the abandon *safety
+story* (which two reviewers signed off on in PR-3), and it needs its own
+double-terminate oracle. Burying it in an "x86 exec walk" PR is exactly the kind
+of scope-blend that cost the campaign rounds before.
+
+**Cheap pre-measurement, already shipped**: `PT_ROOT_DROPPED_UNDECIDED` is
+printed on every boot by `emit_root_custody_summary()`
+(`teardown.rs:628-637`, the `[PT_ROOT_CUSTODY:…:undecided=N:…]` line). A nonzero
+`undecided` on an x86 gate run is a live, quantified leak from item 4 and/or
+item 5 combined.
+
+---
+
+## Remaining genuine PR-4 scope
+
+1. Collapse `cleanup_for_exec` to one arch-neutral custody body; delete
+   `process_memory.rs:2021-2194`.
+2. Collapse `process.rs:587-614` to one bounded `drain_old_page_tables` +
+   `drain_old_page_tables_bounded`.
+3. Rewrite `process_task.rs:364-385` to the per-frame budget loop
+   (`process_task.rs:234-243` is the template); keep the
+   `record_masked_frames_walked` producer at `:374-376` — the leaf-timing oracle
+   depends on it.
+4. Delete `Disposition::RetiredByExecWalk` (4 sites) and
+   `PT_EXEC_WALK_LEASES_UNRETURNED` (4 sites); shrink and re-index
+   `disposition_gate_counters()`.
+5. Re-sync the four `tests/teardown_structure.rs` blocks, replacing the
+   two-body special case with a stronger single-body + raw-free negative control.
+6. New **exec cohort** oracle (below).
+
+Explicitly **out**: items 4 and 5 above; `create_process`/`fork` unpublished
+wrapping (#556); the under-PM-lock exec drain (#527) — PR-4 makes x86 match
+aarch64, it does not fix the lock discipline for either.
+
+## Oracle / evidence plan
+
+The retire-cohort oracle already in `teardown.rs` (per-PID exactness at
+`:1544-1600`, global deltas at `:1574-1596`, refusal-counter equality at
+`:1596-1607`) is the right template — but it is a **fork/exit** cohort and never
+execs. PR-4's oracle is the exec variant:
+
+- **Anti-vacuity first.** Before the change, capture on an x86 gate run:
+  `PT_EXEC_WALK_LEASES_UNRETURNED` (must be **> 0**, else the walk isn't
+  actually stranding anything and the PR's premise is wrong) and
+  `LEAF_CUSTODY_REFUSED` / `LEAF_DECREF_UNREGISTERED` (must be **0**, else
+  custody is *not* a superset and the PR would regress into a leak).
+- **Exec cohort test**: N children, each exec'ing once or twice, then exiting.
+  Assert per PID: `table_frames_returned == table_frames_recorded + roots`,
+  `roots_retired == 1 per superseded root + 1 final`, `LEAF_MAPPINGS_RELEASED ==
+  LEAF_MAPPINGS_RECORDED`, `table_frames_lost == 0`, and the full refusal-counter
+  array unchanged. Global: `PT_ROOT_DROPPED_UNDECIDED` delta `== 0`,
+  `PT_ROOT_DROPPED_MID_RETIRE` delta `== 0`, `PT_RETIRE_BUDGET_REQUEUED` behaves.
+- **Designated mutations** (each must turn the oracle red): drop
+  `release_mapped_leaves` from the new body; drop `retire_bounded`; return
+  `Complete` unconditionally; strip the `Vacant`→`Owned` root-slot claim at
+  `process_memory.rs:1456-1458`; strip the `USER_ACCESSIBLE` skip at
+  `process_memory.rs:592-601`.
+- **Ratchet negative controls**: reintroducing a raw `deallocate_frame` in
+  `process_memory.rs` outside `release_leaf_record`/`retire_bounded` must FAIL
+  `teardown_structure`; reintroducing a `RetiredByExecWalk`-shaped disposition
+  must FAIL.
+- **Free-frame accounting**: exec-heavy loop, `memory_stats().allocated_frames −
+  free_list_len_for_gate()` returns to baseline — the same measurement PR-1c and
+  PR-2 used.
+- **Platform**: x86 full gate on beast (this is an x86-only production change);
+  aarch64 clean run to prove the shared-body refactor didn't disturb the arm
+  path; Parallels 3× per campaign standard. Note per MEMORY: grep
+  `serial_user.log` for `FAILED` yourself — though PR #565 landed the exit-tally
+  gate honesty fix, so the x86 "PASS" is now meaningfully truthful.
+
+## Size call
+
+- Core PR-4: **~450 lines touched, net ≈ −150** (−174 walk, −~30 dead
+  disposition/counter, +~10 shared body, +~40 ratchet, +~150 oracle). Files:
+  `process_memory.rs`, `process.rs`, `process_task.rs`, `teardown.rs`,
+  `tests/teardown_structure.rs`. Concentrated, one concept, easy to review.
+- PR-4b (item 4): ~180.
+- Item 5 issue: ~30 production + ~80 oracle.
+
+## Verdict on "own PR vs fold into #556"
+
+**Keep PR-4 as its own PR.** It (a) is the last production path in the kernel
+that frees page-table memory outside custody, (b) deletes 174 lines rather than
+adding a guard, (c) removes a two-body special case that the structural ratchet
+is currently forced to encode, and (d) carries a behaviour change on the exec
+hot path that deserves its own bisect point and its own red/green evidence. It
+is *smaller* than PR-3 by a wide margin and no longer needs to invent
+machinery — it consumes machinery PR-1/2/3 already proved on x86.
+
+**Do not** fold item 4 or item 5 into it, and **do** send the
+`create_process`/`fork` unpublished-wrapping generalisation to #556.
+
+## Open questions
+
+1. **I could not read DESIGN-470-v2 §7 / C21 — the file is gone**
+   (`/private/tmp/.../scratchpad/470design/` no longer exists; it is not in the
+   repo or in git history). Everything above is derived from the code on main
+   plus the PR-3-era item list in the brief. If C21 imposes an acceptance bar I
+   have not reproduced — specifically if it requires a *demonstrated over-free*
+   (a red proof that the walk frees a frame it does not own) rather than the
+   leases-stranded/refusals-zero equality argument I propose — the evidence plan
+   needs a designated fixture I have not scoped. Worth recovering the doc before
+   the PR-4 brief is written.
+2. **Is `PT_EXEC_WALK_LEASES_UNRETURNED` actually nonzero in production?** If it
+   is zero on a real x86 gate run, PR-4 is a pure-cleanup PR with no defect
+   behind it, and the framing (and possibly the priority relative to #545
+   follow-ups) changes. One boot of the existing x86 gate answers this; I did not
+   run it (read-only slot, and a gate run is a dispatched-agent job).
+3. **Item 5's `already_terminated` branch — how often does it fire with a
+   non-empty `pending_old_page_tables`?** The `[PT_ROOT_CUSTODY:…]` line gives
+   the aggregate `undecided` count but does not separate item-4 (failed exec)
+   from item-5 (terminated-path old roots). If the operator wants item 5
+   prioritised, one throwaway counter split settles it.

--- a/docs/planning/470-custody/README.md
+++ b/docs/planning/470-custody/README.md
@@ -1,0 +1,31 @@
+# #470 custody campaign — recovered design artifacts
+
+This directory preserves the documents that gated the #470 process-teardown custody
+campaign (frame ledger + address-space custody record, PR-1a/1b/1c, PR-2, PR-3, and
+the PR-4 re-scope). They previously lived only under `/tmp` scratchpad directories
+and were lost when a reboot cleaned temporary storage.
+
+- **`DESIGN-470-v2.md`** — the ratified custody design (v2): the allocator-generation
+  frame ledger, the address-space custody record, `retire_bounded`/`abandon` dispositions,
+  leaf custody, the oracle suite (O1/O2/O3), the structural ratchets, the PR plan, and the
+  full constraint crosswalk (C1–C23, including C21). This is the design that PR-1a
+  (#534), PR-1b (#539), PR-1c (#542), and PR-2 (#547) were built and reviewed against,
+  and that gates P3 re-ratification and PR-4.
+- **`TRAP-LIST-1a.md`** — the implementer's contract / trap list for PR-1a: mechanism
+  traps found across review rounds r1–r5, the oracle contract (R1/R7/R9, O2/A–E),
+  harness traps, the honesty contract, and the landing checklist.
+- **`PR4-RESCOPE.md`** — the current PR-4 decision artifact, re-derived against today's
+  main, reflecting the Q4→receipt shift that PR-3 already absorbed.
+
+## Recovery provenance
+
+`DESIGN-470-v2.md` and `TRAP-LIST-1a.md` were authored by workflow agents in an
+earlier session and written to `/tmp` scratchpad paths
+(`scratchpad/470design/DESIGN-470-v2.md`, `scratchpad/470pr1a/TRAP-LIST-1a.md`).
+Both files were lost when a reboot cleaned `/tmp`. They were reconstructed byte-for-byte
+from the original `Write` tool-call payloads recorded in this session's agent
+transcript JSONLs (no intervening `Edit` calls were found for either file, so each
+recovered file is the single, complete, as-written version — not a reassembly of
+partial edits). Section headers 1–10 (including §7 the PR plan and §10 the
+constraint crosswalk with C21) are present and intact in `DESIGN-470-v2.md`; both
+files end on complete sentences with no evidence of mid-content truncation.

--- a/docs/planning/470-custody/TRAP-LIST-1a.md
+++ b/docs/planning/470-custody/TRAP-LIST-1a.md
@@ -1,0 +1,884 @@
+# TRAP-LIST-1a — the implementer's contract for #470 PR-1a
+
+**Status:** binding. This document plus `470design/DESIGN-470-v2.md` (§1.2, §3.1 PR-1a rows,
+§3.3 O2/A–E, §4 R1/R7/R9, §7 PR-1a) is the complete brief. Land PR-1a in one pass by satisfying
+both.
+
+**Baseline.** All "current main" anchors are `main` = `363eb912` (`Merge pull request #532`).
+`kernel/src/memory/frame_allocator.rs` is 405 lines; `tests/teardown_structure.rs` is 1480 lines;
+`kernel/src/test_framework/executor.rs` is 447 lines. Verify with
+`git show main:<path> | grep -n …` before anchoring an edit — do not trust a line number that
+does not match the symbol named beside it here.
+
+**Reference-only branch.** `fix/470-pr1a-frame-ledger` (tip `7d9a798a`, 9 commits off `363eb912`)
+is the five-round artifact these traps were extracted from. **Do not cherry-pick it** — §5 below
+says exactly which ideas to re-derive and which commits embody traps. Every "wrong shape" quoted
+below is real code from that branch, cited as `branch@<sha>:<file>:<line>`.
+
+**Provenance of every item.** `r1`–`r5` = `470pr1a/review-1a-r{1..5}.md`; `b1`–`b5` =
+`blocking-1a-r{1..5}.md`; `fk5` = `fix-notes-1a-r5-kernel.md`; `oe` = `oracle-evidence-1a.md`;
+`dev` = `deviation-record-1a.md`.
+
+**Operator rulings that bind this work.**
+- 2026-08-11: diff size, line counts and file counts are **not** review criteria and produce no
+  findings. Do not weaken coverage or a root-cause fix to hit a line budget; do not cite the
+  withdrawn size law as a justification for anything (r4 f7).
+- Standing: harness determinism is fixed **at root** — never with sleeps, retries, floors, or
+  relaxed equalities (`MEMORY.md`, the #513/#518/#521/#524 flake-purge campaign).
+- Standing (#525): Parallels gates kernel-path merges. QEMU-only missed a deterministic boot
+  fault once; PR-1a touches the boot path on both arches.
+
+---
+
+# 1. MECHANISM TRAPS
+
+Each trap: **what it is** → **the exact wrong shape** (real code from the branch) → **the
+required right shape**, anchored on current main.
+
+---
+
+## MT-1 — The x86 host-RAM boot panic (the headline defect; blocking in r3, r4 and only closed in r5)
+
+**Trap.** `init_frame_ledger` sizes its metadata from the *advertised* usable-frame count. On x86
+that count is the bootloader's entire usable map, while the kernel heap is a **fixed 64 MiB**
+(`main:kernel/src/memory/heap.rs:27`). Eager whole-map metadata therefore makes *installed RAM
+itself* a boot-panic trigger: allocation failure inside `memory::init`, into Rust's alloc error
+handler, **before any serial test marker is emitted** — the kernel dies on a machine where `main`
+boots fine.
+
+**The exact wrong shape** (`branch@bd8b13e7`, reviewed at r3 f6 / r4 f5 / b4 §5):
+
+```rust
+// kernel/src/memory/frame_allocator.rs, inside init_frame_ledger
+let ledger: Vec<AtomicU32> = (0..total_frames).map(|index| { … }).collect();  // 4 B/frame, infallible
+FREE_FRAMES.lock().reserve_exact(total_frames);                                // 8 B/frame, infallible
+assert!(u32::try_from(total_frames).is_ok());                                  // boot panic on huge maps
+```
+
+Both live simultaneously, both infallible (no `try_reserve`), no cap, no fallback = **12 B per
+advertised frame**. r4 f5 computed the failure point at ~21 GiB of usable RAM; an 8 GiB machine
+permanently spends ~24 MiB (37% of the whole kernel heap) on a free list whose steady-state length
+is a handful of entries.
+
+**The required right shape** (`branch@9287c09d` is correct in substance here — re-derive it):
+
+1. **Chunked, demand-backed ledger.** A fallibly-allocated *directory* of
+   `spin::Once<&'static [AtomicU32]>`, one entry per 65 536-ordinal chunk (256 MiB of RAM), each
+   realised slot still the ratified 4-byte generation/state `AtomicU32`:
+   `chunks.try_reserve_exact(total_frames.div_ceil(65_536))`. Cost: **24 B per 256 MiB of
+   advertised RAM** — ~2 KB at 21 GiB, ~98 KB at 1 TiB (r5 blocker-5 disposition).
+2. **Boot realises only chunks below the frontier.** `frontier = NEXT_FREE_FRAME.load(Acquire)`,
+   then `ensure_chunk` for each chunk start `< frontier`. On x86 the frontier at ledger-init time
+   is page tables + the 64 MiB heap mapping ≈ 16.4 k frames → exactly **one** 256 KB chunk,
+   independent of installed RAM.
+3. **No whole-RAM free-list reservation.** Reserve `frontier` entries at boot (~130 KB); grow
+   capacity afterwards with **`try_reserve`** on the *allocation* side only (see MT-3 for the
+   correct failure semantics), always **before** the `NEXT_FREE_FRAME` CAS publishes a new frame.
+4. **Cap, don't assert.** `total_frames = advertised.min(u32::MAX as usize)`, and `ensure_chunk`
+   returns `Err` for `index >= total_frames` so an oversized firmware map stops exposing frames
+   instead of aborting boot. `u32::MAX` stays reserved as the untracked sentinel and is therefore
+   never a real ordinal (r4 Part 3, r5 "also checked").
+5. Failure of the *small* directory/frontier allocation stays a **loud explicit panic**, not the
+   allocator error handler.
+
+**Anchors on main.** `frame_allocator.rs:42` (`NEXT_FREE_FRAME`), `:47` (`FREE_FRAMES`), `:98`
+(`get_usable_frame`, the ordinal space to reuse), `:136-160` (the sequential-alloc CAS loop that
+must gain the pre-publication `prepare` call), `:177` / `:256` (`init` / `init_aarch64`, source of
+`MEMORY_INFO` regions). New `init_frame_ledger` goes in this file.
+
+**Do not** "fix" MT-1 by capping RAM, by `cfg`-disabling the guard on x86, or by catching the
+allocation failure and continuing without a ledger. The guard must be live on both arches on day
+one (§7 PR-1a "Live effect").
+
+---
+
+## MT-2 — The init-order constraint behind MT-1 (and behind R9)
+
+**Trap.** The ledger is heap-backed, so it cannot be built in `frame_allocator::init*`. The two
+arches order heap init differently, and getting this wrong either (a) reintroduces MT-1 by sizing
+metadata before the frontier is meaningful, or (b) puts the ledger *after* the first
+`ProcessPageTable` root, which is exactly what R9 exists to forbid.
+
+**The facts on current main:**
+
+| Arch | Frame allocator init | Heap init | Where `init_frame_ledger()` must go |
+|---|---|---|---|
+| aarch64 | `main_aarch64.rs:491` `frame_allocator::init_aarch64(fa_start, fa_end)` | `main_aarch64.rs:492` `memory::init_aarch64_heap()` (which itself does `heap::init` at `memory/mod.rs:52` **and `slab::init()` at `:53`**) | `main_aarch64.rs:493`, i.e. the line immediately after `init_aarch64_heap()` and **before** `kernel_stack::init()` (currently `:493`) |
+| x86_64 | `memory/mod.rs:74` `frame_allocator::init(memory_regions)` | `memory/mod.rs:130` / `:135` (two cfg arms) | `memory/mod.rs:~137`, after **both** heap arms and **before** `slab::init()` at `:139` |
+
+**Consequences you must encode, not assume:**
+
+- The aarch64 ordering clause is *not* "ledger before slab" — on ARM `slab::init()` runs inside
+  `init_aarch64_heap()` and therefore precedes the ledger. Write the per-arch clauses separately
+  (ARM: after `init_aarch64_heap`, before `kernel_stack::init` and `process::init`
+  (`main_aarch64.rs:799`); x86: after `heap::init`, before `slab::init`). r4 blocker 9 was raised
+  because the ARM branch of the validator silently had *no* "no constructor before the ledger"
+  clause at all.
+- Because the ledger is heap-backed it allocates **no frames** and cannot alias its own entries
+  (r1 "Verified correct").
+- `memory::init` is x86-only and is called once, from `main.rs:180`; ARM never calls it. There is
+  no double-init today, but `init_frame_ledger` must be idempotent by an early
+  `if FRAME_LEDGER.get().is_some() { return; }` — **not** by building the whole structure and
+  throwing it away inside `call_once` (r1 f12: that shape rebuilds the entire allocation on every
+  redundant call).
+- **Pre-ledger returns are legal and must stay legal.** Before publication, `return_lease` still
+  pushes to the legacy free list; seeding then fixes up state (MT-5a). This is `dev` deviation 10
+  and is required by the x86 ordering.
+
+---
+
+## MT-3 — The spurious-OOM defect (r5 f5, b5 §5): lock contention manufactured out-of-memory
+
+**Trap.** The r5 fix for MT-1 moved free-list capacity growth onto the allocation path. Written
+naively, a **transient `try_lock` failure** becomes `allocate_frame() → None`, which every caller
+in the tree reads as out-of-memory. Before r5 the sequential allocation path never touched the
+free-list lock at all, so contention *could not* fail an allocation. A CoW fault then becomes a
+SIGSEGV and a mapping fails, on a kernel with plenty of free memory.
+
+**The exact wrong shape** (`branch@9287c09d:kernel/src/memory/frame_allocator.rs:265-302`):
+
+```rust
+fn ensure_free_frame_capacity(required: usize) -> bool {
+    if FREE_FRAME_CAPACITY.load(Ordering::Acquire) >= required { return true; }
+    let Some(mut free_list) = FREE_FRAMES.try_lock() else { return false; };   // ← transient loss
+    …
+}
+fn prepare_frame_for_allocation(index: usize) -> bool {
+    …  ledger.ensure_chunk(index).is_ok() && ensure_free_frame_capacity(index + 1)
+}
+// BootInfoFrameAllocator::allocate_frame:
+if !prepare_frame_for_allocation(current) { return None; }                     // ← reported as OOM
+```
+
+Contending parties are all live: `return_lease`'s push, `allocate_candidate`'s pop,
+`memory_stats()` (`main:frame_allocator.rs:385`), and O2/E, which **deliberately holds
+`FREE_FRAMES.lock()` across a return**.
+
+**The required right shape.** Distinguish "cannot get capacity now" from "no memory":
+
+- On `try_lock` failure, **do not fail the allocation**. Either (a) retry the whole
+  `NEXT_FREE_FRAME` CAS loop iteration (it is already a retry loop —
+  `main:frame_allocator.rs:136-160`), bounded, or (b) publish the frame and accept that a later
+  `return_lease` of it may report `LostContended` (a counted, honest loss) rather than converting a
+  transient lock hold into OOM.
+- Reserve `Err`/`None` from the prepare path for the **genuine** conditions only: `try_reserve`
+  allocation failure, and `index >= total_frames`.
+- Keep the invariant that matters: capacity and chunk are prepared **before** the CAS publishes the
+  frame, so `return_lease` never needs to grow anything (MT-4).
+
+**Verification that this is fixed:** a mutation that makes `FREE_FRAMES.try_lock()` fail
+unconditionally on the prepare path must **not** turn a healthy boot into an allocation failure.
+
+---
+
+## MT-4 — `return_lease` must never allocate, and the ratchet that "proves" it is text-only (r5 f8, b5 §6)
+
+**Trap.** "`return_lease` is allocation-free" is the property that makes the drain-path cost claim
+(§2) *literally* true rather than argued, and it is what R7 is named for. Two ways it is false while
+every ratchet stays green:
+
+1. **The pre-ledger branch pushes into a `Vec` whose capacity was never reserved**
+   (`branch@7d9a798a:frame_allocator.rs:546-548`) — boot-only and single-threaded, but the record
+   stated the property unconditionally.
+2. **Post-ledger the property rests on `len < capacity`, which is exact-boundary.** Capacity is
+   grown to the frontier high-water mark and `len` is bounded by the same frontier, so
+   `len == capacity` is arithmetically reachable (every exposed frame simultaneously free). The
+   gate's own `inject_duplicate_candidates` pushes 3 duplicates, transiently exceeding the
+   distinct-frame bound (`branch:frame_allocator_tests.rs:4-9`).
+
+**The exact wrong ratchet shape** (`branch@7d9a798a:tests/teardown_structure.rs:731-747`): forbid
+the substrings `log::` / `format!` / `vec!` / `Vec::` / `alloc::` inside `function_body("return_lease")`.
+That cannot see an *implicit* `Vec::push` reallocation — the only way the invariant actually
+breaks. The `debug_assert!(free_list.len() < free_list.capacity())` that documents it is compiled
+out of the release boot-test build.
+
+**The required right shape:**
+
+- Reserve capacity for the **pre-ledger** window too (or state the exception precisely, in the
+  deviation record *and* in a comment on that branch — an unconditional claim about a conditional
+  property is the disclosure defect, not the code).
+- Make the boundary unreachable by construction: reserve `frontier + K` where `K` covers the
+  boot-test injection headroom, or have the injector reserve its own headroom before pushing.
+- Keep the substring ban (it is cheap and catches the tempting `log::warn!`), **and** add the
+  structural clause it is missing: `function_body("return_lease")` must contain no
+  `reserve`/`try_reserve`/`resize`/`with_capacity` call, and the *capacity-preparation* call must
+  appear in `prepare_frame_for_allocation` **before** the `NEXT_FREE_FRAME.compare_exchange`
+  (span-ordered, not merely present).
+- R7's span must cover the transitively-called helpers, not just `return_lease`'s own body:
+  `frame_ordinal`, `claim_frame`, `counted` all run on every return/allocation (r1 f5, closed in
+  r2 — do not regress it). `deallocate_frame` keeps its pre-existing logging and stays outside the
+  span (§1.2 says so explicitly).
+
+---
+
+## MT-5 — Seeding and CAS semantic slips
+
+These are the small, individually-plausible edits that each broke a §1.2 guarantee. All were caught
+at least once across the five rounds.
+
+### MT-5a — Seeding order and the pre-ledger window
+
+**Right shape (verified correct in r1, r2 and r3 — do not "improve" it):** at a quiescent
+single-threaded boot point, snapshot `frontier = NEXT_FREE_FRAME`, then
+
+1. ordinals `< frontier` → `ST_ALLOCATED(gen 1)`;
+2. ordinals `≥ frontier` → `ST_NEVER`;
+3. **then** every frame currently in `FREE_FRAMES` → `ST_FREE(gen 1)` — the free-list pass must
+   come **after** the frontier pass, or bootstrap frames that are already free get mislabelled.
+
+Pre-ledger bootstrap frames therefore land `ST_ALLOCATED` and their double release **is** caught,
+which is the whole point.
+
+**Trap (r2 F12 / r3 f10, never closed).** Quiescence is *assumed*, never checked. Any frame handed
+out between the frontier snapshot and publication is seeded `ST_NEVER` while live — and
+`claim_frame` CAS-claims `ST_NEVER`, so that frame is **re-allocatable while live**: exactly the
+double-hand-out C22 exists to prevent. Safe today only because `heap::init` pre-maps the whole
+64 MiB and nothing else allocates frames there — an invariant of a *different* subsystem, held
+implicitly.
+**Right shape:** one line — `assert_eq!(NEXT_FREE_FRAME.load(Acquire), frontier)` immediately
+before publication.
+
+### MT-5b — The low-memory-floor guard must stay unconditional (r1 f1, b1 §1)
+
+**Wrong shape** (`branch@13d3fa29:frame_allocator.rs:502-508`):
+
+```rust
+if frame.start_address().as_u64() < LOW_MEMORY_FLOOR {
+    log::warn!("Refusing to deallocate frame …");
+    if FRAME_LEDGER.get().is_none() { return; }   // ← was an unconditional `return;`
+}
+```
+
+`init_aarch64` (`main:frame_allocator.rs:256`) applies **no** floor clamp (x86's `init` does, at
+`main:frame_allocator.rs:202-208`), so on any aarch64 platform whose `frame_alloc_start()` is below
+1 MiB a below-floor frame acquires a valid ordinal and is pushed straight back into the allocatable
+pool. The `log::warn!("Refusing …")` also becomes a lie.
+**Right shape:** keep `main:frame_allocator.rs:330`'s unconditional `return;`.
+
+### MT-5c — `ST_NEVER` is a distinct refusal class; do not fold it into `RefusedUntracked` (r1 f9)
+
+**Wrong shape:** a `_ =>` arm routing an in-region, never-handed-out frame into `RefusedUntracked`,
+so "this address is not memory we manage" and "this frame was never allocated" share one counter —
+and it is the counter whose healthy value O2 asserts exactly.
+**Right shape:** a sixth outcome `RefusedNeverAllocated` + `FRAME_RETURN_REFUSED_NEVER_ALLOCATED`.
+This is a **ratified-design departure** (§3.1 says 5 counters, `COUNTER_COUNT` 47→52; you will ship
+6 and 53, and downstream 1b/1c targets shift 58/63 → 59/64). It is sound on the merits — the
+`ST_NEVER` case has a real production producer through `deallocate_frame` — but it **must** appear
+in the deviation record as a departure, not as a restatement of §3.1 (r3 f8, r4 blocker 8, `dev` 5).
+
+### MT-5d — Do not delete `FRAME_RETURN_REFUSED_STALE` (r2 F1, b2 §1)
+
+**Wrong shape** (`branch@bd8b13e7`): the counter was removed on the premise "`deallocate_frame`
+loads the slot's generation immediately before calling `return_lease`, so a mismatch is
+impossible." **That premise is false under concurrency** and describes exactly C15's headline
+scenario: CPU-A reads generation `G`; before A's CAS, CPU-B double-releases the same frame and a
+third party re-allocates it, bumping to `G+1`; A's return takes the stale arm — and with the
+counter gone, "a frame was double-released and had already been re-issued to a new owner" leaves
+**zero** evidence in a production kernel.
+**Right shape:** the counter stays, with the honest disclosure that in a non-`boot_tests` PR-1a
+kernel this arm is reachable only through that narrow race (r4 blocker 7, `dev` 6). Do **not**
+present the boot fixture as evidence of a common production stale-lease path.
+
+### MT-5e — `frame_ordinal` and `get_usable_frame` must be provably inverse (r1 f11, r2 F11, r3 f17)
+
+**Trap.** `get_usable_frame` (`main:frame_allocator.rs:98`) sizes each region as `(end-start)/4096`
+(flooring); a `frame_ordinal` that accepts any address in `start..end` maps the trailing partial
+frame to `ordinal_base + region_frames`, which **aliases the next region's ordinal 0**. Two
+physical frames then share one ledger slot → a spurious `FRAME_DUPLICATE_ALLOC_REFUSED` (a healthy
+frame withheld) or a false `RefusedDoubleRelease` (a frame leaked).
+**Right shape:** `debug_assert!(region.start % 4096 == 0 && region.end % 4096 == 0)` in both
+`init` and `init_aarch64`, or a round-trip check in `init_frame_ledger`. Both functions must walk
+`info.regions[..region_count]` identically — verified sound on the branch (r4 Part 3), keep it that
+way.
+
+### MT-5f — `frame_ordinal`'s region-bounds guard is load-bearing (r4 f4, b4 §4)
+
+Dropping `(region.start..region.end).contains(&address)` and returning the running ordinal makes
+`deallocate_frame` of an out-of-region frame resolve to a *real* slot, read that slot's current
+generation (so the generation check trivially matches), CAS a **foreign** frame's slot
+`ST_ALLOCATED → ST_FREE`, and push the foreign frame onto `FREE_FRAMES`. See §2 O2/C for the oracle
+that must catch this.
+
+### MT-5g — The bootstrap seeding `expect` is a new boot-panic path (r5 f7)
+
+**Wrong shape** (`branch@7d9a798a:frame_allocator.rs:254-261`):
+`ledger.get(index).expect("bootstrap free frame missing ledger chunk")` — `get` returns `None` for
+any in-range ordinal whose chunk has not been realised, and boot realises only chunks below the
+frontier. Any frame sitting in the free list at ledger-init time with ordinal `≥ frontier` panics
+the kernel during `memory::init`. Unreachable today (no `deallocate_frame` call site runs before
+`init_frame_ledger` on either arch — verified in r5), but the pre-ledger branch of `return_lease`
+pushes **unconditionally with no ordinal check**, so a future pre-ledger free of a reclaimed
+loader/firmware page arms it.
+**Right shape:** call `ensure_chunk(index)` in the seeding loop and mark; on `Err`, skip the frame
+(and count it) rather than panicking.
+
+### MT-5h — Lazy chunk realisation must not spin inside `spin::Once` on the allocation path (r5 f6, PLAUSIBLE)
+
+**Wrong shape:** performing a heap allocation and a 256 KB `resize_with` **inside**
+`spin::Once::try_call_once` (`branch@7d9a798a:frame_allocator.rs:65-89`). `try_call_once` spins
+while another party runs the initialiser; if that party is preempted or faults and a nested
+allocation lands in the **same** chunk (very likely — both are at the frontier), the nested
+allocation spins on a `Once` whose initialiser cannot resume. In thread context with interrupts
+enabled this resolves; from an interrupt handler with interrupts disabled it is a hard hang.
+**Right shape:** build the chunk **outside** the `Once` (allocate + initialise into a local, then
+publish with a single `call_once`/CAS, freeing the loser's allocation), so no allocation happens
+under the initialiser lock. No current ratchet can see this hazard — it is your job to not
+introduce it.
+
+### MT-5i — Every discarded allocation candidate must be countable (r3 f3, r4 f8)
+
+**Trap.** `claim_frame` returns `Err(())` from three places: the counted duplicate arm, and the
+**uncounted** ordinal/bounds failure and impossible-state arms. `allocate_claimed` loops on every
+`Err(())`, so an untracked candidate is dropped with **no counter and no log** — steady, invisible
+frame loss in the one function whose §1.2/residual-4 contract is that every loss is countable.
+**Right shape:** either a distinct `Err` variant carrying the reason, or reuse
+`FRAME_RETURN_REFUSED_UNTRACKED`/`_NEVER_ALLOCATED` on the allocation side. Do not leave a silent
+drain.
+
+### MT-5j — Semantics that are correct on the branch: keep them
+
+Verified sound across r1–r5; re-derive without "improving":
+
+- **`allocate_frame()` itself routes through `claim_frame`**, not only `allocate_frame_leased`
+  (`dev` 7). §1.2 only routes the leased API; applying the guard to *every* consumer is stricter
+  and is the live safety effect PR-1a ships. It is a **stated** deviation.
+- **Duplicate-at-allocation withholds the frame**: `claim_frame` returns `Err` *before* the frame
+  escapes, `allocate_claimed` retries with another candidate, the true owner's slot is untouched
+  (I6/C22's safety half, live on both arches day one).
+- **CAS ordering**: state is committed to `ST_FREE` **before** the free-list push, so a frame is
+  `ST_FREE` whenever it is reachable from the list, never the reverse; a lost `try_lock` leaks
+  rather than double-publishing.
+- **30-bit generation** (`+1` at claim, `& 0x3fff_ffff`), symmetric with the `observed >> 2`
+  comparison; `ST_NEVER` (state 0, gen 0) stays distinguishable from a wrapped gen-0 allocation
+  because the state bits differ.
+- **`return_lease` cross-checks `frame_ordinal(frame) == lease.index`** — stronger than §1.2 asked
+  for; keep it.
+- **`u32::MAX` untracked sentinel is unaliasable** because `total_frames` is capped at `u32::MAX`,
+  so the maximum valid ordinal is `u32::MAX - 1`.
+- **`deallocate_frame` is intentionally fail-closed** (`dev` 9): refused returns leak rather than
+  entering the reuse pool. This is a **semantic delta on all 32 existing callers on both arches**
+  and must be named as such — §1.2's "keeps its behaviour" is accurate only for frames the ledger
+  issued (r2 F15, b2 §11).
+
+---
+
+# 2. ORACLE CONTRACT
+
+For every oracle in PR-1a scope: the property it guards, the **mutation command that must make it
+FAIL**, and the **MUST-NOT shapes** — evasions discovered across the five rounds. An oracle that
+does not fail on its mutation is not an oracle; shipping one is the "non-mutation-sensitive oracle
+surviving" blocking category.
+
+**Global rule for every mutation below:** apply it to the **real tree**, compile, run the command,
+record the verbatim failure excerpt, then `git checkout --` and re-run to record the green. Line-
+count-preserving mutations only, so no line-anchored inventory drifts and gives you an incidental
+red (r5 f1 caught its own first attempt failing that way).
+
+---
+
+## R1 — one physical-return choke point (§4/R1, I4, C6)
+
+**Property.** *Every* insertion of a frame into the reuse pool in the tree lies inside
+`function_body("return_lease")` — plus, in `process_memory.rs`, the frozen pre-existing exec-walk
+`deallocate_frame(` site set pinned by `assert_exact` (the 14 lines named in §4/R1). **Span
+membership, never counts.**
+
+**Mutations that must FAIL (`cargo test --test teardown_structure`):**
+
+| # | Mutation, applied inside `allocate_candidate` (which already holds a `free_list` binding) | Source |
+|---|---|---|
+| M-R1.1 | `free_list.push(frame);` | design M1 / r4 blocker 5 |
+| M-R1.2 | `free_list.insert(0, frame);` | r4 f2 → recorded FAIL in `oe` §R1 |
+| M-R1.3 | `free_list /* trivia */ .insert(…);` | r5 blocker-2 disposition |
+| M-R1.4 | `let list = &mut *free_list; list.insert(0, frame);` | `oe` "reborrowed_free_list" |
+| M-R1.5 | **`if let Some(mut aliased) = FREE_FRAMES.try_lock() { aliased.insert(0, PhysFrame::containing_address(PhysAddr::new(0x100000))); }`** | **r5 f1, b5 §1 — CONFIRMED still green on the branch** |
+| M-R1.6 | in `frame_allocator_tests.rs`, outside every allowed span: `FREE_FRAMES.lock().append(&mut alloc::vec![frame]); FREE_FRAMES.lock().extend_from_slice(&[frame]);` | r2 F4 — CONFIRMED green at r2 |
+| M-R1.7 | add a `return_lease(`/`deallocate_frame(` call in `process_memory.rs` outside the pinned span | design M1 / r1 f7 |
+
+**MUST-NOT shapes (each one shipped at least once and was evaded):**
+
+- **MUST NOT** enumerate method names. `[".push(", ".append(", ".extend(", ".extend_from_slice("]`
+  is one method away from evasion (`insert`, `resize`, `push_within_capacity`, `splice`,
+  `swap_remove`+re-add) — r4 f2, b4 §2.
+- **MUST NOT** root the receiver-chain walk at a fixed identifier set (`FREE_FRAMES`,
+  `free_list`). Binding the guard to *any other name* defeats it: the chain from `FREE_FRAMES`
+  terminates at the allowed `.try_lock(`, and the insertion is spelled on an untracked name —
+  r5 f1, **the single confirmed still-open evasion at branch tip**.
+- **MUST NOT** scope the scan to `frame_allocator.rs` only. `frame_allocator_tests.rs` is
+  `#[path]`-included as `mod boot_tests` with `use super::*` and has full access to the private
+  `FREE_FRAMES` (r1 f6, b1 §4).
+- **MUST NOT** use count equality ("there are still N pushes") in place of span membership — the
+  C6 evasion the design names explicitly.
+- **MUST NOT** run `match_indices` over raw file text. Use the comment/string-aware mask, or a
+  `.push(` in a comment or string false-fires (r2 F4 tail).
+
+**Required right shape (spelling-independent, alias-closed):**
+
+1. Compute the code mask (comment/string-aware, byte-level) for each scanned file — re-derive
+   `code_mask` + `code_offsets` + `code_sites` from `branch@4d759a62`, and keep its self-test
+   (`code_mask_reports_only_real_code_occurrences`).
+2. Build the alias set by **transitive closure**, not a fixed identifier list: seed
+   `{FREE_FRAMES}`; for every `let`/`if let`/`let … else`/`match` binding whose initializer span
+   contains any member of the set (including through `.lock()`, `.try_lock()`, `&mut *x`,
+   `Some(mut x)` patterns), add the bound name.
+3. Require every **mutating** use of any alias — i.e. every method call whose name is **not** in a
+   short read-only allow-list (`len`, `capacity`, `iter`, `is_empty`, `pop`, `lock`, `try_lock`,
+   plus the separately-allowlisted boot-test helpers) — and every bare occurrence of the
+   `FREE_FRAMES` identifier, to lie inside an allowlisted function span. Allowlist by **span**, not
+   by method: `init_frame_ledger`, `allocate_candidate` (pop only), `return_lease`, `memory_stats`,
+   and the explicitly capability-allowlisted boot-only fixture helpers (`dev` 15).
+4. Ship a standing negative (`with_replaced_source` inside
+   `deliberately_broken_variants_fail_the_ratchet`, `main:tests/teardown_structure.rs:1285`) for
+   **each** of M-R1.1 … M-R1.7, each using a *syntactically different* forbidden form (§4's own
+   requirement; r1 f7 caught a negative that was byte-identical to the production spelling).
+5. If the closure is still not total, **say so precisely** in the deviation record — the r5 residual
+   note disclosed helper-function and `DerefMut` paths but **not** that renaming the binding
+   suffices, which is the disclosure defect (r5 f1 final paragraph).
+
+---
+
+## R7 — the drain stays minimal (§4/R7, C3)
+
+**Property.** `function_body` of `return_lease` — **and of every helper it transitively calls on
+every return**: `frame_ordinal`, `claim_frame`, `counted` — contains none of `log::`,
+`serial_println!`, `format!`, `vec!`, `Vec::new`, `Vec::with_capacity`, `alloc::`; and no capacity
+growth (MT-4).
+
+**Mutations that must FAIL:**
+- M-R7.1: `log::warn!("refused")` inside `counted`'s refusal arm (this is the *single most tempting*
+  place, and the r1 f5 shape that R7 originally missed).
+- M-R7.2: `log::info!` inside `return_lease`.
+- M-R7.3: a `reserve`/`try_reserve` call inside `return_lease`.
+
+**MUST-NOT:** check only `return_lease`'s own body (r1 f5); treat the `debug_assert!` as the proof
+(compiled out of release — r5 f8). `deallocate_frame` keeps its pre-existing logging and stays
+**outside** the span, deliberately (§1.2).
+
+---
+
+## R9 — the ledger exists before the first process root (§4/R9)
+
+**Property (three clauses, all required):**
+1. `init_frame_ledger()` call sites are **exactly** `{memory/mod.rs:<post-heap, pre-slab>,
+   main_aarch64.rs:<after init_aarch64_heap>}` via `assert_exact`.
+2. **Per-arch ordering**: on x86, the ledger call precedes `slab::init()`; on aarch64 it follows
+   `init_aarch64_heap()` and precedes `kernel_stack::init()` and `process::init()`; and on **both**
+   arches no `ProcessPageTable::new(` occurrence precedes the ledger call in the boot function.
+3. A **whole-tree inventory** of `ProcessPageTable::new(` construction sites, pinned by
+   `assert_exact`, so a new constructor anywhere is a red.
+
+**Mutations that must FAIL:**
+- M-R9.1: move `init_frame_ledger()` below `slab::init()` (x86) / below `kernel_stack::init()` (ARM).
+- M-R9.2: insert `let _p = ProcessPageTable::new();` **before** the ledger call in
+  `main_aarch64.rs`. This must fail via the **ordering** validator, called **directly** by the
+  negative.
+- M-R9.3 (recorded FAIL in `oe` §R9): inside `manager.rs::fork_process_with_context`, before the
+  existing child page-table constructor, add
+  `let _shadow_page_table = crate::memory::process_memory::ProcessPageTable::new().expect("root alloc");`
+  → must produce `R9 frame-ledger initialization moved`.
+
+**MUST-NOT shapes:**
+- **MUST NOT** use the whole-line predicate
+  `line.contains("ProcessPageTable::new(") && !line.contains('"')`. It exists to skip five log
+  strings and silently drops any **real** call site whose line carries an inline `.expect("…")` or
+  `map_err(|e| …"…")` — r4 f3, b4 §3, demonstrated in `oe`. Use the code mask instead, so a
+  constructor on a quoted line is counted and the log strings are excluded lexically.
+- **MUST NOT** let the negative pass through a *different* validator. r3 f9 / r4 blocker 9: the ARM
+  negative "passed" only because `PROCESS_PAGE_TABLE_CONSTRUCTORS`'s `assert_exact` caught the new
+  call site, while the ordering clause it was named for did not exist. **Every negative must invoke
+  the validator it is named for, directly.**
+- **MUST NOT** inflate the pinned constructor constant to absorb string text — the inventory must
+  stay at its true count (13 constructors / 2 ledger-init calls on the branch) when the mask is
+  introduced. A constant that moves when you change the *lexer* means the lexer is wrong.
+- **Known residual to disclose, not hide:** the ordering clause is a textual scan of the boot
+  function's own body, so a constructor reached **indirectly** (from something
+  `init_aarch64_heap()` calls) is invisible to it (r2 F9).
+
+---
+
+## O2 — the standing injection gate (§3.3 A–E)
+
+**Global properties.** Every sub-case asserts the counter that must fire **and** the counters that
+must not, then **restores clean state and asserts a healthy operation still succeeds** (so no
+counter latches and no refusal is sticky). A and C originally omitted the restore (r1 f16, b1 §10)
+— `healthy_round_trip()` after every arm. Sub-cases drive the **real production primitives**; a
+simulated flag is not an oracle.
+
+The end-of-gate aggregate delta must be exact for the five refusal counters and a **floor** for
+contention: `double +1, stale +1, never +1, untracked +1, duplicate +3, contended ≥ +1`. Including
+`FRAME_LOST_CONTENDED` in a per-operation equality is a flake and was one (r3 f12, b3 §12) —
+`healthy_round_trip` compares `counters()[..5]` only.
+
+### O2/A — double release
+
+**Property:** first `return_lease` → `Returned`; second → `RefusedDoubleRelease`; the frame appears
+**exactly once** in `FREE_FRAMES`; a healthy round trip still succeeds.
+**Mutation that must FAIL:** make the `ST_FREE` arm of `return_lease` push anyway (drop the
+`RefusedDoubleRelease` return).
+**MUST-NOT:** assert only `FREE_FRAMES.lock().len() == free_before + 1`. §3.3-A's stated property is
+*appears exactly once*; use `free_frame_count(frame) == 1` (r3 f18). Keep **both** — length catches
+a second insertion of a different frame.
+
+### O2/B — stale authority
+
+**Property:** a lease copied before the frame was returned **and re-claimed** is refused
+`RefusedStale`, and the current owner's slot is untouched (state `ST_ALLOCATED`, generation ==
+current).
+**Mutation that must FAIL:** `if observed >> 2 != lease.generation && false {` in `return_lease`
+(the r5 f9 comparison confirmed to turn the suite red — this is the *correct* behaviour for a
+generation pin, and it is the sibling that proves the serial-join pin is broken).
+**MUST-NOT (the r4 f9 evasion):** pin the fixture with substring presence
+(`stale.contains("return_lease(stale)")`, `stale.contains("take_free_frame(stale.frame)")`).
+Editing `take_free_frame` to return the frame *without* re-claiming it leaves the substrings intact
+and B degenerates into testing nothing.
+**Required right shape (the strongest fix of round 5 — re-derive it):** the fixture builds stale
+authority through **real transitions** (`allocate_frame_leased` → `return_lease` → `take_free_frame`
+→ `claim_frame`) **and proves it at runtime**:
+
+```rust
+if current.index != stale.index || current.generation == stale.generation { return None; }
+```
+
+with a `None` fixture failing the gate. Then a structural pin on top:
+`function_body("take_free_frame")` must contain `claim_frame(candidate)` and must **not** contain a
+`FrameLease {` literal. Four standing negatives (synthesised lease, removed self-check,
+`if false` generation test, mis-mapped counter).
+**Known wart to fix, not copy:** the fixture's `LostContended` recovery branch calls
+`claim_frame(stale.frame)` on a still-`ST_ALLOCATED` frame, which takes the duplicate branch,
+pollutes `FRAME_DUPLICATE_ALLOC_REFUSED`, and produces a misleading `B: exact frame reuse failed`
+plus a broken `duplicate +3` aggregate (r5 f12). Handle contention by retrying the fixture, not by
+a fallback that corrupts counters.
+
+### O2/C — untracked vs never-allocated
+
+**Property:** an out-of-region frame and an in-region-never-handed-out frame are **distinct**
+refusals (`RefusedUntracked` vs `RefusedNeverAllocated`); nothing enters `FREE_FRAMES` in either
+case; and the untracked arm exercises **`frame_ordinal`'s region-bounds logic** in the failing
+direction.
+**Mutation that must FAIL (recorded in `oe`, ARM boot):** replace the trailing `None` in
+`frame_ordinal` with `Some(0)` → the boot suite must go red with
+`C: untracked frame return was not isolated` (and the late healthy-counter guard red too).
+**MUST-NOT (r4 f4, b4 §4):** hand-forge the lease —
+`FrameLease { frame: …PhysAddr::new(0), index: u32::MAX, generation: 0 }` + `return_lease(untracked)`
+proves only that `ledger.get(out_of_range)` returns `None`, leaving the production producer
+(`deallocate_frame`'s `frame_ordinal(frame)` lookup) completely unoracled.
+**Required right shape:** derive the fixture frame from the **live memory map** —
+`MEMORY_INFO.get()` → max `region.end` → round up to a 4 KiB boundary — and drive **production
+`deallocate_frame(untracked)`**, then assert `untracked +1` and an unchanged free-list length after
+unconditionally scrubbing the frame. Structural pins: the gate must contain
+`above_top_of_ram_frame()` and `deallocate_frame(untracked)`, must contain **no `FrameLease {`
+literal**, and the helper must contain `MEMORY_INFO.get()` / `region.end` / `.max()`; plus a
+`hand_forged_untracked` standing negative that restores the pre-r5 shape and requires `Err`.
+
+### O2/D — duplicate at allocation
+
+**Property:** three injected duplicates of a **live** frame are each withheld and counted
+(`FRAME_DUPLICATE_ALLOC_REFUSED += 3`); the live owner's ledger entry is unchanged **read
+directly**, not inferred; no OOM is reported to the caller.
+**Mutation that must FAIL:** make `claim_frame`'s `ST_ALLOCATED` arm return `Ok(None)` instead of
+`Err(())` — the duplicate escapes to a second owner.
+**MUST-NOT:**
+- **MUST NOT** infer "the live owner's slot survived" from a later successful `return_lease(live)`;
+  read the slot the way B does (r2 F18, r1 f16).
+- **MUST NOT** leave injected corruption behind on any exit path. `remove_duplicate_candidates(live.frame)`
+  must run **unconditionally, immediately after the single allocation attempt and before any failure
+  is evaluated**; owner restoration must cover all result shapes; `restore_lease` must republish an
+  already-committed `ST_FREE` frame if the `try_lock` races (r3 f11, b3 §11). A failing boot test
+  that leaves real duplicates in the production free list produces a later memory-corruption crash
+  that masks the original failure.
+- **MUST NOT** keep the dead defensive arm
+  `Some(replacement) if replacement.frame == live.frame => restore_lease(replacement)`; it is
+  unreachable, and if it *ever* fired it would return only `replacement` and leak `live` — the frame
+  it was written to protect (r4 f10). Delete it or restore both.
+- C22's "never as OOM" half is **not** delivered in PR-1a (no `MapError::AllocatorCorrupt`); that is
+  a stated deviation (`dev` 4), not something to paper over. Do **not** reintroduce a dormant
+  `ALLOCATOR_CORRUPT` static with no production reader — that is PLAN.md law 2 and it was correctly
+  removed (r2 F6, b2 §6).
+
+### O2/E — contention is loss, never corruption
+
+**Property:** holding the **real** `FREE_FRAMES` lock on this CPU across a **real** `return_lease`
+produces `FRAME_LOST_CONTENDED` (floor, `≥ +1`), the ledger is left `ST_FREE` with the frame off the
+list, and the test repairs it rather than leaving the pool corrupted.
+**MUST-NOT:** assert an equality on the contention counter anywhere (r3 f12); leave the frame
+unrepaired. Note the interaction with MT-3: E deliberately holds the lock, so a capacity-growth path
+that fails on `try_lock` will manufacture OOM **inside your own gate**.
+
+### O2 registration — one execution path per architecture
+
+**Property:** the gate function has **exactly one** dispatch path per arch: the aarch64 `TestDef`
+(`arch: Arch::Aarch64`, `stage: TestStage::SerialBoot`) and the x86 direct hook from `memory::init`.
+They are architecture-**exclusive**, so fixing x86 staged dispatch (#533) cannot double-run it.
+**Why it matters:** a second execution sees `start[..5] = [1,1,1,1,3]` and fails
+`A-E: unexpected refusal preceded injection gate`, and the late healthy-counters check sees
+`[2,2,2,2,6]` — a deterministic self-inflicted failure armed for whoever lands #533 (r3 f1, b3 §1).
+**Mutations that must FAIL:**
+- M-REG.1: rewrite the `TestDef`'s `arch: Arch::Aarch64` to `Arch::Any`.
+- M-REG.2 (**r5 f2, b5 §2 — CONFIRMED still green at branch tip**): add
+  `use crate::memory::frame_allocator::frame_custody_refusal_gate_test as aliased_frame_custody_gate;`
+  before `PROCESS_TESTS`, plus a second `TestDef { name: "frame_custody_refusal_gate_x86",
+  func: aliased_frame_custody_gate, arch: Arch::Any, stage: TestStage::EarlyBoot }`.
+- M-REG.3: a second `TestDef` with a **different name** but the same fully-qualified `func:` path
+  (r4 f11, b4 §8).
+
+**MUST-NOT shapes:**
+- **MUST NOT** key the pin on the display **name** (`registry.split("name: \"frame_custody_refusal_gate\"").nth(1)`),
+  which matches only the *first* `TestDef` with that literal name — r4 f11.
+- **MUST NOT** key the pin on one literal spelling of the `func:` path. Counting
+  `code_offsets(registry, mask, "func: crate::memory::frame_allocator::frame_custody_refusal_gate_test") == 1`
+  counts a spelling, not a resolved function — r5 f2.
+**Required right shape:** count code occurrences of the **last path segment identifier**
+(`frame_custody_refusal_gate_test`) across the registry; require exactly one enclosing `TestDef`
+(brace-matched) and check its `name`, `arch` and `stage`; **and** forbid any
+`use …frame_custody_refusal_gate_test as` alias in the file. Separately pin exactly one call site in
+`memory/mod.rs` under `cfg(target_arch = "x86_64")`.
+
+---
+
+## The boot-allocation-shape pin (guards MT-1)
+
+**Property:** `init_frame_ledger` contains **no** `(0..total_frames)` loop and **no**
+`reserve_exact(total_frames)`; it **does** contain `try_reserve_exact(chunk_count)`; and chunk +
+capacity preparation appears **before** the `NEXT_FREE_FRAME.compare_exchange` in the sequential
+allocation path (span-ordered).
+**Mutations that must FAIL:** restore `FREE_FRAMES.lock().reserve_exact(total_frames);`; restore the
+flat `(0..total_frames).map(…).collect()`; move `prepare_frame_for_allocation(current)` to *after*
+the CAS.
+**MUST-NOT:** rely on a boot run as the proof. The x86 harness runs QEMU at `-m 512`
+(`branch:docker/qemu/run-x86-boot-tests.sh:38`), which advertises ~131 k frames — **a size that
+would not have panicked before the fix either**. Nothing in the branch tests the large-RAM regime;
+the disposition rests on the code analysis, and the record must say so (r5 f10).
+
+---
+
+## The x86 harness pin
+
+**Property:** the x86 script asserts **exactly one** `[TEST:process:frame_custody_refusal_gate:PASS]`
+marker **and** the exact counter vector
+`\[FRAME_CUSTODY_COUNTERS:x86:double=1:stale=1:never=1:untracked=1:duplicate=3:contended=[1-9][0-9]*\]`,
+and aborts on `[BOOT_TESTS:FAIL|KERNEL PANIC|panic!`.
+**Mutation that must FAIL:** rewrite the marker count test `-eq 1` to `-ge 0`.
+**MUST-NOT:** gate on `[BOOT_TESTS:PASS]`. The x86 build emits it unconditionally from
+`advance_stage_marker_only` alongside `[TESTS_COMPLETE:0/0]` — a vacuous gate (r3 f14, b3 §14). The
+script header must state why it does not use that marker.
+
+---
+
+## Counter inventory (R6-lite, §3.1)
+
+**Property:** six counters declared with `counter!`, all present in `COUNTERS`
+(`main:kernel/src/tracing/providers/teardown.rs:449`), `COUNTER_COUNT` 47 → **53**
+(`main:…:444`), exposed by `snapshot()` (`:510`), **none** carrying `cfg(target_arch)` or
+`cfg(feature)` (C13/C19), each with a real production producer and a same-PR injection arm.
+**Mutations that must FAIL:** delete one `COUNTERS` entry (declarations/readers equality); add a
+counter with no producer (the `all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates`
+test).
+**Disclosure obligation:** 6/53 is a departure from the ratified 5/52 and shifts 1b/1c to 59/64 —
+deviation record, not silence (MT-5c).
+
+---
+
+# 3. HARNESS TRAPS
+
+## HT-1 — The racy-O2 gate class, and the only acceptable fix shape
+
+**The trap (r4 f1, b4 §1 — the most serious finding of the campaign).**
+`run_staged_tests` spawns **one kthread per subsystem** for the same stage and joins them all
+afterwards (`main:kernel/src/test_framework/executor.rs:190`, header comment at `:1`). O2 was a
+PROCESS-subsystem `EarlyBoot` test; the MEMORY subsystem has an `Arch::Any` `EarlyBoot` test
+literally named `frame_allocator` (`main:registry.rs:4808`) which allocates three frames and then
+`deallocate_frame`s them, plus `heap_large_alloc`/`heap_many_small` — **same stage, another kthread,
+same global `FREE_FRAMES`.**
+
+Two concrete failures on a completely healthy kernel:
+- **A:** MEMORY's `deallocate_frame` lands between the gate's `let free_before = …len()` and its
+  `len() != free_before + 1` → `A: double return or recovery was not exact`.
+- **B (worse — it defeats the injection):** MEMORY pushes its three freed frames between
+  `inject_duplicate_candidates(live.frame, 3)` and the allocation. `FREE_FRAMES` is a **LIFO
+  `Vec`**, so the first pop returns a *clean* frame, `claim_frame` succeeds immediately,
+  `duplicate` advances by 0, `remove_duplicate_candidates` silently discards the injection, and the
+  gate fails `D: duplicate live frame escaped allocation` — two red tests from one benign
+  interleaving.
+
+**The required fix shape (deterministic, at the scheduling boundary — `branch@9287c09d`, re-derive):**
+
+1. Add `TestStage::SerialBoot = 0` **ahead of** `EarlyBoot` (`main:registry.rs:72-91`), documented
+   as "must run alone before the parallel cohort; reserved for tests that deliberately mutate shared
+   global state and restore it exactly."
+2. Register the aarch64 gate at `Arch::Aarch64` / `SerialBoot`.
+3. `run_all_tests` runs **and joins** `run_staged_tests(SerialBoot)` **before** printing
+   `[STAGE:early:ADVANCE]` and storing `CURRENT_STAGE = EarlyBoot`
+   (`main:executor.rs:122-190` is the function to edit).
+4. Inside `run_staged_tests`' spawn loop, **join each SerialBoot subsystem immediately** rather than
+   pushing its handle, so the stage stays serial if a second exclusive test is ever added.
+5. Renumber coherently and completely: `TestStage::from_u8` (`main:registry.rs:104`),
+   `TestStage::COUNT` 4 → 5 (`:91`), **both** `progress.rs` arrays
+   (`main:progress.rs:27,:29,:82,:145-148`), and `display.rs`'s `STAGE_COLORS`
+   (`main:display.rs:267`). Then grep `docker/`, `scripts/`, `xtask/` to confirm **no consumer parses
+   stage integers or the `EARLY_BOOT` count** (r5 verified this — repeat it, don't assume).
+6. Keep **every** exact assertion. No sleep, no retry-until-green, no counter floor replacing an
+   equality, no relaxed free-list equality, no IRQ masking.
+7. Standing negatives in **both** directions: gate moved back to `EarlyBoot`; serial-join condition
+   flipped.
+
+**The serial-join pin must not be evadable (r5 f9, b5 §7 — CONFIRMED open).**
+Pinning `run_staged.contains("if target_stage == TestStage::SerialBoot")` — **no trailing brace** —
+is defeated by mutating the source to `if target_stage == TestStage::SerialBoot && false {`, which
+compiles and leaves the suite green. Pin the condition **through its opening brace**
+(`"if target_stage == TestStage::SerialBoot {"`, as its sibling generation pin does), and
+additionally require that the true-arm block contains `join_test_thread(` and the else-arm contains
+`handles.push(`.
+
+**Residual you must disclose (r5 f13):** serialisation removes the *identified* concurrent producer;
+the assertions are still exact equalities over a global LIFO and remain valid only while nothing else
+in the kernel allocates or frees during the gate. No such producer exists at that point in boot
+today (display init runs before the stage, `render_progress` after). Say that; do not claim the
+dependency is gone.
+
+## HT-2 — Vacuous gates
+
+Every one of these shipped and was caught:
+
+| Pattern | Where it appeared | Rule |
+|---|---|---|
+| Gating CI on a marker the build emits unconditionally (`[BOOT_TESTS:PASS]` with `[TESTS_COMPLETE:0/0]`) | r3 f14 | Gate on the specific evidence, and state in the script header what is *not* being claimed |
+| A structural pin that is a **prefix** of a mutable expression (`&& false` evasion) | r5 f9 | Pin through the closing token; add a sibling positive/negative pair |
+| A standing negative that goes red via a **different** validator | r3 f9, r4 blocker 9 | Every negative calls its named validator directly |
+| A pinned **count** where the property is **membership** | design C6, r4 f2 | Span membership, always |
+| A pin keyed on a **display name** or one **literal path spelling** | r4 f11, r5 f2 | Key on the resolved item; forbid aliasing |
+| Byte-identical build logs offered as two-architecture evidence | r4 f14 | Log the command line, target and feature set with each artifact |
+| A placeholder string where a measurement belongs (`BEAST_COUNTERS_PLACEHOLDER`) | r5 f10 | Transmit the real vector or say it was not obtained |
+
+## HT-3 — Unfailable tests (CLAUDE.md testing-integrity rule)
+
+- `if ticks >= 0 { Pass }` on an **unsigned** value — vacuous (r3 f15).
+- Replacing it with an unconditional `TestResult::Pass` — worse (r3 f15, b3 §15). The correct fix is
+  to delegate to the real `test_timer_ticks()` (`main:registry.rs:1198`), which fails on
+  `timestamp did not advance on x86_64`, and pin that with a standing negative that replaces it with
+  `TestResult::Pass`. Note the forward cost: when #533 lands, `test_timer_ticks` is registered in its
+  own right and the 5 M-iteration spin runs twice per boot (r4 f12) — name it, don't discover it.
+- A fixture that can silently degenerate. The runtime self-check in O2/B is the model: a fixture that
+  cannot construct genuine authority must return `None` and **fail** the gate, not pass vacuously.
+
+## HT-4 — Test code with production side effects
+
+- A gate that reads `NEXT_FREE_FRAME` and then frees the frame at that index races a concurrent
+  allocation and **actually frees a live frame** — memory corruption, not a red test (r2 F17). Derive
+  such fixtures from the memory map (`above_top_of_ram_frame`) or re-check the frontier with a CAS.
+- Injected duplicates left in the production free list on any failure path corrupt the rest of the
+  boot (r3 f11). Clean up unconditionally, before evaluating any failure.
+- The x86 gate ends in `assert!(result.is_pass(), …)` executed from `memory::init`, so a pre-existing
+  production refusal panics the kernel during memory initialisation rather than being counted — a
+  defensible fail-loud choice that is **harsher than design residual 6 describes** ("the discovery is
+  a counter, not a crash"). State it (r4 f15).
+
+---
+
+# 4. HONESTY CONTRACT
+
+## 4.1 What the deviation record must contain
+
+One durable artifact, and it must be **copied into the PR body** (a PR must exist — `gh pr list`
+returned `[]` through r4 and r5, which is itself a blocking finding: b4 §6, b5 §4).
+
+Required properties:
+
+1. **Live deviations only.** Every entry describes a difference that exists in the tree at the head
+   you are shipping. No historical narrative, no "we originally measured".
+2. **Every entry cites its design section**, states the implementation difference, and gives a
+   justification that stands **on its own merits**. Format (from `dev`, which is the right shape):
+   *Design section* / *Difference* / *Justification*.
+3. **No dead premises.** The 2026-08-11 ruling withdrew the size law, so any justification of the
+   form "…and would exceed the 230-line seam" is void and must be restated without it (r4 f7).
+4. **Stamped at the final SHA**, with the diff inventory regenerated at that SHA.
+5. **Explicitly retires the claims it supersedes**, correctly (see 4.2).
+6. **Names, at minimum, these deviations** (all established across r1–r5; `dev` 1–17 is the working
+   set): chunked demand-backed ledger; free-list capacity following the high-water mark; the `u32`
+   cap as a ceiling rather than an assertion; C22's missing `MapError::AllocatorCorrupt` channel
+   ("this is not exact C22 conformance"); 6 counters / 53 total vs the ratified 5 / 52 with the
+   59/64 downstream shift; the stale outcome's fixture-plus-narrow-race status; `allocate_frame()`
+   also routing through the claim guard; the leased API staying private and `boot_tests`-only;
+   `deallocate_frame` being intentionally fail-closed (**not** "behaviour unchanged"); pre-ledger
+   bootstrap retaining legacy return behaviour; the ≤128-region ordinal lookup cost replacing §1.2's
+   "1–4 iterations"; O2 serialized on aarch64 / directly hooked on x86 with #533 named; the x86
+   counter line being an **injection checkpoint**, not a post-cohort read; O2/E asserting allocator
+   contention rather than PR-1c retirement accounting; boot-only fixture authority allowlisted
+   separately from production return authority; and the two x86-support drive-bys
+   (`test_timer_init` → `test_timer_ticks`, `display.rs` cfg-gating) named as
+   "warning fixes newly exposed by the x86 `boot_tests` build" (r4 f13).
+7. **A plain statement of what #470 still owes** (§7's acceptance record requires it).
+
+## 4.2 Stale-claim failures to avoid — each one was a blocking finding
+
+| Failure | Round | Rule |
+|---|---|---|
+| The record lives only in a scratchpad; no PR carries it | r4 f6, r5 f4 | Open the PR; paste the record into the body |
+| Record stamped at a **superseded SHA**, with line counts that no longer match the branch | r5 f4 | Re-stamp and regenerate at the head you ship |
+| A notes file stale at an older head, asserting a test that does not exist and contradicting its sibling notes | r2 F3 | One record. Mark superseded documents as superseded, explicitly |
+| "No dormant allocator-corruption latch" presented as a **delivered feature** while C22's error channel is missing | r4 f6 | State the unmet clause, not the adjacent achievement |
+| Residual-6 stated as a cross-arch result when it is aarch64-only | r1 f15, r2 F2, r3 f13 | "No refusal fired during the aarch64 boot-test window"; the x86 line is an injection checkpoint taken at the end of `memory::init`, before any process has existed, so it measures nothing about post-cohort leakage |
+| "The ~21 GiB ceiling is gone" when it **moved** from boot panic to runtime allocation failure | r5 f3, b5 §3 | Runtime cost is still ~12 B of heap per **exposed** frame (4 B ledger slot, realised per chunk, plus 8 B of never-released `FREE_FRAMES` capacity per published frame) ≈ the same ~21 GiB of *allocatable* RAM against a 64 MiB heap — a genuinely better failure mode (`allocate_frame() → None`), which is what to say |
+| Mutation evidence attributed to a baseline that **predates** the code it exercises | r5 f11 | Record the SHA the run actually used, and whether the tree had uncommitted changes |
+| Two byte-identical `Finished release profile in 0.06s` logs offered as x86 + ARM build evidence | r4 f14 | Capture the command line, target and features; per `MEMORY.md`, all x86 builds run on beast |
+| A placeholder where a counter vector belongs | r5 f10 | Transmit the measurement or state that it was not obtained |
+| Claiming the harness exercised a regime it cannot reach (`-m 512` vs the large-RAM path) | r5 f10 | Say the disposition rests on code analysis, and that the boot green is corroboration |
+
+## 4.3 The acceptance record (§7, mandatory per PR)
+
+Both aarch64 builds warning-free and error-free; `cargo test --test teardown_structure` green
+**including every standing negative**; one `docker/qemu/run-aarch64-full-test.sh --boot-tests-only
+--rebuild` reaching `[BOOT_TESTS:PASS]` at the **final** head; `clean-gate.sh` 0/100 and
+`starved-gate.sh` 0/100 under 14 host hogs (both scripts are already in this scratchpad directory);
+**beast x86 build + boot 3/3 + kthread 3/3**; **Parallels 3× consecutive long-window green**, each
+from a force-stopped VM with a truncated serial log (#525: Parallels gates kernel-path merges, and
+PR-1a is a kernel-path change on both arches); `git diff --numstat` quoted in the body (as a fact,
+not as a gate); revert dry run; all QEMU processes killed and `pgrep` empty before reporting.
+
+---
+
+# 5. SALVAGE MAP — `fix/470-pr1a-frame-ledger` (reference only; nothing cherry-picks)
+
+Merge base `363eb912`. Read a hunk, understand the property, **re-derive it**; do not `git
+cherry-pick`, because every commit after the first carries repair scar tissue for the commit before
+it.
+
+| Commit | Contents | Verdict |
+|---|---|---|
+| `13d3fa29` *memory: add generation-checked frame ledger* (4 files, +193/−17) | ledger statics, ordinal map, seeding, `FrameLease`/`ReturnOutcome`, `return_lease`, duplicate-at-allocation, `deallocate_frame` routing, 5 counters | **MIXED.** The **CAS/generation state machine, seeding order and duplicate-withhold are the sound core** — re-derive. **Embodies MT-1** (flat whole-RAM ledger), **MT-5b** (ledger-conditional low-memory floor), **MT-5c** (`ST_NEVER` folded into `RefusedUntracked`), and ships `ALLOCATOR_CORRUPT` as dormant code |
+| `b0c689e4` *test: ratchet frame ledger authority* (+150 test lines, +135 ratchet) | first O2 gate, first R1/R7/R9 | **MOSTLY TRAP.** R1 is a 3-spelling blacklist (r2 F4, evasion demonstrated); R7's span excludes the helpers (r1 f5); R1 does not scan `frame_allocator_tests.rs` (r1 f6); the one negative is byte-identical to the production spelling (r1 f7); O2/A and /C never restore to healthy (r1 f16). Salvage only the **structure** (a gate driving real primitives + standing negatives inside `deliberately_broken_variants_fail_the_ratchet`) |
+| `bd8b13e7` *address frame ledger review findings* | r1 fixes | **MIXED, contains the two worst regressions.** Sound: restored the unconditional floor `return`; extended R7 to the helpers; `healthy_round_trip` for A/C. **Traps: deleted `FRAME_RETURN_REFUSED_STALE` on a false single-threaded premise (MT-5d), and added `FREE_FRAMES.reserve_exact(total_frames)` — the 8 B/frame half of MT-1** |
+| `bc8686ee` *close frame ledger review r2 findings* | r2 fixes | **MOSTLY SOUND — the best commit to learn from.** Restored the stale counter; added `RefusedNeverAllocated` with a real production producer (MT-5c); replaced R1's blacklist with span containment; removed `ALLOCATOR_CORRUPT` entirely (PLAN.md law 2); added the x86 harness script; `display.rs` cfg-gating. Residual traps: R1 still function-granular (r3 f5); R9's ARM branch still missing its ordering clause (r3 f9) |
+| `e8829c20` *close r3 blockers* | r3 fixes | **MOSTLY SOUND.** Arch-exclusive gate registration; R1's push-containment clause; the **stale fixture built through real transitions** (re-derive); `test_timer_ticks` replacing the vacuous timer test; the non-vacuous x86 script; `healthy_round_trip` scoped to `[..5]`; unconditional duplicate cleanup before failure evaluation. Residual traps: **the racy O2 gate is still there** (HT-1), push-containment is a 4-name list (r4 f2), R9's inventory drops quoted lines (r4 f3), O2/C hand-forges the lease (r4 f4), the registration pin is name-keyed (r4 f11) |
+| `9287c09d` *make frame ledger boot and gate deterministic* (7 files) | the r5 kernel fix | **SOUND IN CONCEPT, THREE NEW TRAPS.** Re-derive: the **chunked demand-backed ledger** (MT-1), the **`SerialBoot` stage + immediate join** (HT-1), the `u32` cap-not-assert change, the boot-allocation-shape ratchet. Do **not** copy: `ensure_free_frame_capacity`'s `try_lock`-failure → OOM (**MT-3**), `ensure_chunk`'s allocation inside `spin::Once::try_call_once` (**MT-5h**), the bootstrap `.expect("bootstrap free frame missing ledger chunk")` (**MT-5g**) |
+| `4d759a62` *harden oracles against lexical evasions* (+360 ratchet) | the r5 oracle fix | **SOUND — re-derive most of it.** The byte-level `code_mask` lexer + `code_offsets`/`code_sites` + its self-test; `braced_block`/`enclosing_test_def`; the `above_top_of_ram_frame` O2/C fixture driving real `deallocate_frame`; the **runtime identity+generation self-check** in `stale_lease_fixture`; the production-unreachability disclosure moved into a pinned production comment |
+| `dddf98fd` *close lexical trivia evasion in free-list ratchet* (+22/−11) | receiver-chain lexer | **PARTIAL TRAP.** Closes `free_list /* trivia */ .insert(…)` and `&mut *free_list` re-borrows, but the walk is rooted at the fixed identifiers `{FREE_FRAMES, free_list}` and the containment loop knows four method names — **the confirmed-open R1 alias evasion (r5 f1)**. Replace with the transitive alias closure in §2/R1 |
+| `7d9a798a` *close round-5 oracle ratchet residuals* (+59 ratchet) | registration + serial-join pins | **PARTIAL TRAP.** The `TestDef` brace-matching + arch/stage check is sound; the **occurrence count keyed on one literal `func:` spelling is evaded by `use … as`** (r5 f2), and the **serial-join pin lacks its trailing brace and is evaded by `&& false`** (r5 f9). Re-derive per §2 "O2 registration" and §3/HT-1 |
+
+**Also on the branch, worth taking:** `docker/qemu/run-x86-boot-tests.sh` (79 lines, no equivalent
+on main — `git ls-tree main docker/qemu/` has no x86 boot-test script) in its `e8829c20` form: exact
+counter-vector regex, exactly-one PASS marker, abort on `FAIL|KERNEL PANIC|panic!`, and a header
+stating that its `[BOOT_TESTS:PASS]` is marker-only and is deliberately not treated as evidence.
+
+**Do not take:** `impl-1a-notes.md` in any form (superseded and materially false — r2 F3, r4 f6);
+any evidence artifact stamped at a SHA other than the one you ship.
+
+---
+
+# 6. One-pass landing checklist
+
+1. Branch fresh from `main` (`363eb912`+). Never push to main; feature branch + PR.
+2. Kernel: chunked ledger (MT-1) with the MT-3 / MT-5g / MT-5h corrections; seeding order + the
+   quiescence assert (MT-5a); unconditional floor (MT-5b); six-outcome taxonomy (MT-5c); stale
+   counter retained (MT-5d); alignment asserts (MT-5e); countable candidate drops (MT-5i); the
+   MT-5j properties preserved verbatim.
+3. Init wiring at the two anchors in MT-2, with the per-arch ordering clauses written separately.
+4. Counters: 6 declarations, `COUNTERS`, `COUNTER_COUNT` 47→53, `snapshot()`, no `cfg` on any.
+5. Harness: `SerialBoot` + immediate join + complete renumbering (HT-1), arch-exclusive gate
+   registration, the x86 direct hook, the x86 script.
+6. O2/A–E per §2, every arm restoring to healthy, cleanup unconditional, fixtures self-checking.
+7. Ratchets R1/R7/R9 + the four pins per §2, each with its standing negative(s) calling its own
+   validator directly.
+8. Run **every** mutation in §2 on the real tree; record verbatim FAIL and the restored PASS; leave
+   `git status --porcelain` empty.
+9. Acceptance record per §4.3, at the final SHA.
+10. Deviation record per §4.1, stamped at that SHA, pasted into the PR body.


### PR DESCRIPTION
## Summary
- The ratified #470 custody design (`DESIGN-470-v2.md`), its PR-1a trap list (`TRAP-LIST-1a.md`), and the current PR-4 re-scope decision (`PR4-RESCOPE.md`) lived only under `/tmp` scratchpad paths and were lost when a reboot cleaned temporary storage.
- These documents gate P3 re-ratification and PR-4 of the #470 campaign, so losing them left no durable record of the ratified design, the constraint crosswalk (C1-C23 incl. C21), or the review-round trap list that PR-1a/1b/1c and PR-2 were built against.
- `DESIGN-470-v2.md` and `TRAP-LIST-1a.md` were reconstructed byte-for-byte from the original `Write` tool-call payloads in this session's agent transcripts (no intervening edits found, so each is the complete as-written version, not a partial reassembly). `PR4-RESCOPE.md` is copied from today's fresh decision artifact with a provenance note prepended.

## Test plan
- [x] Verified section headers 1-10 present in `DESIGN-470-v2.md`, including §7 (PR plan) and §10 (constraint crosswalk with C21)
- [x] Verified both recovered files end on complete sentences with no mid-content truncation
- [x] Sizes match the expected ~68KB / ~62KB originals (67990 / 61446 bytes as authored)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>