### PR TITLE
fix(docs): restore the ./-prefixed aarch64 gate command the P0 ratchet pins

### DIFF
--- a/docs/planning/teardown-unification/PLAN.md
+++ b/docs/planning/teardown-unification/PLAN.md
@@ -381,7 +381,7 @@ not a prediction about arguments not yet made. The PR that splits says so in its
      blanket retry would swallow the wake regressions it exists to catch. Its `EXPECTED_EXITS` floor
      is a consciously re-pinned literal in the script; a phase that adds or removes a userspace test
      program re-pins it in the same PR.
-   - **aarch64 runtime gates:** `docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only`
+   - **aarch64 runtime gates:** `./docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only`
      must reach **`[BOOT_TESTS:PASS]`** over the registered suite, plus
      `docker/qemu/run-aarch64-boot-test-strict.sh`. `[BOOT_TESTS:PASS]` is *never* accepted on its
      own from a stage-advance path — `advance_stage_marker_only`


### PR DESCRIPTION
## Why main is red

`tests/teardown_structure.rs::all_phase_zero_counters_have_registered_readers_and_honest_runtime_gates`
pins the exact aarch64 standard-gate command string:

```rust
let plan = repo_text("docs/planning/teardown-unification/PLAN.md");
assert!(plan.contains("./docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only"));
```

The tranche-2 document repair (#581) re-typeset the standard-gate section of
`docs/planning/teardown-unification/PLAN.md` and dropped the leading `./`. Measured on `main` @
`43336f54`:

- occurrences of `docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only`: **1**
- occurrences of `./docker/qemu/run-aarch64-full-test.sh --rebuild --boot-tests-only`: **0**

so the assertion cannot hold and the suite has been red on `main` since that merge (32 passed, 1
failed).

## What this does

Repairs the **document**, not the ratchet — the ratchet is pinning the command the standard gate is
supposed to name, and the doc drifted away from it. One character.

## Why it is its own PR

Found while establishing the tranche-2 P3 anti-vacuity baseline. It was originally carried on the P3
branch, which contaminated that phase's single-revert-story property: reverting the P3 merge would
have re-broken this ratchet on `main` as a second, unrelated story riding in the same revert. It
belongs ahead of P3, alone.

## Verification

`cargo test --release --test teardown_structure` — red on `main` before this change (the assertion
above), green after: 33 passed.

Co-Authored-By: Ryan Breen <rbreen@jrni.com>
Co-Authored-By: Claude Code <noreply@anthropic.com>